### PR TITLE
Improve PushStream resampling audio quality

### DIFF
--- a/aiosendspin/server/audio.py
+++ b/aiosendspin/server/audio.py
@@ -395,6 +395,26 @@ class BufferTracker:
         return self.blocked_until_us - now_us
 
 
+def _convert_s24_to_s32(data: bytes) -> bytes:
+    """Expand packed 24-bit PCM samples to PyAV's left-aligned s32 representation."""
+    if len(data) % 3:
+        raise ValueError("s24 PCM buffer length must be a multiple of 3 bytes")
+
+    if np := _get_numpy():
+        arr = np.frombuffer(data, dtype=np.uint8).reshape(-1, 3)
+        zero_column = np.zeros((arr.shape[0], 1), dtype=np.uint8)
+        expanded = (
+            np.concatenate((zero_column, arr), axis=1)
+            if sys.byteorder == "little"
+            else np.concatenate((arr, zero_column), axis=1)
+        )
+        return bytes(expanded.tobytes())
+
+    if sys.byteorder == "little":
+        return b"".join(b"\x00" + data[i : i + 3] for i in range(0, len(data), 3))
+    return b"".join(data[i : i + 3] + b"\x00" for i in range(0, len(data), 3))
+
+
 def _convert_s32_to_s24(data: bytes) -> bytes:
     """Convert 32-bit PCM samples to packed 24-bit samples."""
     if len(data) % 4:
@@ -412,8 +432,17 @@ def _convert_s32_to_s24(data: bytes) -> bytes:
     return b"".join(data[i : i + 3] for i in range(0, len(data), 4))
 
 
+def _validate_pcm_buffer_length(data: bytes, *, expected: int, context: str) -> None:
+    """Fail fast when PCM byte counts do not match the expected frame shape."""
+    if len(data) != expected:
+        msg = f"{context} PCM buffer length {len(data)} does not match expected {expected} bytes"
+        raise ValueError(msg)
+
+
 __all__ = [
     "AudioFormat",
     "BufferTracker",
+    "_convert_s24_to_s32",
     "_convert_s32_to_s24",
+    "_validate_pcm_buffer_length",
 ]

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -41,6 +41,8 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_INITIAL_DELAY_US = 250_000  # 250ms
 # Pre-roll amount for catch-up encoding to absorb codec startup delay.
 ENCODER_CATCHUP_WARMUP_US = 120_000
+# Dithering policy when reducing to 16-bit integer PCM.
+_DITHER_METHOD_TRIANGULAR_HP = "triangular_hp"
 # Maximum allowed drift between transformer's internal timeline and the expected output
 # timestamp before we discard the transformer's timeline. Normal codec buffering delays are
 # < 100ms; this threshold catches the accumulated drift from timeline rebasing.
@@ -100,12 +102,18 @@ def _build_resample_graph(
     target_av_format: str,
     target_layout: str,
     target_sample_rate: int,
+    dither_method: str | None = None,
 ) -> _AudioFilterGraph:
     """Create an audio filter graph for resampling with soxr (or swr fallback)."""
     av = _get_av()
 
     preferred_resampler = (
         "resampler=soxr:precision=30" if _supports_soxr_resampler() else "resampler=swr"
+    )
+    preferred_aresample = (
+        preferred_resampler
+        if dither_method is None
+        else f"{preferred_resampler}:osf={target_av_format}:dither_method={dither_method}"
     )
 
     graph = av.filter.Graph()
@@ -116,7 +124,7 @@ def _build_resample_graph(
                 sample_rate=source_sample_rate,
                 layout=source_layout,
             ),
