### PR TITLE
Fix late chunk drops with large `static_delay_ms`

### DIFF
--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -351,7 +351,7 @@ class PushStream:
         """Return a stable timestamp for commits interrupted by stop()."""
         if self._channel_timing:
             return min(self._channel_timing.values())
-        return self._clock.now_us() + DEFAULT_INITIAL_DELAY_US
+        return self._clock.now_us() + DEFAULT_INITIAL_DELAY_US + self._max_active_static_delay_us()
 
     @staticmethod
     def _client_in_audio_pipeline(client: SendspinClient) -> bool:
@@ -385,6 +385,13 @@ class PushStream:
                     continue
                 result.append((client, role))
         return result
+
+    def _max_active_static_delay_us(self) -> int:
+        """Return the largest static delay among active audio roles."""
+        roles = self._get_audio_roles()
+        if not roles:
+            return 0
+        return max(role.get_static_delay_us() for _, role in roles)
 
     def _get_cached_resampler(self, key: _ResamplerKey) -> _ResamplerState | None:
         """Get existing resampler from cache, or None if not cached."""
@@ -443,8 +450,9 @@ class PushStream:
         max_timing_us = max(active_timings)
         now_us = self._clock.now_us()
         ahead_us = max_timing_us - now_us
-        if ahead_us > max_buffer_us:
-            await asyncio.sleep(min((ahead_us - max_buffer_us) / 1_000_000, 1.0))
+        effective_limit_us = max_buffer_us + self._max_active_static_delay_us()
+        if ahead_us > effective_limit_us:
+            await asyncio.sleep(min((ahead_us - effective_limit_us) / 1_000_000, 1.0))
 
     def prepare_audio(
         self,
@@ -575,7 +583,9 @@ class PushStream:
         if not self._channel_buffers and not historical:
             now_us = self._clock.now_us()
             if not self._channel_timing:
-                self._channel_timing[MAIN_CHANNEL] = now_us + DEFAULT_INITIAL_DELAY_US
+                self._channel_timing[MAIN_CHANNEL] = (
+                    now_us + DEFAULT_INITIAL_DELAY_US + self._max_active_static_delay_us()
+                )
             return min(self._channel_timing.values())
 
         # Process historical buffers first: assign timestamps and inject into caches.
@@ -684,7 +694,7 @@ class PushStream:
 
         # Auto-calculate mode (existing behavior).
         now_us = self._clock.now_us()
-        target_min_us = now_us + DEFAULT_INITIAL_DELAY_US
+        target_min_us = now_us + DEFAULT_INITIAL_DELAY_US + self._max_active_static_delay_us()
         # Limit timeline sharing/rebase inputs to channels participating in this commit
         # (active subscribers + prepared payloads). This excludes stale timing entries
         # from inactive channels.
@@ -744,7 +754,9 @@ class PushStream:
         :param historical: Channel ID -> list of (pcm, format) chunks (oldest first).
         """
         now_us = self._clock.now_us()
-        min_delivery_timestamp_us = now_us + DEFAULT_INITIAL_DELAY_US
+        min_delivery_timestamp_us = (
+            now_us + DEFAULT_INITIAL_DELAY_US + self._max_active_static_delay_us()
+        )
 
         for channel_id, chunks in historical.items():
             if not self._is_generation_active(commit_generation):
@@ -783,7 +795,9 @@ class PushStream:
                 anchor_timing_us = min(anchor_candidates)
                 self._channel_timing[channel_id] = max(0, anchor_timing_us - total_duration_us)
             else:
-                self._channel_timing[channel_id] = now_us + DEFAULT_INITIAL_DELAY_US
+                self._channel_timing[channel_id] = (
+                    now_us + DEFAULT_INITIAL_DELAY_US + self._max_active_static_delay_us()
+                )
 
             for pcm_bytes, fmt in chunks:
                 chunk_start_us = self._channel_timing[channel_id]

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -29,7 +29,12 @@ from aiosendspin.server.audio_transformers import TransformerPool
 from aiosendspin.server.channels import MAIN_CHANNEL
 from aiosendspin.server.client import SendspinClient
 from aiosendspin.server.clock import LoopClock, ManualClock
-from aiosendspin.server.push_stream import CachedChunk, CachedPCMChunk, PushStream
+from aiosendspin.server.push_stream import (
+    DEFAULT_INITIAL_DELAY_US,
+    CachedChunk,
+    CachedPCMChunk,
+    PushStream,
+)
 from aiosendspin.server.roles import AudioChunk, AudioRequirements
 from aiosendspin.server.roles.player.audio_transformers import PcmPassthrough
 
@@ -106,8 +111,9 @@ class _FakeConnection:
 
 
 class _DummyRole:
-    def __init__(self, requirements: AudioRequirements) -> None:
+    def __init__(self, requirements: AudioRequirements, *, static_delay_us: int = 0) -> None:
         self._requirements = requirements
+        self._static_delay_us = static_delay_us
         self.received: list[AudioChunk] = []
         self.started = 0
 
@@ -115,7 +121,7 @@ class _DummyRole:
         return self._requirements
 
     def get_static_delay_us(self) -> int:
-        return 0
+        return self._static_delay_us
 
     def get_join_delay_s(self) -> float:
         return 0.0
@@ -1893,3 +1899,125 @@ async def test_late_joiner_after_historical_injection() -> None:
 
     assert role2.started == 1
     assert role2.received
+
+
+# ---------------------------------------------------------------------------
+# Static delay send-ahead budget tests
+# ---------------------------------------------------------------------------
+
+_STATIC_DELAY_US = 5_000_000  # 5 s
+
+
+def _make_role(
+    *,
+    static_delay_us: int = 0,
+    channel_id: UUID = MAIN_CHANNEL,
+) -> _DummyRole:
+    return _DummyRole(
+        AudioRequirements(
+            sample_rate=48000,
+            bit_depth=16,
+            channels=2,
+            transformer=None,
+            channel_id=channel_id,
+            frame_duration_us=25_000,
+        ),
+        static_delay_us=static_delay_us,
+    )
+
+
+@pytest.mark.asyncio
+async def test_commit_audio_bootstrap_includes_static_delay() -> None:
+    """First commit with a large-delay player pushes timeline forward."""
+    loop = asyncio.get_running_loop()
+    clock = ManualClock(now_us_value=1_000_000)
+    group = _DummyGroup(clients=[])
+    role = _make_role(static_delay_us=_STATIC_DELAY_US)
+    group.clients.append(_DummyClient([role]))
+
+    stream = PushStream(loop=loop, clock=clock, group=group)
+    fmt = AudioFormat(sample_rate=48000, bit_depth=16, channels=2)
+    stream.prepare_audio(bytes(4800), fmt)
+    play_start = await stream.commit_audio()
+
+    assert play_start >= clock.now_us() + DEFAULT_INITIAL_DELAY_US + _STATIC_DELAY_US
+
+
+@pytest.mark.asyncio
+async def test_mixed_delay_timeline_uses_largest_static_delay() -> None:
+    """With 0 ms and 5 s delay players, timeline anchored for the largest."""
+    loop = asyncio.get_running_loop()
+    clock = ManualClock(now_us_value=1_000_000)
+    group = _DummyGroup(clients=[])
+    role_fast = _make_role(static_delay_us=0)
+    role_slow = _make_role(static_delay_us=_STATIC_DELAY_US)
+    group.clients.extend([_DummyClient([role_fast]), _DummyClient([role_slow])])
+
+    stream = PushStream(loop=loop, clock=clock, group=group)
+    fmt = AudioFormat(sample_rate=48000, bit_depth=16, channels=2)
+    stream.prepare_audio(bytes(4800), fmt)
+    play_start = await stream.commit_audio()
+
+    assert play_start >= clock.now_us() + DEFAULT_INITIAL_DELAY_US + _STATIC_DELAY_US
+
+
+@pytest.mark.asyncio
+async def test_sleep_to_limit_buffer_accounts_for_static_delay() -> None:
+    """Buffer throttle allows extra lead equal to the largest static delay."""
+    loop = asyncio.get_running_loop()
+    clock = ManualClock(now_us_value=1_000_000)
+    group = _DummyGroup(clients=[])
+    role = _make_role(static_delay_us=_STATIC_DELAY_US)
+    group.clients.append(_DummyClient([role]))
+
+    stream = PushStream(loop=loop, clock=clock, group=group)
+    # Timeline 5.25 s ahead — exactly DEFAULT + static_delay
+    stream._channel_timing[MAIN_CHANNEL] = (  # noqa: SLF001
+        clock.now_us() + DEFAULT_INITIAL_DELAY_US + _STATIC_DELAY_US
+    )
+
+    # With a 500 ms base buffer, effective limit = 500 ms + 5 s = 5.5 s.
+    # ahead_us = 5.25 s < 5.5 s → no sleep.
+    await stream.sleep_to_limit_buffer(max_buffer_us=500_000)
+    # Test passes by returning immediately (no hang).
+
+
+@pytest.mark.asyncio
+async def test_historical_stale_filter_includes_static_delay() -> None:
+    """Historical chunk between DEFAULT and DEFAULT+static_delay is filtered."""
+    loop = asyncio.get_running_loop()
+    clock = ManualClock(now_us_value=1_000_000)
+    channel = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
+    group = _DummyGroup(clients=[])
+    role = _make_role(static_delay_us=_STATIC_DELAY_US, channel_id=channel)
+    group.clients.append(_DummyClient([role]))
+
+    stream = PushStream(loop=loop, clock=clock, group=group)
+    fmt = AudioFormat(sample_rate=48000, bit_depth=16, channels=2)
+    # Place chunk just above the old threshold (now + DEFAULT = 1_250_000) but well
+    # below the new threshold (now + DEFAULT + 5s = 6_250_000).  Without the fix
+    # this chunk would have been delivered; with the fix it is correctly filtered.
+    start_us = clock.now_us() + DEFAULT_INITIAL_DELAY_US + 100_000  # now + 350 ms
+    stream.prepare_historical_audio(bytes(4800), fmt, channel_id=channel, start_time_us=start_us)
+    await stream.commit_audio()
+
+    assert not role.received
+    # Channel timing still advanced (continuity preserved)
+    assert channel in stream._channel_timing  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_zero_delay_regression_commit_audio_unchanged() -> None:
+    """With all delays at 0, commit_audio behaves identically to before."""
+    loop = asyncio.get_running_loop()
+    clock = ManualClock(now_us_value=1_000_000)
+    group = _DummyGroup(clients=[])
+    role = _make_role(static_delay_us=0)
+    group.clients.append(_DummyClient([role]))
+
+    stream = PushStream(loop=loop, clock=clock, group=group)
+    fmt = AudioFormat(sample_rate=48000, bit_depth=16, channels=2)
+    stream.prepare_audio(bytes(4800), fmt)
+    play_start = await stream.commit_audio()
+
+    assert play_start == clock.now_us() + DEFAULT_INITIAL_DELAY_US


### PR DESCRIPTION
When a player advertises a large `static_delay_ms`, the server's fixed 250ms send-ahead window wasn't enough. Chunks arrived late from the player's perspective and got dropped at startup.

`PushStream` scheduling paths now extend the send-ahead by the largest active player's `static_delay_us` via a new `_max_active_static_delay_us()` helper. Buffer throttling also accounts for the extra lead so the producer isn't throttled prematurely.

Resolves the issue raised in https://github.com/Sendspin/sendspin-cli/pull/185