### PR TITLE
Move server-only dependencies to optional extras

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           python-version: "3.12"
           enable-cache: true
-      - run: uv sync --dev
+      - run: uv sync --dev --extra server
       - name: Lint with pre-commit
         run: SKIP=no-commit-to-branch uv run pre-commit run --all-files
 
@@ -39,6 +39,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
-      - run: uv sync --dev
+      - run: uv sync --dev --extra server
       - name: Pytest
         run: uv run pytest --durations 10 --cov-report term-missing --cov=aiosendspin --cov-report=xml tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,8 @@ classifiers = [
 ]
 dependencies = [
   "aiohttp>=3.9.2",
-  "av>=15.0.0",
   "mashumaro>=3.14",
-  "numpy>=1.26.0",
   "orjson>=3.10.0",
-  "pillow>=11.0.0",
   "zeroconf>=0.147",
 ]
 
@@ -30,6 +27,11 @@ requires-python = ">=3.12"
 version = "0.0.0"
 
 [project.optional-dependencies]
+server = [
+  "av>=15.0.0",
+  "numpy>=1.26.0",
+  "pillow>=11.0.0",
+]
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
## Summary

- **Breaking change:** Moves `av`, `numpy`, and `pillow` from core dependencies to `[project.optional-dependencies] server`, since they are only used by the server subpackage.
- Users that depend on server functionality must now install `aiosendspin[server]`.
- Client-only users get a lighter install without unnecessary native dependencies.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Test plan

- [x] Verified that `av`, `numpy`, and `pillow` are only imported within `aiosendspin/server/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)