### PR TITLE
Fix time filter drift covariance and adaptive forgetting bugs

### DIFF
--- a/aiosendspin/client/time_sync.py
+++ b/aiosendspin/client/time_sync.py
@@ -115,7 +115,7 @@ class SendspinTimeFilter:
             self._offset = float(measurement)
 
             # Drift variance estimated from propagation of offset uncertainties
-            self._drift_covariance = (self._offset_covariance + measurement_variance) / dt
+            self._drift_covariance = (self._offset_covariance + measurement_variance) / (dt * dt)
             self._offset_covariance = measurement_variance
 
             self._current_time_element = TimeElement(
@@ -161,7 +161,7 @@ class SendspinTimeFilter:
         if self._count < 100:
             # Build sufficient history before enabling adaptive forgetting
             self._count += 1
-        elif residual > max_residual_cutoff:
+        elif abs(residual) > max_residual_cutoff:
             # Large prediction error detected - likely network disruption or clock adjustment
             # Apply forgetting factor to increase Kalman gain and accelerate convergence
             new_drift_covariance *= self._forget_variance_factor


### PR DESCRIPTION
## Summary
- Fix drift covariance initialization: divide by dt² instead of dt (error propagation for finite difference)
- Fix adaptive forgetting: use abs(residual) to trigger on both positive and negative clock jumps

## Details
These bugs were found by comparing the Python implementation against the [reference C++ time filter](https://github.com/Sendspin/time-filter).

### Drift covariance (dt vs dt²)
The drift is estimated via finite differences: `drift = (measurement - offset) / dt`. By error propagation, `var(drift) = var(delta_offset) / dt²`. The code was dividing by `dt` instead of `dt²`, vastly overestimating the initial drift uncertainty (by a factor of ~dt, which is ~200,000 for typical microsecond timestamps with 200ms sync intervals), severely slowing drift convergence.

### Adaptive forgetting (missing abs)
The adaptive forgetting check used `residual > cutoff` instead of `abs(residual) > cutoff`. This meant only positive residuals (measured offset larger than predicted) triggered forgetting. Negative residuals from backwards clock jumps or shortened network paths would not trigger fast recovery.