-            graph.add("aresample", preferred_resampler),
+            graph.add("aresample", preferred_aresample),
             graph.add(
                 "aformat",
                 (
@@ -134,6 +142,11 @@ def _build_resample_graph(
         return cast("_AudioFilterGraph", graph)
 
     _LOGGER.warning("Falling back to swr resampler after soxr graph setup failure")
+    fallback_aresample = (
+        "resampler=swr"
+        if dither_method is None
+        else f"resampler=swr:osf={target_av_format}:dither_method={dither_method}"
+    )
     graph = av.filter.Graph()
     graph.link_nodes(
         graph.add_abuffer(
@@ -141,7 +154,7 @@ def _build_resample_graph(
             sample_rate=source_sample_rate,
             layout=source_layout,
         ),
-        graph.add("aresample", "resampler=swr"),
+        graph.add("aresample", fallback_aresample),
         graph.add(
             "aformat",
             (
@@ -193,6 +206,8 @@ class _ResamplerKey(NamedTuple):
     target_sample_rate: int
     target_channels: int
     target_bit_depth: int
+    target_sample_type: Literal["int", "float"] = "int"
+    dither_method: str | None = None
 
 
 @dataclass
@@ -231,6 +246,7 @@ class _ResampledPCM:
     output_start_ts: int
     sample_count: int
     needs_s32_to_s24_conversion: bool
+    sample_type: Literal["int", "float"]
 
 
 def _create_resampler_state(
@@ -253,6 +269,7 @@ def _create_resampler_state(
         target_av_format=target_av_format,
         target_layout=target_layout,
         target_sample_rate=target_format.sample_rate,
+        dither_method=key.dither_method,
     )
 
     return _ResamplerState(
@@ -266,7 +283,9 @@ def _create_resampler_state(
         target_wire_frame_stride=target_wire_bytes * target_format.channels,
         target_av_frame_stride=target_av_bytes * target_format.channels,
         needs_s32_to_s24_conversion=(
-            target_format.bit_depth == 24 and target_av_bytes != target_wire_bytes
+            target_format.sample_type == "int"
+            and target_format.bit_depth == 24
+            and target_av_bytes != target_wire_bytes
         ),
     )
 
@@ -307,6 +326,7 @@ def _resample_pcm_standalone(
                 target_av_format=resampler_state.target_av_format,
                 target_layout=resampler_state.target_layout,
                 target_sample_rate=resampler_state.key.target_sample_rate,
+                dither_method=resampler_state.key.dither_method,
             )
 
     # Calculate sample count from input
@@ -320,6 +340,7 @@ def _resample_pcm_standalone(
             output_start_ts=resampler_state.pending_timestamp_us,
             sample_count=0,
             needs_s32_to_s24_conversion=resampler_state.needs_s32_to_s24_conversion,
+            sample_type="float" if resampler_state.target_av_format == "flt" else "int",
         )
 
     # Create input frame
@@ -353,6 +374,29 @@ def _resample_pcm_standalone(
         output_start_ts=output_start_ts,
         sample_count=output_sample_count,
         needs_s32_to_s24_conversion=resampler_state.needs_s32_to_s24_conversion,
+        sample_type="float" if resampler_state.target_av_format == "flt" else "int",
+    )
+
+
+def _processing_format_for_roles(
+    source_format: AudioFormat,
+    *,
+    target_sample_rate: int,
+    target_bit_depth: int,
+    target_channels: int,
+) -> AudioFormat:
+    """Select processing format used during shared per-role resampling."""
+    if source_format.sample_type == "float":
+        return AudioFormat(
+            sample_rate=target_sample_rate,
+            bit_depth=32,
+            channels=target_channels,
+            sample_type="float",
+        )
+    return AudioFormat(
+        sample_rate=target_sample_rate,
+        bit_depth=target_bit_depth,
+        channels=target_channels,
     )
 
 
@@ -1032,15 +1076,17 @@ class PushStream:
             return {}
 
         results: dict[tuple[UUID, int, int, int], _ResampledPCM] = {}
+        shared_results_by_resampler: dict[_ResamplerKey, _ResampledPCM] = {}
         for pcm_key in roles_by_pcm:
             channel_id, target_sample_rate, target_bit_depth, target_channels = pcm_key
             source_pcm, source_format = prepared[channel_id]
             input_timestamp_us = channel_play_start[channel_id]
 
-            target_format = AudioFormat(
-                sample_rate=target_sample_rate,
-                bit_depth=target_bit_depth,
-                channels=target_channels,
+            target_format = _processing_format_for_roles(
+                source_format,
+                target_sample_rate=target_sample_rate,
+                target_bit_depth=target_bit_depth,
+                target_channels=target_channels,
             )
 
             resampler_key = _ResamplerKey(
@@ -1048,18 +1094,65 @@ class PushStream:
                 source_format=source_format,
                 target_sample_rate=target_sample_rate,
                 target_channels=target_channels,
-                target_bit_depth=target_bit_depth,
+                target_bit_depth=target_format.bit_depth,
+                target_sample_type=target_format.sample_type,
             )
+
+            if resampler_key in shared_results_by_resampler:
+                results[pcm_key] = shared_results_by_resampler[resampler_key]
+                continue
 
             state = self._get_cached_resampler(resampler_key)
             if state is None:
                 state = _create_resampler_state(resampler_key, source_format, target_format)
                 self._cache_resampler(state)
 
-            results[pcm_key] = _resample_pcm_standalone(
+            resampled = _resample_pcm_standalone(
                 state, source_pcm, source_format, input_timestamp_us
             )
+            shared_results_by_resampler[resampler_key] = resampled
+            results[pcm_key] = resampled
         return results
+
+    def _quantize_float_pcm_for_output(
+        self,
+        *,
+        channel_id: UUID,
+        pcm_data: bytes,
+        output_ts: int,
+        sample_rate: int,
+        channels: int,
+        target_bit_depth: int,
+    ) -> _ResampledPCM:
+        """Convert float32 PCM to integer output format at the final output edge."""
+        source_format = AudioFormat(
+            sample_rate=sample_rate,
+            bit_depth=32,
+            channels=channels,
+            sample_type="float",
+        )
+        target_format = AudioFormat(
+            sample_rate=sample_rate,
+            bit_depth=target_bit_depth,
+            channels=channels,
+            sample_type="int",
+        )
+        dither_method = _DITHER_METHOD_TRIANGULAR_HP if target_bit_depth == 16 else None
+
+        resampler_key = _ResamplerKey(
+            channel_id=channel_id,
+            source_format=source_format,
+            target_sample_rate=sample_rate,
+            target_channels=channels,
+            target_bit_depth=target_bit_depth,
+            target_sample_type="int",
+            dither_method=dither_method,
+        )
+        state = self._get_cached_resampler(resampler_key)
+        if state is None:
+            state = _create_resampler_state(resampler_key, source_format, target_format)
+            self._cache_resampler(state)
+        return _resample_pcm_standalone(state, pcm_data, source_format, output_ts)
 
     def _resolve_frame_duration_us(self, req: AudioRequirements) -> int:
         if req.frame_duration_us is not None:
@@ -1183,8 +1276,20 @@ class PushStream:
                     continue
                 transformer = grouped[0][2].transformer
                 transformed_pcm = pcm_data
+                needs_s32_to_s24_conversion = resampled.needs_s32_to_s24_conversion
+                if resampled.sample_type == "float":
+                    edge_quantized = self._quantize_float_pcm_for_output(
+                        channel_id=channel_id,
+                        pcm_data=transformed_pcm,
+                        output_ts=output_ts,
+                        sample_rate=rate,
+                        channels=_channels,
+                        target_bit_depth=depth,
+                    )
+                    transformed_pcm = edge_quantized.pcm_data
+                    needs_s32_to_s24_conversion = edge_quantized.needs_s32_to_s24_conversion
                 if (
-                    resampled.needs_s32_to_s24_conversion
+                    needs_s32_to_s24_conversion
                     and depth == 24
                     and isinstance(transformer, PcmPassthrough)
                 ):
@@ -1596,14 +1701,9 @@ class PushStream:
     ) -> list[CachedChunk]:
         """Resample PCM chunks to the target format and encode them sequentially."""
         tkey = self._build_transform_key(req, channel_id)
-        target_format = AudioFormat(
-            sample_rate=req.sample_rate,
-            bit_depth=req.bit_depth,
-            channels=req.channels,
-        )
         cached: list[CachedChunk] = []
         resampler_state: _ResamplerState | None = None
-        resampler_source_format: AudioFormat | None = None
+        resampler_cache_key: _ResamplerKey | None = None
 
         for chunk in pcm_chunks:
             source_format = AudioFormat(
@@ -1612,24 +1712,31 @@ class PushStream:
                 channels=chunk.channels,
                 sample_type=chunk.sample_type,
             )
+            target_format = _processing_format_for_roles(
+                source_format,
+                target_sample_rate=req.sample_rate,
+                target_bit_depth=req.bit_depth,
+                target_channels=req.channels,
+            )
+            current_resampler_key = _ResamplerKey(
+                channel_id=channel_id,
+                source_format=source_format,
+                target_sample_rate=req.sample_rate,
+                target_channels=req.channels,
+                target_bit_depth=target_format.bit_depth,
+                target_sample_type=target_format.sample_type,
+            )
             if (
                 resampler_state is None
-                or resampler_source_format is None
-                or resampler_source_format != source_format
+                or resampler_cache_key is None
+                or resampler_cache_key != current_resampler_key
             ):
-                resampler_key = _ResamplerKey(
-                    channel_id=channel_id,
-                    source_format=source_format,
-                    target_sample_rate=req.sample_rate,
-                    target_channels=req.channels,
-                    target_bit_depth=req.bit_depth,
-                )
                 resampler_state = _create_resampler_state(
-                    resampler_key,
+                    current_resampler_key,
                     source_format,
                     target_format,
                 )
-                resampler_source_format = source_format
+                resampler_cache_key = current_resampler_key
 
             resampled = _resample_pcm_standalone(
                 resampler_state,
@@ -1641,8 +1748,20 @@ class PushStream:
                 continue
 
             resampled_pcm = resampled.pcm_data
+            needs_s32_to_s24_conversion = resampled.needs_s32_to_s24_conversion
+            if resampled.sample_type == "float":
+                edge_quantized = self._quantize_float_pcm_for_output(
+                    channel_id=channel_id,
+                    pcm_data=resampled_pcm,
+                    output_ts=resampled.output_start_ts,
+                    sample_rate=req.sample_rate,
+                    channels=req.channels,
+                    target_bit_depth=req.bit_depth,
+                )
+                resampled_pcm = edge_quantized.pcm_data
+                needs_s32_to_s24_conversion = edge_quantized.needs_s32_to_s24_conversion
             if (
-                resampled.needs_s32_to_s24_conversion
+                needs_s32_to_s24_conversion
                 and req.bit_depth == 24
                 and isinstance(encoder, PcmPassthrough)
             ):

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -9,7 +9,9 @@ import logging
 import weakref
 from collections import defaultdict, deque
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal, NamedTuple
+from errno import EAGAIN
+from functools import lru_cache
+from typing import TYPE_CHECKING, Literal, NamedTuple, Protocol, cast
 from uuid import UUID
 
 from aiosendspin.server.audio import (
@@ -43,6 +45,114 @@ ENCODER_CATCHUP_WARMUP_US = 120_000
 # timestamp before we discard the transformer's timeline. Normal codec buffering delays are
 # < 100ms; this threshold catches the accumulated drift from timeline rebasing.
 _TRANSFORMER_DRIFT_THRESHOLD_US = 500_000  # 500ms
+
+
+class _AudioFilterGraph(Protocol):
+    """Subset of PyAV filter graph API used by PushStream."""
+
+    def push(self, frame: av.AudioFrame) -> None:
+        """Push one audio frame into the graph."""
+        ...
+
+    def pull(self) -> av.AudioFrame:
+        """Pull one audio frame from the graph sink."""
+        ...
+
+
+def _drain_audio_graph(graph: _AudioFilterGraph) -> list[av.AudioFrame]:
+    """Pull all currently available audio frames from a configured filter graph."""
+    out_frames: list[av.AudioFrame] = []
+    while True:
+        try:
+            out_frames.append(graph.pull())
+        except EOFError:
+            break
+        except OSError as exc:  # pragma: no cover - depends on FFmpeg/PyAV build details
+            if exc.errno == EAGAIN:
+                break
+            raise
+    return out_frames
+
+
+@lru_cache(maxsize=1)
+def _supports_soxr_resampler() -> bool:
+    """Return True when this runtime FFmpeg build supports libsoxr in aresample."""
+    av = _get_av()
+
+    graph = av.filter.Graph()
+    try:
+        graph.link_nodes(
+            graph.add_abuffer(format="s16", sample_rate=48_000, layout="stereo"),
+            graph.add("aresample", "resampler=soxr:precision=30"),
+            graph.add("abuffersink"),
+        ).configure()
+    except (OSError, RuntimeError, ValueError) as exc:  # pragma: no cover
+        _LOGGER.debug("libsoxr not available for aresample; using swr fallback: %s", exc)
+        return False
+    return True
+
+
+def _build_resample_graph(
+    *,
+    source_av_format: str,
+    source_layout: str,
+    source_sample_rate: int,
+    target_av_format: str,
+    target_layout: str,
+    target_sample_rate: int,
+) -> _AudioFilterGraph:
+    """Create an audio filter graph for resampling with soxr (or swr fallback)."""
+    av = _get_av()
+
+    preferred_resampler = (
+        "resampler=soxr:precision=30" if _supports_soxr_resampler() else "resampler=swr"
+    )
+
+    graph = av.filter.Graph()
+    try:
+        graph.link_nodes(
+            graph.add_abuffer(
+                format=source_av_format,
+                sample_rate=source_sample_rate,
+                layout=source_layout,
+            ),
+            graph.add("aresample", preferred_resampler),
+            graph.add(
+                "aformat",
+                (
+                    f"sample_fmts={target_av_format}:"
+                    f"sample_rates={target_sample_rate}:"
+                    f"channel_layouts={target_layout}"
+                ),
+            ),
+            graph.add("abuffersink"),
+        ).configure()
+    except (OSError, RuntimeError, ValueError):
+        if preferred_resampler != "resampler=soxr:precision=30":
+            raise
+    else:
+        return cast("_AudioFilterGraph", graph)
+
+    _LOGGER.warning("Falling back to swr resampler after soxr graph setup failure")
+    graph = av.filter.Graph()
+    graph.link_nodes(
+        graph.add_abuffer(
+            format=source_av_format,
+            sample_rate=source_sample_rate,
+            layout=source_layout,
+        ),
+        graph.add("aresample", "resampler=swr"),
+        graph.add(
+            "aformat",
+            (
+                f"sample_fmts={target_av_format}:"
+                f"sample_rates={target_sample_rate}:"
+                f"channel_layouts={target_layout}"
+            ),
+        ),
+        graph.add("abuffersink"),
+    ).configure()
+    return cast("_AudioFilterGraph", graph)
 
 
 def _encode_for_transform_key(
@@ -91,12 +201,14 @@ class _ResamplerState:
 
     key: _ResamplerKey
     """Resampler key for identification."""
-    resampler: av.AudioResampler
-    """PyAV audio resampler."""
+    graph: _AudioFilterGraph
+    """PyAV audio filter graph used for resampling."""
     source_av_format: str
     """PyAV format string for source."""
     source_av_layout: str
     """PyAV channel layout for source."""
+    source_sample_rate: int
+    """Source sample rate used when configuring the filter graph."""
     target_av_format: str
     """PyAV format string for target (after resampling)."""
     target_layout: str
@@ -127,8 +239,6 @@ def _create_resampler_state(
     target_format: AudioFormat,
 ) -> _ResamplerState:
     """Create a new resampler state. Thread-safe (no shared state)."""
-    av = _get_av()
-
     _source_wire_bytes, source_av_format, source_layout, _source_av_bytes = (
         source_format.resolve_av_format()
     )
@@ -136,17 +246,21 @@ def _create_resampler_state(
         target_format.resolve_av_format()
     )
 
-    resampler = av.AudioResampler(
-        format=target_av_format,
-        layout=target_layout,
-        rate=target_format.sample_rate,
+    graph = _build_resample_graph(
+        source_av_format=source_av_format,
+        source_layout=source_layout,
+        source_sample_rate=source_format.sample_rate,
+        target_av_format=target_av_format,
+        target_layout=target_layout,
+        target_sample_rate=target_format.sample_rate,
     )
 
     return _ResamplerState(
         key=key,
-        resampler=resampler,
+        graph=graph,
         source_av_format=source_av_format,
         source_av_layout=source_layout,
+        source_sample_rate=source_format.sample_rate,
         target_av_format=target_av_format,
         target_layout=target_layout,
         target_wire_frame_stride=target_wire_bytes * target_format.channels,
@@ -186,10 +300,13 @@ def _resample_pcm_standalone(
         drift_us = abs(resampler_state.pending_timestamp_us - input_timestamp_us)
         if drift_us > 20_000:
             resampler_state.pending_timestamp_us = input_timestamp_us
-            resampler_state.resampler = av.AudioResampler(
-                format=resampler_state.target_av_format,
-                layout=resampler_state.target_layout,
-                rate=resampler_state.key.target_sample_rate,
+            resampler_state.graph = _build_resample_graph(
+                source_av_format=resampler_state.source_av_format,
+                source_layout=resampler_state.source_av_layout,
+                source_sample_rate=resampler_state.source_sample_rate,
+                target_av_format=resampler_state.target_av_format,
+                target_layout=resampler_state.target_layout,
+                target_sample_rate=resampler_state.key.target_sample_rate,
             )
 
     # Calculate sample count from input
@@ -215,7 +332,8 @@ def _resample_pcm_standalone(
     frame.planes[0].update(source_pcm)
 
     # Resample
-    out_frames = resampler_state.resampler.resample(frame)
+    resampler_state.graph.push(frame)
+    out_frames = _drain_audio_graph(resampler_state.graph)
     out_pcm = bytearray()
     output_sample_count = 0
     for out_frame in out_frames:

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -1121,46 +1121,6 @@ class PushStream:
             results[pcm_key] = resampled
         return results
 
-    def _quantize_float_pcm_for_output(
-        self,
-        *,
-        channel_id: UUID,
-        pcm_data: bytes,
-        output_ts: int,
-        sample_rate: int,
-        channels: int,
-        target_bit_depth: int,
-    ) -> _ResampledPCM:
-        """Convert float32 PCM to integer output format at the final output edge."""
-        source_format = AudioFormat(
-            sample_rate=sample_rate,
-            bit_depth=32,
-            channels=channels,
-            sample_type="float",
-        )
-        target_format = AudioFormat(
-            sample_rate=sample_rate,
-            bit_depth=target_bit_depth,
-            channels=channels,
-            sample_type="int",
-        )
-        dither_method = _DITHER_METHOD_TRIANGULAR_HP if target_bit_depth == 16 else None
-
-        resampler_key = _ResamplerKey(
-            channel_id=channel_id,
-            source_format=source_format,
-            target_sample_rate=sample_rate,
-            target_channels=channels,
-            target_bit_depth=target_bit_depth,
-            target_sample_type="int",
-            dither_method=dither_method,
-        )
-        state = self._get_cached_resampler(resampler_key)
-        if state is None:
-            state = _create_resampler_state(resampler_key, source_format, target_format)
-            self._cache_resampler(state)
-        return _resample_pcm_standalone(state, pcm_data, source_format, output_ts)
-
     def _resolve_frame_duration_us(self, req: AudioRequirements) -> int:
         if req.frame_duration_us is not None:
             return req.frame_duration_us
@@ -1267,6 +1227,26 @@ class PushStream:
             pcm_data = resampled.pcm_data
             output_ts = resampled.output_start_ts
             duration_us = int(resampled.sample_count * 1_000_000 / rate) if rate > 0 else 0
+            needs_s32_to_s24_conversion = resampled.needs_s32_to_s24_conversion
+
+            # Quantize float PCM once per pcm_key — all TransformKeys sharing this
+            # pcm_key produce the same quantizer _ResamplerKey. Using the quantizer's
+            # output_start_ts and sample_count ensures downstream timestamps reflect
+            # any buffering/trimming by the quantizer graph (fixes issue #3).
+            if resampled.sample_type == "float":
+                edge_quantized = _quantize_float_pcm(
+                    channel_id=channel_id,
+                    pcm_data=pcm_data,
+                    output_ts=output_ts,
+                    sample_rate=rate,
+                    channels=_channels,
+                    target_bit_depth=depth,
+                    resampler_cache=self._resamplers,
+                )
+                pcm_data = edge_quantized.pcm_data
+                output_ts = edge_quantized.output_start_ts
+                duration_us = int(edge_quantized.sample_count * 1_000_000 / rate) if rate > 0 else 0
+                needs_s32_to_s24_conversion = edge_quantized.needs_s32_to_s24_conversion
 
             grouped_by_key: defaultdict[
                 TransformKey, list[tuple[SendspinClient, Role, AudioRequirements]]
@@ -1283,18 +1263,6 @@ class PushStream:
                     continue
                 transformer = grouped[0][2].transformer
                 transformed_pcm = pcm_data
-                needs_s32_to_s24_conversion = resampled.needs_s32_to_s24_conversion
-                if resampled.sample_type == "float":
-                    edge_quantized = self._quantize_float_pcm_for_output(
-                        channel_id=channel_id,
-                        pcm_data=transformed_pcm,
-                        output_ts=output_ts,
-                        sample_rate=rate,
-                        channels=_channels,
-                        target_bit_depth=depth,
-                    )
-                    transformed_pcm = edge_quantized.pcm_data
-                    needs_s32_to_s24_conversion = edge_quantized.needs_s32_to_s24_conversion
                 if (
                     needs_s32_to_s24_conversion
                     and depth == 24

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -94,6 +94,10 @@ def _supports_soxr_resampler() -> bool:
     return True
 
 
+# Tracks format combos where soxr graph construction failed, to avoid retrying.
+_soxr_failed_configs: set[tuple[str, str, int, str, str, int]] = set()
+
+
 def _build_resample_graph(
     *,
     source_av_format: str,
@@ -107,9 +111,17 @@ def _build_resample_graph(
     """Create an audio filter graph for resampling with soxr (or swr fallback)."""
     av = _get_av()
 
-    preferred_resampler = (
-        "resampler=soxr:precision=30" if _supports_soxr_resampler() else "resampler=swr"
+    config_key = (
+        source_av_format,
+        source_layout,
+        source_sample_rate,
+        target_av_format,
+        target_layout,
+        target_sample_rate,
     )
+    use_soxr = _supports_soxr_resampler() and config_key not in _soxr_failed_configs
+
+    preferred_resampler = "resampler=soxr:precision=30" if use_soxr else "resampler=swr"
     preferred_aresample = (
         preferred_resampler
         if dither_method is None
@@ -136,11 +148,12 @@ def _build_resample_graph(
             graph.add("abuffersink"),
         ).configure()
     except (OSError, RuntimeError, ValueError):
-        if preferred_resampler != "resampler=soxr:precision=30":
+        if not use_soxr:
             raise
     else:
         return cast("_AudioFilterGraph", graph)
 
+    _soxr_failed_configs.add(config_key)
     _LOGGER.warning("Falling back to swr resampler after soxr graph setup failure")
     fallback_aresample = (
         "resampler=swr"

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -52,8 +52,8 @@ _TRANSFORMER_DRIFT_THRESHOLD_US = 500_000  # 500ms
 class _AudioFilterGraph(Protocol):
     """Subset of PyAV filter graph API used by PushStream."""
 
-    def push(self, frame: av.AudioFrame) -> None:
-        """Push one audio frame into the graph."""
+    def push(self, frame: av.AudioFrame | None) -> None:
+        """Push one audio frame into the graph, or None to signal EOF/flush."""
         ...
 
     def pull(self) -> av.AudioFrame:
@@ -318,6 +318,13 @@ def _resample_pcm_standalone(
         # Resync if timestamp drifts too far (e.g., resampler was idle)
         drift_us = abs(resampler_state.pending_timestamp_us - input_timestamp_us)
         if drift_us > 20_000:
+            # Flush the old graph to release FIR filter tails cleanly.
+            # Flushed samples are discarded — they belong to the stale timeline.
+            try:
+                resampler_state.graph.push(None)
+                _drain_audio_graph(resampler_state.graph)
+            except (EOFError, OSError):
+                pass
             resampler_state.pending_timestamp_us = input_timestamp_us
             resampler_state.graph = _build_resample_graph(
                 source_av_format=resampler_state.source_av_format,

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -385,6 +385,47 @@ def _resample_pcm_standalone(
     )
 
 
+def _quantize_float_pcm(
+    *,
+    channel_id: UUID,
+    pcm_data: bytes,
+    output_ts: int,
+    sample_rate: int,
+    channels: int,
+    target_bit_depth: int,
+    resampler_cache: dict[_ResamplerKey, _ResamplerState],
+) -> _ResampledPCM:
+    """Convert float32 PCM to integer output format using the provided cache."""
+    source_format = AudioFormat(
+        sample_rate=sample_rate,
+        bit_depth=32,
+        channels=channels,
+        sample_type="float",
+    )
+    target_format = AudioFormat(
+        sample_rate=sample_rate,
+        bit_depth=target_bit_depth,
+        channels=channels,
+        sample_type="int",
+    )
+    dither_method = _DITHER_METHOD_TRIANGULAR_HP if target_bit_depth == 16 else None
+
+    resampler_key = _ResamplerKey(
+        channel_id=channel_id,
+        source_format=source_format,
+        target_sample_rate=sample_rate,
+        target_channels=channels,
+        target_bit_depth=target_bit_depth,
+        target_sample_type="int",
+        dither_method=dither_method,
+    )
+    state = resampler_cache.get(resampler_key)
+    if state is None:
+        state = _create_resampler_state(resampler_key, source_format, target_format)
+        resampler_cache[resampler_key] = state
+    return _resample_pcm_standalone(state, pcm_data, source_format, output_ts)
+
+
 def _processing_format_for_roles(
     source_format: AudioFormat,
     *,
@@ -1679,6 +1720,7 @@ class PushStream:
         cached: list[CachedChunk] = []
         resampler_state: _ResamplerState | None = None
         resampler_cache_key: _ResamplerKey | None = None
+        quantizer_cache: dict[_ResamplerKey, _ResamplerState] = {}
 
         for chunk in pcm_chunks:
             source_format = AudioFormat(
@@ -1724,34 +1766,37 @@ class PushStream:
 
             resampled_pcm = resampled.pcm_data
             needs_s32_to_s24_conversion = resampled.needs_s32_to_s24_conversion
+            output_start_ts = resampled.output_start_ts
+            sample_count = resampled.sample_count
+
             if resampled.sample_type == "float":
-                edge_quantized = self._quantize_float_pcm_for_output(
+                edge_quantized = _quantize_float_pcm(
                     channel_id=channel_id,
                     pcm_data=resampled_pcm,
                     output_ts=resampled.output_start_ts,
                     sample_rate=req.sample_rate,
                     channels=req.channels,
                     target_bit_depth=req.bit_depth,
+                    resampler_cache=quantizer_cache,
                 )
                 resampled_pcm = edge_quantized.pcm_data
                 needs_s32_to_s24_conversion = edge_quantized.needs_s32_to_s24_conversion
+                output_start_ts = edge_quantized.output_start_ts
+                sample_count = edge_quantized.sample_count
+
             if (
                 needs_s32_to_s24_conversion
                 and req.bit_depth == 24
                 and isinstance(encoder, PcmPassthrough)
             ):
                 resampled_pcm = _convert_s32_to_s24(resampled_pcm)
-            duration_us = (
-                int(resampled.sample_count * 1_000_000 / req.sample_rate)
-                if resampled.sample_count > 0
-                else 0
-            )
+            duration_us = int(sample_count * 1_000_000 / req.sample_rate) if sample_count > 0 else 0
 
             encoded_frames = self._encode_transform_for_key(
                 tkey,
                 encoder,
                 resampled_pcm,
-                resampled.output_start_ts,
+                output_start_ts,
                 duration_us,
             )
             for data, ts, dur in encoded_frames:

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -389,6 +389,12 @@ def _resample_pcm_standalone(
     # Calculate sample count from input
     bytes_per_sample = source_format.bit_depth // 8
     frame_stride = bytes_per_sample * source_format.channels
+    if len(source_pcm) % frame_stride != 0:
+        msg = (
+            f"source PCM buffer length {len(source_pcm)} does not align to "
+            f"{frame_stride}-byte frames"
+        )
+        raise ValueError(msg)
     sample_count = len(source_pcm) // frame_stride
     av_input_pcm = (
         _convert_s24_to_s32(source_pcm)

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -216,8 +216,8 @@ class _ResamplerState:
 
     key: _ResamplerKey
     """Resampler key for identification."""
-    graph: _AudioFilterGraph
-    """PyAV audio filter graph used for resampling."""
+    graph: _AudioFilterGraph | None
+    """PyAV audio filter graph used for resampling. None for passthrough."""
     source_av_format: str
     """PyAV format string for source."""
     source_av_layout: str
@@ -236,6 +236,8 @@ class _ResamplerState:
     """True when resampler output is s32 but wire PCM is packed s24."""
     pending_timestamp_us: int | None = None
     """Timestamp of the earliest audio sample not yet emitted by this resampler."""
+    is_passthrough: bool = False
+    """True when source and target formats are identical — skip graph processing."""
 
 
 @dataclass(frozen=True)
@@ -262,15 +264,31 @@ def _create_resampler_state(
         target_format.resolve_av_format()
     )
 
-    graph = _build_resample_graph(
-        source_av_format=source_av_format,
-        source_layout=source_layout,
-        source_sample_rate=source_format.sample_rate,
-        target_av_format=target_av_format,
-        target_layout=target_layout,
-        target_sample_rate=target_format.sample_rate,
-        dither_method=key.dither_method,
+    needs_s32_to_s24 = (
+        target_format.sample_type == "int"
+        and target_format.bit_depth == 24
+        and target_av_bytes != target_wire_bytes
     )
+
+    is_passthrough = (
+        source_format.sample_rate == target_format.sample_rate
+        and source_format.channels == target_format.channels
+        and source_av_format == target_av_format
+        and not needs_s32_to_s24
+        and key.dither_method is None
+    )
+
+    graph: _AudioFilterGraph | None = None
+    if not is_passthrough:
+        graph = _build_resample_graph(
+            source_av_format=source_av_format,
+            source_layout=source_layout,
+            source_sample_rate=source_format.sample_rate,
+            target_av_format=target_av_format,
+            target_layout=target_layout,
+            target_sample_rate=target_format.sample_rate,
+            dither_method=key.dither_method,
+        )
 
     return _ResamplerState(
         key=key,
@@ -282,11 +300,8 @@ def _create_resampler_state(
         target_layout=target_layout,
         target_wire_frame_stride=target_wire_bytes * target_format.channels,
         target_av_frame_stride=target_av_bytes * target_format.channels,
-        needs_s32_to_s24_conversion=(
-            target_format.sample_type == "int"
-            and target_format.bit_depth == 24
-            and target_av_bytes != target_wire_bytes
-        ),
+        needs_s32_to_s24_conversion=needs_s32_to_s24,
+        is_passthrough=is_passthrough,
     )
 
 
@@ -320,21 +335,22 @@ def _resample_pcm_standalone(
         if drift_us > 20_000:
             # Flush the old graph to release FIR filter tails cleanly.
             # Flushed samples are discarded — they belong to the stale timeline.
-            try:
-                resampler_state.graph.push(None)
-                _drain_audio_graph(resampler_state.graph)
-            except (EOFError, OSError):
-                pass
+            if resampler_state.graph is not None:
+                try:
+                    resampler_state.graph.push(None)
+                    _drain_audio_graph(resampler_state.graph)
+                except (EOFError, OSError):
+                    pass
+                resampler_state.graph = _build_resample_graph(
+                    source_av_format=resampler_state.source_av_format,
+                    source_layout=resampler_state.source_av_layout,
+                    source_sample_rate=resampler_state.source_sample_rate,
+                    target_av_format=resampler_state.target_av_format,
+                    target_layout=resampler_state.target_layout,
+                    target_sample_rate=resampler_state.key.target_sample_rate,
+                    dither_method=resampler_state.key.dither_method,
+                )
             resampler_state.pending_timestamp_us = input_timestamp_us
-            resampler_state.graph = _build_resample_graph(
-                source_av_format=resampler_state.source_av_format,
-                source_layout=resampler_state.source_av_layout,
-                source_sample_rate=resampler_state.source_sample_rate,
-                target_av_format=resampler_state.target_av_format,
-                target_layout=resampler_state.target_layout,
-                target_sample_rate=resampler_state.key.target_sample_rate,
-                dither_method=resampler_state.key.dither_method,
-            )
 
     # Calculate sample count from input
     bytes_per_sample = source_format.bit_depth // 8
@@ -349,6 +365,21 @@ def _resample_pcm_standalone(
             needs_s32_to_s24_conversion=resampler_state.needs_s32_to_s24_conversion,
             sample_type="float" if resampler_state.target_av_format == "flt" else "int",
         )
+
+    # Fast path: no conversion needed — return input PCM with timestamp tracking
+    if resampler_state.is_passthrough:
+        output_start_ts = resampler_state.pending_timestamp_us
+        duration_us = int(sample_count * 1_000_000 / resampler_state.key.target_sample_rate)
+        resampler_state.pending_timestamp_us += duration_us
+        return _ResampledPCM(
+            pcm_data=source_pcm,
+            output_start_ts=output_start_ts,
+            sample_count=sample_count,
+            needs_s32_to_s24_conversion=False,
+            sample_type=source_format.sample_type,
+        )
+
+    assert resampler_state.graph is not None  # guaranteed: not passthrough → graph was built
 
     # Create input frame
     frame = av.AudioFrame(

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -286,8 +286,8 @@ def _create_resampler_state(
     is_passthrough = (
         source_format.sample_rate == target_format.sample_rate
         and source_format.channels == target_format.channels
-        and source_av_format == target_av_format
-        and not needs_s32_to_s24
+        and source_format.bit_depth == target_format.bit_depth
+        and source_format.sample_type == target_format.sample_type
         and key.dither_method is None
     )
 

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -16,8 +16,10 @@ from uuid import UUID
 
 from aiosendspin.server.audio import (
     AudioFormat,
+    _convert_s24_to_s32,
     _convert_s32_to_s24,
     _get_av,
+    _validate_pcm_buffer_length,
 )
 from aiosendspin.server.audio_transformers import TransformKey, normalize_options
 from aiosendspin.server.channels import MAIN_CHANNEL
@@ -248,6 +250,8 @@ class _ResamplerState:
     """PyAV channel layout for source."""
     source_sample_rate: int
     """Source sample rate used when configuring the filter graph."""
+    source_av_frame_stride: int
+    """Bytes per frame in PyAV representation for source PCM."""
     target_av_format: str
     """PyAV format string for target (after resampling)."""
     target_layout: str
@@ -325,6 +329,7 @@ def _create_resampler_state(
         source_av_format=source_av_format,
         source_av_layout=source_layout,
         source_sample_rate=source_format.sample_rate,
+        source_av_frame_stride=_source_av_bytes * source_format.channels,
         target_av_format=target_av_format,
         target_layout=target_layout,
         target_wire_frame_stride=target_wire_bytes * target_format.channels,
@@ -385,6 +390,13 @@ def _resample_pcm_standalone(
     bytes_per_sample = source_format.bit_depth // 8
     frame_stride = bytes_per_sample * source_format.channels
     sample_count = len(source_pcm) // frame_stride
+    av_input_pcm = (
+        _convert_s24_to_s32(source_pcm)
+        if source_format.sample_type == "int"
+        and source_format.bit_depth == 24
+        and resampler_state.source_av_format == "s32"
+        else source_pcm
+    )
 
     if sample_count == 0:
         return _ResampledPCM(
@@ -401,23 +413,28 @@ def _resample_pcm_standalone(
         duration_us = int(sample_count * 1_000_000 / resampler_state.key.target_sample_rate)
         resampler_state.pending_timestamp_us += duration_us
         return _ResampledPCM(
-            pcm_data=source_pcm,
+            pcm_data=av_input_pcm,
             output_start_ts=output_start_ts,
             sample_count=sample_count,
-            needs_s32_to_s24_conversion=False,
-            sample_type=source_format.sample_type,
+            needs_s32_to_s24_conversion=resampler_state.needs_s32_to_s24_conversion,
+            sample_type=resampler_state.target_sample_type,
         )
 
     assert resampler_state.graph is not None  # guaranteed: not passthrough → graph was built
 
     # Create input frame
+    _validate_pcm_buffer_length(
+        av_input_pcm,
+        expected=sample_count * resampler_state.source_av_frame_stride,
+        context="resampler input",
+    )
     frame = av.AudioFrame(
         format=resampler_state.source_av_format,
         layout=resampler_state.source_av_layout,
         samples=sample_count,
     )
     frame.sample_rate = source_format.sample_rate
-    frame.planes[0].update(source_pcm)
+    frame.planes[0].update(av_input_pcm)
 
     # Resample
     resampler_state.graph.push(frame)

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -98,6 +98,40 @@ def _supports_soxr_resampler() -> bool:
 _soxr_failed_configs: set[tuple[str, str, int, str, str, int]] = set()
 
 
+def _assemble_resample_graph(
+    *,
+    source_av_format: str,
+    source_layout: str,
+    source_sample_rate: int,
+    target_av_format: str,
+    target_layout: str,
+    target_sample_rate: int,
+    aresample_args: str,
+) -> _AudioFilterGraph:
+    """Build and configure a PyAV graph for one resampling configuration."""
+    av = _get_av()
+
+    graph = av.filter.Graph()
+    graph.link_nodes(
+        graph.add_abuffer(
+            format=source_av_format,
+            sample_rate=source_sample_rate,
+            layout=source_layout,
+        ),
+        graph.add("aresample", aresample_args),
+        graph.add(
+            "aformat",
+            (
+                f"sample_fmts={target_av_format}:"
+                f"sample_rates={target_sample_rate}:"
+                f"channel_layouts={target_layout}"
+            ),
+        ),
+        graph.add("abuffersink"),
+    ).configure()
+    return cast("_AudioFilterGraph", graph)
+
+
 def _build_resample_graph(
     *,
     source_av_format: str,
@@ -109,8 +143,6 @@ def _build_resample_graph(
     dither_method: str | None = None,
 ) -> _AudioFilterGraph:
     """Create an audio filter graph for resampling with soxr (or swr fallback)."""
-    av = _get_av()
-
     config_key = (
         source_av_format,
         source_layout,
@@ -128,30 +160,19 @@ def _build_resample_graph(
         else f"{preferred_resampler}:osf={target_av_format}:dither_method={dither_method}"
     )
 
-    graph = av.filter.Graph()
     try:
-        graph.link_nodes(
-            graph.add_abuffer(
-                format=source_av_format,
-                sample_rate=source_sample_rate,
-                layout=source_layout,
-            ),
-            graph.add("aresample", preferred_aresample),
-            graph.add(
-                "aformat",
-                (
-                    f"sample_fmts={target_av_format}:"
-                    f"sample_rates={target_sample_rate}:"
-                    f"channel_layouts={target_layout}"
-                ),
-            ),
-            graph.add("abuffersink"),
-        ).configure()
+        return _assemble_resample_graph(
+            source_av_format=source_av_format,
+            source_layout=source_layout,
+            source_sample_rate=source_sample_rate,
+            target_av_format=target_av_format,
+            target_layout=target_layout,
+            target_sample_rate=target_sample_rate,
+            aresample_args=preferred_aresample,
+        )
     except (OSError, RuntimeError, ValueError):
         if not use_soxr:
             raise
-    else:
-        return cast("_AudioFilterGraph", graph)
 
     _soxr_failed_configs.add(config_key)
     _LOGGER.warning("Falling back to swr resampler after soxr graph setup failure")
@@ -160,25 +181,15 @@ def _build_resample_graph(
         if dither_method is None
         else f"resampler=swr:osf={target_av_format}:dither_method={dither_method}"
     )
-    graph = av.filter.Graph()
-    graph.link_nodes(
-        graph.add_abuffer(
-            format=source_av_format,
-            sample_rate=source_sample_rate,
-            layout=source_layout,
-        ),
-        graph.add("aresample", fallback_aresample),
-        graph.add(
-            "aformat",
-            (
-                f"sample_fmts={target_av_format}:"
-                f"sample_rates={target_sample_rate}:"
-                f"channel_layouts={target_layout}"
-            ),
-        ),
-        graph.add("abuffersink"),
-    ).configure()
-    return cast("_AudioFilterGraph", graph)
+    return _assemble_resample_graph(
+        source_av_format=source_av_format,
+        source_layout=source_layout,
+        source_sample_rate=source_sample_rate,
+        target_av_format=target_av_format,
+        target_layout=target_layout,
+        target_sample_rate=target_sample_rate,
+        aresample_args=fallback_aresample,
+    )
 
 
 def _encode_for_transform_key(
@@ -251,6 +262,11 @@ class _ResamplerState:
     """Timestamp of the earliest audio sample not yet emitted by this resampler."""
     is_passthrough: bool = False
     """True when source and target formats are identical — skip graph processing."""
+
+    @property
+    def target_sample_type(self) -> Literal["int", "float"]:
+        """PCM sample type produced by this resampler."""
+        return "float" if self.target_av_format == "flt" else "int"
 
 
 @dataclass(frozen=True)
@@ -376,7 +392,7 @@ def _resample_pcm_standalone(
             output_start_ts=resampler_state.pending_timestamp_us,
             sample_count=0,
             needs_s32_to_s24_conversion=resampler_state.needs_s32_to_s24_conversion,
-            sample_type="float" if resampler_state.target_av_format == "flt" else "int",
+            sample_type=resampler_state.target_sample_type,
         )
 
     # Fast path: no conversion needed — return input PCM with timestamp tracking
@@ -425,7 +441,7 @@ def _resample_pcm_standalone(
         output_start_ts=output_start_ts,
         sample_count=output_sample_count,
         needs_s32_to_s24_conversion=resampler_state.needs_s32_to_s24_conversion,
-        sample_type="float" if resampler_state.target_av_format == "flt" else "int",
+        sample_type=resampler_state.target_sample_type,
     )
 
 
@@ -1320,7 +1336,7 @@ class PushStream:
             # Quantize float PCM once per pcm_key — all TransformKeys sharing this
             # pcm_key produce the same quantizer _ResamplerKey. Using the quantizer's
             # output_start_ts and sample_count ensures downstream timestamps reflect
-            # any buffering/trimming by the quantizer graph (fixes issue #3).
+            # any buffering or trimming introduced by the quantizer graph.
             if resampled.sample_type == "float":
                 edge_quantized = _quantize_float_pcm(
                     channel_id=channel_id,

--- a/aiosendspin/server/roles/player/audio_transformers.py
+++ b/aiosendspin/server/roles/player/audio_transformers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
-from aiosendspin.server.audio import AudioFormat, _get_av
+from aiosendspin.server.audio import AudioFormat, _get_av, _validate_pcm_buffer_length
 
 if TYPE_CHECKING:
     import av
@@ -220,6 +220,11 @@ class FlacEncoder:
         """Encode a single chunk of PCM to FLAC."""
         assert self._encoder is not None
         av = _get_av()
+        _validate_pcm_buffer_length(
+            chunk_pcm,
+            expected=self._chunk_samples * self._frame_stride,
+            context="FLAC encoder input",
+        )
 
         frame = av.AudioFrame(
             format=self._av_format,
@@ -413,6 +418,11 @@ class OpusEncoder:
         """Encode a single chunk of PCM to Opus."""
         assert self._encoder is not None
         av = _get_av()
+        _validate_pcm_buffer_length(
+            chunk_pcm,
+            expected=self._chunk_samples * self._frame_stride,
+            context="Opus encoder input",
+        )
 
         frame = av.AudioFrame(
             format="s16",

--- a/tests/server/test_audio_format_utils.py
+++ b/tests/server/test_audio_format_utils.py
@@ -5,7 +5,7 @@ import sys
 import pytest
 
 from aiosendspin.server import audio as audio_module
-from aiosendspin.server.audio import AudioFormat, _convert_s32_to_s24
+from aiosendspin.server.audio import AudioFormat, _convert_s24_to_s32, _convert_s32_to_s24
 
 S32_SAMPLES = bytes([0x01, 0x11, 0x21, 0x31, 0x02, 0x12, 0x22, 0x32])
 
@@ -14,6 +14,12 @@ def _expected_s24_samples() -> bytes:
     if sys.byteorder == "little":
         return bytes([0x11, 0x21, 0x31, 0x12, 0x22, 0x32])
     return bytes([0x01, 0x11, 0x21, 0x02, 0x12, 0x22])
+
+
+def _expected_s32_from_s24_samples() -> bytes:
+    if sys.byteorder == "little":
+        return bytes([0x00, 0x11, 0x21, 0x31, 0x00, 0x12, 0x22, 0x32])
+    return bytes([0x01, 0x11, 0x21, 0x00, 0x02, 0x12, 0x22, 0x00])
 
 
 def test_resolve_audio_format_24_bit_uses_s32_in_pyav() -> None:
@@ -66,6 +72,15 @@ def test_convert_s32_to_s24_drops_least_significant_byte_python_impl(
     assert converted == _expected_s24_samples()
 
 
+def test_convert_s24_to_s32_inserts_zero_lsb_python_impl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """s24->s32 conversion should expand samples into left-aligned PyAV representation."""
+    monkeypatch.setattr(audio_module, "_get_numpy", lambda: None)
+    converted = _convert_s24_to_s32(_expected_s24_samples())
+    assert converted == _expected_s32_from_s24_samples()
+
+
 def test_convert_s32_to_s24_drops_least_significant_byte_numpy_impl(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -76,7 +91,29 @@ def test_convert_s32_to_s24_drops_least_significant_byte_numpy_impl(
     assert converted == _expected_s24_samples()
 
 
+def test_convert_s24_to_s32_inserts_zero_lsb_numpy_impl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """s24->s32 conversion should expand samples into left-aligned PyAV representation."""
+    np = pytest.importorskip("numpy")
+    monkeypatch.setattr(audio_module, "_get_numpy", lambda: np)
+    converted = _convert_s24_to_s32(_expected_s24_samples())
+    assert converted == _expected_s32_from_s24_samples()
+
+
 def test_convert_s32_to_s24_rejects_invalid_length() -> None:
     """Invalid byte lengths must be rejected."""
     with pytest.raises(ValueError, match="multiple of 4"):
         _convert_s32_to_s24(b"\x00\x01\x02")
+
+
+def test_convert_s24_to_s32_rejects_invalid_length() -> None:
+    """Invalid byte lengths must be rejected."""
+    with pytest.raises(ValueError, match="multiple of 3"):
+        _convert_s24_to_s32(b"\x00\x01")
+
+
+def test_convert_s24_to_s32_round_trips_with_s32_to_s24() -> None:
+    """Round-tripping packed s24 through PyAV's s32 layout should preserve wire bytes."""
+    converted = _convert_s32_to_s24(_convert_s24_to_s32(_expected_s24_samples()))
+    assert converted == _expected_s24_samples()

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -2254,6 +2254,40 @@ def test_noop_resample_bypasses_graph_construction(
     assert result.output_start_ts == 1_000_000
 
 
+def test_24bit_to_32bit_is_not_passthrough(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """24-bit packed PCM to 32-bit must not be treated as passthrough.
+
+    Both resolve to PyAV format 's32', but the wire byte widths differ
+    (3 vs 4 bytes per sample). Passthrough would corrupt framing.
+    """
+    build_calls = 0
+    original_build = push_stream_module._build_resample_graph  # noqa: SLF001
+
+    def _counting_build(**kwargs: Any) -> object:
+        nonlocal build_calls
+        build_calls += 1
+        return original_build(**kwargs)
+
+    monkeypatch.setattr(push_stream_module, "_build_resample_graph", _counting_build)
+
+    source = AudioFormat(sample_rate=48_000, bit_depth=24, channels=2, sample_type="int")
+    target = AudioFormat(sample_rate=48_000, bit_depth=32, channels=2, sample_type="int")
+    key = push_stream_module._ResamplerKey(  # noqa: SLF001
+        channel_id=MAIN_CHANNEL,
+        source_format=source,
+        target_sample_rate=48_000,
+        target_channels=2,
+        target_bit_depth=32,
+        target_sample_type="int",
+    )
+    state = push_stream_module._create_resampler_state(key, source, target)  # noqa: SLF001
+
+    assert not state.is_passthrough, "24-bit to 32-bit must not be passthrough"
+    assert build_calls == 1, "Graph should be built for 24-bit to 32-bit conversion"
+
+
 def test_soxr_fallback_caches_failure_per_format(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -2037,3 +2037,72 @@ def test_drift_rebuild_flushes_old_graph_before_replacing(
     )
 
     assert flush_calls, "Old graph should have been flushed with push(None) before rebuild"
+
+
+@pytest.mark.asyncio
+async def test_multi_role_fanout_quantizes_once_per_pcm_key(
+    mock_loop: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multiple TransformKeys sharing a pcm_key must quantize float PCM only once."""
+    group = _DummyGroup(clients=[])
+    pool = group.transformer_pool
+
+    # Two roles with different frame durations → different TransformKeys, same pcm_key
+    role1 = _DummyRole(
+        AudioRequirements(
+            sample_rate=48_000,
+            bit_depth=16,
+            channels=2,
+            transformer=pool.get_or_create(
+                PcmPassthrough,
+                channel_id=MAIN_CHANNEL.int,
+                sample_rate=48_000,
+                bit_depth=16,
+                channels=2,
+                frame_duration_us=25_000,
+            ),
+            channel_id=MAIN_CHANNEL,
+            frame_duration_us=25_000,
+        )
+    )
+    role2 = _DummyRole(
+        AudioRequirements(
+            sample_rate=48_000,
+            bit_depth=16,
+            channels=2,
+            transformer=pool.get_or_create(
+                PcmPassthrough,
+                channel_id=MAIN_CHANNEL.int,
+                sample_rate=48_000,
+                bit_depth=16,
+                channels=2,
+                frame_duration_us=50_000,
+            ),
+            channel_id=MAIN_CHANNEL,
+            frame_duration_us=50_000,
+        )
+    )
+    group.clients.extend([_DummyClient([role1]), _DummyClient([role2])])
+
+    quantize_calls = 0
+    original_quantizer = PushStream._quantize_float_pcm_for_output  # noqa: SLF001
+
+    def _counted_quantizer(self: PushStream, **kwargs: Any) -> object:
+        nonlocal quantize_calls
+        quantize_calls += 1
+        return original_quantizer(self, **kwargs)
+
+    monkeypatch.setattr(PushStream, "_quantize_float_pcm_for_output", _counted_quantizer)
+
+    stream = PushStream(loop=mock_loop, clock=LoopClock(mock_loop), group=group)
+    stream.prepare_audio(
+        bytes(9600),  # 25ms @ 48kHz stereo f32
+        AudioFormat(sample_rate=48_000, bit_depth=32, channels=2, sample_type="float"),
+    )
+    await stream.commit_audio()
+
+    assert quantize_calls == 1, f"Expected 1 quantize call per pcm_key, got {quantize_calls}"
+    assert role1.received, "role1 should have received audio chunks"
+    # role2 may not receive chunks yet because 25ms of data is below its
+    # 50ms frame duration — the important assertion is quantize_calls == 1.

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -2211,3 +2211,39 @@ async def test_catchup_quantizer_does_not_share_live_cache(
         f"Expected 0 drift-triggered rebuilds during catch-up, got {catchup_drifts} "
         f"(likely shared quantizer cache causing timestamp jump)"
     )
+
+
+def test_noop_resample_bypasses_graph_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resampling with identical source/target should skip graph construction."""
+    build_calls = 0
+    original_build = push_stream_module._build_resample_graph  # noqa: SLF001
+
+    def _counting_build(**kwargs: Any) -> object:
+        nonlocal build_calls
+        build_calls += 1
+        return original_build(**kwargs)
+
+    monkeypatch.setattr(push_stream_module, "_build_resample_graph", _counting_build)
+
+    source = AudioFormat(sample_rate=48_000, bit_depth=16, channels=2, sample_type="int")
+    key = push_stream_module._ResamplerKey(  # noqa: SLF001
+        channel_id=MAIN_CHANNEL,
+        source_format=source,
+        target_sample_rate=48_000,
+        target_channels=2,
+        target_bit_depth=16,
+        target_sample_type="int",
+    )
+    state = push_stream_module._create_resampler_state(key, source, source)  # noqa: SLF001
+
+    pcm_25ms = bytes(4800)  # 25ms @ 48kHz stereo s16
+    result = push_stream_module._resample_pcm_standalone(  # noqa: SLF001
+        state, pcm_25ms, source, 1_000_000
+    )
+
+    assert build_calls == 0, "No-op resample should not build a filter graph"
+    assert result.pcm_data == pcm_25ms, "No-op resample should return input PCM unchanged"
+    assert result.sample_count == 1200  # 48000 * 0.025
+    assert result.output_start_ts == 1_000_000

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from collections import deque
 from dataclasses import dataclass
 from typing import Any
@@ -32,7 +33,7 @@ from aiosendspin.server.client import SendspinClient
 from aiosendspin.server.clock import LoopClock, ManualClock
 from aiosendspin.server.push_stream import CachedChunk, CachedPCMChunk, PushStream
 from aiosendspin.server.roles import AudioChunk, AudioRequirements
-from aiosendspin.server.roles.player.audio_transformers import PcmPassthrough
+from aiosendspin.server.roles.player.audio_transformers import FlacEncoder, PcmPassthrough
 
 
 @dataclass(slots=True)
@@ -139,6 +140,18 @@ class _DummyClient:
         self.is_connected = True
         self.active_roles = roles
         self.connection = _FakeConnection()
+
+
+def _expand_packed_s24_to_s32(data: bytes) -> bytes:
+    """Expand packed s24 PCM to PyAV's left-aligned s32 representation."""
+    if sys.byteorder == "little":
+        return b"".join(b"\x00" + data[i : i + 3] for i in range(0, len(data), 3))
+    return b"".join(data[i : i + 3] + b"\x00" for i in range(0, len(data), 3))
+
+
+def _packed_s24_pcm_25ms() -> bytes:
+    """Build one 25ms stereo PCM chunk with a stable packed-s24 byte pattern."""
+    return bytes([0x11, 0x21, 0x31, 0x12, 0x22, 0x32]) * 1200
 
 
 def _make_connected_player(
@@ -2297,23 +2310,47 @@ def test_noop_resample_bypasses_graph_construction(
     assert result.output_start_ts == 1_000_000
 
 
-def test_24bit_to_32bit_is_not_passthrough(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """24-bit packed PCM to 32-bit must not be treated as passthrough.
+def test_24bit_passthrough_expands_to_s32_and_marks_wire_conversion() -> None:
+    """Packed s24 passthrough should still normalize to s32 for internal processing."""
+    source = AudioFormat(sample_rate=48_000, bit_depth=24, channels=2, sample_type="int")
+    key = push_stream_module._ResamplerKey(  # noqa: SLF001
+        channel_id=MAIN_CHANNEL,
+        source_format=source,
+        target_sample_rate=48_000,
+        target_channels=2,
+        target_bit_depth=24,
+        target_sample_type="int",
+    )
+    state = push_stream_module._create_resampler_state(key, source, source)  # noqa: SLF001
 
-    Both resolve to PyAV format 's32', but the wire byte widths differ
-    (3 vs 4 bytes per sample). Passthrough would corrupt framing.
-    """
-    build_calls = 0
-    original_build = push_stream_module._build_resample_graph  # noqa: SLF001
+    packed_pcm = bytes([0x11, 0x21, 0x31, 0x12, 0x22, 0x32]) * 2
+    result = push_stream_module._resample_pcm_standalone(  # noqa: SLF001
+        state, packed_pcm, source, 1_000_000
+    )
 
-    def _counting_build(**kwargs: Any) -> object:
-        nonlocal build_calls
-        build_calls += 1
-        return original_build(**kwargs)
+    assert state.is_passthrough
+    assert result.pcm_data == _expand_packed_s24_to_s32(packed_pcm)
+    assert result.sample_count == 2
+    assert result.needs_s32_to_s24_conversion is True
 
-    monkeypatch.setattr(push_stream_module, "_build_resample_graph", _counting_build)
+
+def test_24bit_input_expands_to_s32_before_graph(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Packed s24 input must be expanded before writing into an s32 PyAV frame."""
+    captured_input: bytes | None = None
+
+    class _CapturingGraph:
+        def push(self, frame: Any | None) -> None:
+            nonlocal captured_input
+            assert frame is not None
+            captured_input = bytes(frame.planes[0])
+
+        def pull(self) -> Any:
+            raise EOFError
+
+    def _build_capturing_graph(**_kwargs: Any) -> _CapturingGraph:
+        return _CapturingGraph()
+
+    monkeypatch.setattr(push_stream_module, "_build_resample_graph", _build_capturing_graph)
 
     source = AudioFormat(sample_rate=48_000, bit_depth=24, channels=2, sample_type="int")
     target = AudioFormat(sample_rate=48_000, bit_depth=32, channels=2, sample_type="int")
@@ -2327,8 +2364,91 @@ def test_24bit_to_32bit_is_not_passthrough(
     )
     state = push_stream_module._create_resampler_state(key, source, target)  # noqa: SLF001
 
-    assert not state.is_passthrough, "24-bit to 32-bit must not be passthrough"
-    assert build_calls == 1, "Graph should be built for 24-bit to 32-bit conversion"
+    packed_pcm = bytes([0x11, 0x21, 0x31, 0x12, 0x22, 0x32]) * 2
+    push_stream_module._resample_pcm_standalone(  # noqa: SLF001
+        state, packed_pcm, source, 1_000_000
+    )
+
+    assert captured_input == _expand_packed_s24_to_s32(packed_pcm)
+
+
+def test_encode_pcm_sequence_preserves_packed_s24_for_pcm_passthrough() -> None:
+    """Raw PCM output should convert internal s32 back to packed s24 on the wire."""
+    group = _DummyGroup(clients=[])
+    stream = PushStream(loop=MagicMock(), clock=ManualClock(), group=group)
+    encoder = PcmPassthrough(sample_rate=48_000, bit_depth=24, channels=2)
+    req = AudioRequirements(
+        sample_rate=48_000,
+        bit_depth=24,
+        channels=2,
+        transformer=encoder,
+        channel_id=MAIN_CHANNEL,
+        frame_duration_us=25_000,
+    )
+    packed_pcm = _packed_s24_pcm_25ms()
+    pcm_chunk = CachedPCMChunk(
+        timestamp_us=1_000_000,
+        duration_us=25_000,
+        pcm_data=packed_pcm,
+        sample_rate=48_000,
+        bit_depth=24,
+        channels=2,
+    )
+
+    encoded = stream._encode_pcm_sequence([pcm_chunk], encoder, req, MAIN_CHANNEL)  # noqa: SLF001
+
+    assert len(encoded) == 1
+    assert encoded[0].payload == packed_pcm
+
+
+def test_encode_pcm_sequence_expands_s24_before_flac_encoder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FLAC encoding should receive AV-format s32 bytes for 24-bit PCM."""
+    group = _DummyGroup(clients=[])
+    stream = PushStream(loop=MagicMock(), clock=ManualClock(), group=group)
+    encoder = FlacEncoder(sample_rate=48_000, bit_depth=24, channels=2)
+    captured_chunk: bytes | None = None
+
+    def _fake_ensure_initialized() -> None:
+        encoder._initialized = True  # noqa: SLF001
+        encoder._chunk_samples = 1200  # noqa: SLF001
+        encoder._chunk_duration_us = 25_000  # noqa: SLF001
+        encoder._frame_stride = 8  # noqa: SLF001
+        encoder._av_format = "s32"  # noqa: SLF001
+        encoder._av_layout = "stereo"  # noqa: SLF001
+
+    def _capture_chunk(chunk_pcm: bytes) -> bytes:
+        nonlocal captured_chunk
+        captured_chunk = chunk_pcm
+        return b"flac"
+
+    monkeypatch.setattr(encoder, "_ensure_initialized", _fake_ensure_initialized)
+    monkeypatch.setattr(encoder, "_encode_chunk", _capture_chunk)
+
+    req = AudioRequirements(
+        sample_rate=48_000,
+        bit_depth=24,
+        channels=2,
+        transformer=encoder,
+        channel_id=MAIN_CHANNEL,
+        frame_duration_us=25_000,
+    )
+    packed_pcm = _packed_s24_pcm_25ms()
+    pcm_chunk = CachedPCMChunk(
+        timestamp_us=1_000_000,
+        duration_us=25_000,
+        pcm_data=packed_pcm,
+        sample_rate=48_000,
+        bit_depth=24,
+        channels=2,
+    )
+
+    encoded = stream._encode_pcm_sequence([pcm_chunk], encoder, req, MAIN_CHANNEL)  # noqa: SLF001
+
+    assert len(encoded) == 1
+    assert encoded[0].payload == b"flac"
+    assert captured_chunk == _expand_packed_s24_to_s32(packed_pcm)
 
 
 def test_soxr_fallback_caches_failure_per_format(

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -1984,3 +1984,56 @@ async def test_late_joiner_after_historical_injection() -> None:
 
     assert role2.started == 1
     assert role2.received
+
+
+def test_drift_rebuild_flushes_old_graph_before_replacing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Drift-triggered graph rebuild must flush the old graph before replacing it."""
+    flush_calls: list[bool] = []
+    original_build = push_stream_module._build_resample_graph  # noqa: SLF001
+
+    class _SpyGraph:
+        """Wraps a real graph to detect push(None) flush calls."""
+
+        def __init__(self, real_graph: object) -> None:
+            self._real = real_graph
+
+        def push(self, frame: object) -> None:
+            if frame is None:
+                flush_calls.append(True)
+            self._real.push(frame)  # type: ignore[union-attr]
+
+        def pull(self) -> object:
+            return self._real.pull()  # type: ignore[union-attr]
+
+    def _spy_build(**kwargs: Any) -> object:
+        graph = original_build(**kwargs)
+        return _SpyGraph(graph)
+
+    monkeypatch.setattr(push_stream_module, "_build_resample_graph", _spy_build)
+
+    group = _DummyGroup(clients=[])
+    stream = PushStream(loop=MagicMock(), clock=ManualClock(), group=group)
+    pcm_25ms = bytes(9600)  # 25ms @ 48kHz stereo f32
+
+    # First call: creates graph, advances pending_timestamp_us by ~25ms
+    stream._quantize_float_pcm_for_output(  # noqa: SLF001
+        channel_id=MAIN_CHANNEL,
+        pcm_data=pcm_25ms,
+        output_ts=0,
+        sample_rate=48_000,
+        channels=2,
+        target_bit_depth=16,
+    )
+    # Second call with same output_ts=0: drift > 20ms, triggers rebuild
+    stream._quantize_float_pcm_for_output(  # noqa: SLF001
+        channel_id=MAIN_CHANNEL,
+        pcm_data=pcm_25ms,
+        output_ts=0,
+        sample_rate=48_000,
+        channels=2,
+        target_bit_depth=16,
+    )
+
+    assert flush_calls, "Old graph should have been flushed with push(None) before rebuild"

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -24,6 +24,7 @@ from aiosendspin.models.player import (
     SupportedAudioFormat,
 )
 from aiosendspin.models.types import AudioCodec, PlayerCommand, Roles
+from aiosendspin.server import push_stream as push_stream_module
 from aiosendspin.server.audio import AudioFormat
 from aiosendspin.server.audio_transformers import TransformerPool
 from aiosendspin.server.channels import MAIN_CHANNEL
@@ -223,6 +224,139 @@ async def test_commit_audio_sends_stream_start_and_binary(mock_loop: Any) -> Non
     buffer_tracker = role.get_buffer_tracker()
     assert buffer_tracker is not None
     assert buffer_tracker.buffered_bytes > 0
+
+
+@pytest.mark.asyncio
+async def test_commit_audio_float_input_quantizes_at_output_edge(
+    mock_loop: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Float input should be quantized at the output edge for integer player requirements."""
+    group = _DummyGroup(clients=[])
+    _client, conn = _make_connected_player(mock_loop, group, "p1")
+
+    quantize_calls = 0
+    original_quantizer = PushStream._quantize_float_pcm_for_output  # noqa: SLF001
+
+    def _counted_quantizer(self: PushStream, **kwargs: Any) -> object:
+        nonlocal quantize_calls
+        quantize_calls += 1
+        return original_quantizer(self, **kwargs)
+
+    monkeypatch.setattr(PushStream, "_quantize_float_pcm_for_output", _counted_quantizer)
+
+    stream = PushStream(loop=mock_loop, clock=LoopClock(mock_loop), group=group)
+    stream.prepare_audio(
+        bytes(9600),  # 25ms @ 48kHz stereo f32
+        AudioFormat(sample_rate=48_000, bit_depth=32, channels=2, sample_type="float"),
+    )
+    await stream.commit_audio()
+
+    assert quantize_calls > 0
+    assert conn.sent_binary
+
+
+def test_quantize_float_to_s16_uses_triangular_hp_dither(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Float to s16 quantization should request triangular_hp dithering."""
+    captured_dither_methods: list[str | None] = []
+    original_build_resample_graph = push_stream_module._build_resample_graph  # noqa: SLF001
+
+    def _record_build_resample_graph(
+        *,
+        source_av_format: str,
+        source_layout: str,
+        source_sample_rate: int,
+        target_av_format: str,
+        target_layout: str,
+        target_sample_rate: int,
+        dither_method: str | None = None,
+    ) -> object:
+        if source_av_format == "flt" and target_av_format == "s16":
+            captured_dither_methods.append(dither_method)
+        return original_build_resample_graph(
+            source_av_format=source_av_format,
+            source_layout=source_layout,
+            source_sample_rate=source_sample_rate,
+            target_av_format=target_av_format,
+            target_layout=target_layout,
+            target_sample_rate=target_sample_rate,
+            dither_method=dither_method,
+        )
+
+    monkeypatch.setattr(push_stream_module, "_build_resample_graph", _record_build_resample_graph)
+
+    group = _DummyGroup(clients=[])
+    stream = PushStream(loop=MagicMock(), clock=ManualClock(), group=group)
+    stream._quantize_float_pcm_for_output(  # noqa: SLF001
+        channel_id=MAIN_CHANNEL,
+        pcm_data=bytes(9600),  # 25ms @ 48kHz stereo f32
+        output_ts=0,
+        sample_rate=48_000,
+        channels=2,
+        target_bit_depth=16,
+    )
+
+    assert captured_dither_methods
+    assert captured_dither_methods[-1] == "triangular_hp"
+
+
+def test_quantize_float_to_s16_preserves_dither_on_resampler_reset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Drift-triggered graph rebuild must preserve triangular_hp dithering."""
+    captured_dither_methods: list[str | None] = []
+    original_build_resample_graph = push_stream_module._build_resample_graph  # noqa: SLF001
+
+    def _record_build_resample_graph(
+        *,
+        source_av_format: str,
+        source_layout: str,
+        source_sample_rate: int,
+        target_av_format: str,
+        target_layout: str,
+        target_sample_rate: int,
+        dither_method: str | None = None,
+    ) -> object:
+        if source_av_format == "flt" and target_av_format == "s16":
+            captured_dither_methods.append(dither_method)
+        return original_build_resample_graph(
+            source_av_format=source_av_format,
+            source_layout=source_layout,
+            source_sample_rate=source_sample_rate,
+            target_av_format=target_av_format,
+            target_layout=target_layout,
+            target_sample_rate=target_sample_rate,
+            dither_method=dither_method,
+        )
+
+    monkeypatch.setattr(push_stream_module, "_build_resample_graph", _record_build_resample_graph)
+
+    group = _DummyGroup(clients=[])
+    stream = PushStream(loop=MagicMock(), clock=ManualClock(), group=group)
+    # First call creates the quantizer graph. Second call with stale timestamp creates >20ms
+    # drift, forcing graph rebuild in _resample_pcm_standalone.
+    stream._quantize_float_pcm_for_output(  # noqa: SLF001
+        channel_id=MAIN_CHANNEL,
+        pcm_data=bytes(9600),  # 25ms @ 48kHz stereo f32
+        output_ts=0,
+        sample_rate=48_000,
+        channels=2,
+        target_bit_depth=16,
+    )
+    stream._quantize_float_pcm_for_output(  # noqa: SLF001
+        channel_id=MAIN_CHANNEL,
+        pcm_data=bytes(9600),  # 25ms @ 48kHz stereo f32
+        output_ts=0,
+        sample_rate=48_000,
+        channels=2,
+        target_bit_depth=16,
+    )
+
+    assert len(captured_dither_methods) >= 2
+    assert captured_dither_methods[0] == "triangular_hp"
+    assert captured_dither_methods[-1] == "triangular_hp"
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -2106,3 +2106,108 @@ async def test_multi_role_fanout_quantizes_once_per_pcm_key(
     assert role1.received, "role1 should have received audio chunks"
     # role2 may not receive chunks yet because 25ms of data is below its
     # 50ms frame duration — the important assertion is quantize_calls == 1.
+
+
+@pytest.mark.asyncio
+async def test_catchup_quantizer_does_not_share_live_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Catch-up path must use its own quantizer state, not the shared live cache."""
+    drift_rebuild_count = 0
+    original_resample = push_stream_module._resample_pcm_standalone  # noqa: SLF001
+
+    def _tracking_resample(state: Any, pcm: bytes, fmt: Any, ts: int) -> Any:
+        nonlocal drift_rebuild_count
+        if state.pending_timestamp_us is not None:
+            drift_us = abs(state.pending_timestamp_us - ts)
+            if drift_us > 20_000:
+                drift_rebuild_count += 1
+        return original_resample(state, pcm, fmt, ts)
+
+    monkeypatch.setattr(push_stream_module, "_resample_pcm_standalone", _tracking_resample)
+
+    class TransformerA:
+        pending_timestamp_us: int | None = None
+
+        @property
+        def frame_duration_us(self) -> int:
+            return 25_000
+
+        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[bytes]:
+            return [pcm]
+
+        def flush(self) -> list[bytes]:
+            return []
+
+        def get_header(self) -> bytes | None:
+            return None
+
+        def reset(self) -> None:
+            return
+
+    class TransformerB(TransformerA):
+        pass
+
+    group = _DummyGroup(clients=[])
+
+    # role1 uses TransformerA — its live encoding builds quantizer state in self._resamplers
+    role1 = _DummyRole(
+        AudioRequirements(
+            sample_rate=48_000,
+            bit_depth=16,
+            channels=2,
+            transformer=TransformerA(),
+            channel_id=MAIN_CHANNEL,
+            frame_duration_us=25_000,
+        )
+    )
+    group.clients.append(_DummyClient([role1]))
+
+    loop = asyncio.get_running_loop()
+    clock = ManualClock(now_us_value=0)
+    stream = PushStream(loop=loop, clock=clock, group=group)
+    stream.enable_pcm_cache_for_channel(MAIN_CHANNEL)
+
+    # Commit several float PCM chunks — builds live quantizer state.
+    # Advance clock by 25ms (matching audio duration) between commits to
+    # keep resampler timestamps monotonic without drift-triggered rebuilds.
+    for _ in range(4):
+        stream.prepare_audio(
+            bytes(9600),  # 25ms @ 48kHz stereo f32
+            AudioFormat(sample_rate=48_000, bit_depth=32, channels=2, sample_type="float"),
+        )
+        await stream.commit_audio()
+        clock.advance_us(25_000)
+
+    # Count drift rebuilds so far (live path — should be 0 with ManualClock)
+    live_drifts = drift_rebuild_count
+
+    # Add a late-joining role with TransformerB — different TransformKey, triggers PCM catch-up
+    role2 = _DummyRole(
+        AudioRequirements(
+            sample_rate=48_000,
+            bit_depth=16,
+            channels=2,
+            transformer=TransformerB(),
+            channel_id=MAIN_CHANNEL,
+            frame_duration_us=25_000,
+        )
+    )
+    group.clients.append(_DummyClient([role2]))
+    stream.on_role_join(role2)
+
+    # Wait for the async catch-up task to complete
+    for _ in range(50):
+        if role2.received:
+            break
+        await asyncio.sleep(0.01)
+
+    # Catch-up should NOT trigger drift-rebuilds in the shared quantizer cache.
+    # With separate cache: fresh quantizer state, no drift detection.
+    # With shared cache: the jump from live timestamps (~350ms) to historical
+    # timestamps (~250ms) causes drift > 20ms, triggering a graph rebuild.
+    catchup_drifts = drift_rebuild_count - live_drifts
+    assert catchup_drifts == 0, (
+        f"Expected 0 drift-triggered rebuilds during catch-up, got {catchup_drifts} "
+        f"(likely shared quantizer cache causing timestamp jump)"
+    )

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -236,14 +236,14 @@ async def test_commit_audio_float_input_quantizes_at_output_edge(
     _client, conn = _make_connected_player(mock_loop, group, "p1")
 
     quantize_calls = 0
-    original_quantizer = PushStream._quantize_float_pcm_for_output  # noqa: SLF001
+    original_quantizer = push_stream_module._quantize_float_pcm  # noqa: SLF001
 
-    def _counted_quantizer(self: PushStream, **kwargs: Any) -> object:
+    def _counted_quantizer(**kwargs: Any) -> object:
         nonlocal quantize_calls
         quantize_calls += 1
-        return original_quantizer(self, **kwargs)
+        return original_quantizer(**kwargs)
 
-    monkeypatch.setattr(PushStream, "_quantize_float_pcm_for_output", _counted_quantizer)
+    monkeypatch.setattr(push_stream_module, "_quantize_float_pcm", _counted_quantizer)
 
     stream = PushStream(loop=mock_loop, clock=LoopClock(mock_loop), group=group)
     stream.prepare_audio(
@@ -289,13 +289,14 @@ def test_quantize_float_to_s16_uses_triangular_hp_dither(
 
     group = _DummyGroup(clients=[])
     stream = PushStream(loop=MagicMock(), clock=ManualClock(), group=group)
-    stream._quantize_float_pcm_for_output(  # noqa: SLF001
+    push_stream_module._quantize_float_pcm(  # noqa: SLF001
         channel_id=MAIN_CHANNEL,
         pcm_data=bytes(9600),  # 25ms @ 48kHz stereo f32
         output_ts=0,
         sample_rate=48_000,
         channels=2,
         target_bit_depth=16,
+        resampler_cache=stream._resamplers,  # noqa: SLF001
     )
 
     assert captured_dither_methods
@@ -337,21 +338,23 @@ def test_quantize_float_to_s16_preserves_dither_on_resampler_reset(
     stream = PushStream(loop=MagicMock(), clock=ManualClock(), group=group)
     # First call creates the quantizer graph. Second call with stale timestamp creates >20ms
     # drift, forcing graph rebuild in _resample_pcm_standalone.
-    stream._quantize_float_pcm_for_output(  # noqa: SLF001
+    push_stream_module._quantize_float_pcm(  # noqa: SLF001
         channel_id=MAIN_CHANNEL,
         pcm_data=bytes(9600),  # 25ms @ 48kHz stereo f32
         output_ts=0,
         sample_rate=48_000,
         channels=2,
         target_bit_depth=16,
+        resampler_cache=stream._resamplers,  # noqa: SLF001
     )
-    stream._quantize_float_pcm_for_output(  # noqa: SLF001
+    push_stream_module._quantize_float_pcm(  # noqa: SLF001
         channel_id=MAIN_CHANNEL,
         pcm_data=bytes(9600),  # 25ms @ 48kHz stereo f32
         output_ts=0,
         sample_rate=48_000,
         channels=2,
         target_bit_depth=16,
+        resampler_cache=stream._resamplers,  # noqa: SLF001
     )
 
     assert len(captured_dither_methods) >= 2
@@ -2018,22 +2021,24 @@ def test_drift_rebuild_flushes_old_graph_before_replacing(
     pcm_25ms = bytes(9600)  # 25ms @ 48kHz stereo f32
 
     # First call: creates graph, advances pending_timestamp_us by ~25ms
-    stream._quantize_float_pcm_for_output(  # noqa: SLF001
+    push_stream_module._quantize_float_pcm(  # noqa: SLF001
         channel_id=MAIN_CHANNEL,
         pcm_data=pcm_25ms,
         output_ts=0,
         sample_rate=48_000,
         channels=2,
         target_bit_depth=16,
+        resampler_cache=stream._resamplers,  # noqa: SLF001
     )
     # Second call with same output_ts=0: drift > 20ms, triggers rebuild
-    stream._quantize_float_pcm_for_output(  # noqa: SLF001
+    push_stream_module._quantize_float_pcm(  # noqa: SLF001
         channel_id=MAIN_CHANNEL,
         pcm_data=pcm_25ms,
         output_ts=0,
         sample_rate=48_000,
         channels=2,
         target_bit_depth=16,
+        resampler_cache=stream._resamplers,  # noqa: SLF001
     )
 
     assert flush_calls, "Old graph should have been flushed with push(None) before rebuild"
@@ -2086,14 +2091,14 @@ async def test_multi_role_fanout_quantizes_once_per_pcm_key(
     group.clients.extend([_DummyClient([role1]), _DummyClient([role2])])
 
     quantize_calls = 0
-    original_quantizer = PushStream._quantize_float_pcm_for_output  # noqa: SLF001
+    original_quantizer = push_stream_module._quantize_float_pcm  # noqa: SLF001
 
-    def _counted_quantizer(self: PushStream, **kwargs: Any) -> object:
+    def _counted_quantizer(**kwargs: Any) -> object:
         nonlocal quantize_calls
         quantize_calls += 1
-        return original_quantizer(self, **kwargs)
+        return original_quantizer(**kwargs)
 
-    monkeypatch.setattr(PushStream, "_quantize_float_pcm_for_output", _counted_quantizer)
+    monkeypatch.setattr(push_stream_module, "_quantize_float_pcm", _counted_quantizer)
 
     stream = PushStream(loop=mock_loop, clock=LoopClock(mock_loop), group=group)
     stream.prepare_audio(
@@ -2247,3 +2252,65 @@ def test_noop_resample_bypasses_graph_construction(
     assert result.pcm_data == pcm_25ms, "No-op resample should return input PCM unchanged"
     assert result.sample_count == 1200  # 48000 * 0.025
     assert result.output_start_ts == 1_000_000
+
+
+def test_soxr_fallback_caches_failure_per_format(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After soxr fails for a format combo, subsequent calls skip straight to swr."""
+    # Force _supports_soxr_resampler to return True
+    monkeypatch.setattr(push_stream_module, "_supports_soxr_resampler", lambda: True)
+
+    # Replace with a fresh set so test mutations don't leak; monkeypatch restores on teardown
+    monkeypatch.setattr(push_stream_module, "_soxr_failed_configs", set())
+
+    av_mod = push_stream_module._get_av()  # noqa: SLF001
+    OriginalGraph = av_mod.filter.Graph  # noqa: N806
+    soxr_attempt_count = 0
+
+    class _TrackingSoxrGraph:
+        """Graph wrapper that fails on soxr and tracks attempts."""
+
+        def __init__(self) -> None:
+            self._real = OriginalGraph()
+
+        def add_abuffer(self, **kwargs: Any) -> Any:
+            return self._real.add_abuffer(**kwargs)
+
+        def add(self, name: str, args: str = "") -> Any:
+            nonlocal soxr_attempt_count
+            if "soxr" in args:
+                soxr_attempt_count += 1
+                raise OSError("simulated soxr failure")
+            return self._real.add(name, args)
+
+        def link_nodes(self, *nodes: Any) -> Any:
+            return self._real.link_nodes(*nodes)
+
+    monkeypatch.setattr(av_mod.filter, "Graph", _TrackingSoxrGraph)
+
+    # First call: soxr fails, falls back to swr
+    push_stream_module._build_resample_graph(  # noqa: SLF001
+        source_av_format="s16",
+        source_layout="stereo",
+        source_sample_rate=44_100,
+        target_av_format="s16",
+        target_layout="stereo",
+        target_sample_rate=48_000,
+    )
+    first_soxr_attempts = soxr_attempt_count
+
+    # Second call with same format: should skip soxr entirely
+    push_stream_module._build_resample_graph(  # noqa: SLF001
+        source_av_format="s16",
+        source_layout="stereo",
+        source_sample_rate=44_100,
+        target_av_format="s16",
+        target_layout="stereo",
+        target_sample_rate=48_000,
+    )
+
+    assert first_soxr_attempts == 1, "First call should attempt soxr once"
+    assert soxr_attempt_count == 1, (
+        f"Second call should skip soxr (cached failure), but got {soxr_attempt_count} attempts"
+    )


### PR DESCRIPTION
Move PushStream resampling to an FFmpeg filter graph and prefer soxr.
Keep float sources in float32 through shared processing and only quantize once at the output edge for integer outputs. Apply triangular_hp dithering for float to s16 conversion.

