### PR TITLE
Use a global `ClientSession` for all connections

### DIFF
--- a/aioresonate/server/server.py
+++ b/aioresonate/server/server.py
@@ -61,7 +61,7 @@ class ResonateServer:
         self._id = server_id
         self._name = server_name
         if client_session is None:
-            self._client_session = ClientSession()
+            self._client_session = ClientSession(loop=loop)
             self._owns_session = True
         else:
             self._client_session = client_session


### PR DESCRIPTION
With this PR only a single `ClientSession` will be created for all clients.
If given in the constructor, the user can also provide their own `ClientSession`.