### PR TITLE
Fix wrong connection check in send_message

### DIFF
--- a/aiosendspin/client/client.py
+++ b/aiosendspin/client/client.py
@@ -714,7 +714,7 @@ class SendspinClient:
         await self._send_message(message.to_json())
 
     async def _send_message(self, payload: str) -> None:
-        if not self._ws:
+        if self._ws is None:
             raise RuntimeError("WebSocket is not connected")
         async with self._send_lock:
             await self._ws.send_str(payload)


### PR DESCRIPTION
On `aiohttp<3.12` `WebSocketResponse` (by extending from `StreamResponse`) is always falsy, causing aiosendspin to claim that it is not connected, even if it is.

On `aiohttp>=3.12` it is always truthy, making the check work correctly and erroring only when `ws` is `None`.

Because aiosendspin depends on `aiohttp>=3.9.2` the condition should be adjusted to support both cases.

Relevant aiohttp change: https://github.com/aio-libs/aiohttp/pull/10172