### PR TITLE
Fix timestamp drift after extended playback

### DIFF
--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -264,6 +264,13 @@ class _ResamplerState:
     """True when resampler output is s32 but wire PCM is packed s24."""
     pending_timestamp_us: int | None = None
     """Timestamp of the earliest audio sample not yet emitted by this resampler."""
+    pending_ts_residue: int = 0
+    """Drift-free residue accumulator for `pending_timestamp_us`. Each call advances
+    pending by `output_samples * 1_000_000 / target_sample_rate`. For target rates
+    where this isn't a whole number (e.g. 44.1kHz), `int(...)` truncation accumulates
+    backward drift over time. We track the unconsumed numerator across calls so
+    cumulative pending exactly matches sample-derived elapsed time. Reset to 0
+    whenever pending is rebased onto a fresh anchor (drift_reset, init)."""
     is_passthrough: bool = False
     """True when source and target formats are identical — skip graph processing."""
 
@@ -363,6 +370,7 @@ def _resample_pcm_standalone(
     # Handle timestamp tracking
     if resampler_state.pending_timestamp_us is None:
         resampler_state.pending_timestamp_us = input_timestamp_us
+        resampler_state.pending_ts_residue = 0
     else:
         # Resync if timestamp drifts too far (e.g., resampler was idle)
         drift_us = abs(resampler_state.pending_timestamp_us - input_timestamp_us)
@@ -385,6 +393,9 @@ def _resample_pcm_standalone(
                     dither_method=resampler_state.key.dither_method,
                 )
             resampler_state.pending_timestamp_us = input_timestamp_us
+            # Reset the residue accumulator: pending has been rebased onto a fresh
+            # anchor and any carried fractional µs from the prior segment are stale.
+            resampler_state.pending_ts_residue = 0
 
     # Calculate sample count from input
     bytes_per_sample = source_format.bit_depth // 8
@@ -416,7 +427,14 @@ def _resample_pcm_standalone(
     # Fast path: no conversion needed — return input PCM with timestamp tracking
     if resampler_state.is_passthrough:
         output_start_ts = resampler_state.pending_timestamp_us
-        duration_us = int(sample_count * 1_000_000 / resampler_state.key.target_sample_rate)
+        # Drift-free advance: track the fractional µs across calls. Plain
+        # `int(samples * 1e6 / sample_rate)` accumulates per-call truncation
+        # error for rates that don't divide cleanly into 1e6 (e.g. 44.1k).
+        resampler_state.pending_ts_residue += sample_count * 1_000_000
+        duration_us, resampler_state.pending_ts_residue = divmod(
+            resampler_state.pending_ts_residue,
+            resampler_state.key.target_sample_rate,
+        )
         resampler_state.pending_timestamp_us += duration_us
         return _ResampledPCM(
             pcm_data=av_input_pcm,
@@ -455,8 +473,13 @@ def _resample_pcm_standalone(
 
     output_start_ts = resampler_state.pending_timestamp_us
 
-    # Update pending timestamp based on output samples
-    duration_us = int(output_sample_count * 1_000_000 / resampler_state.key.target_sample_rate)
+    # Update pending timestamp based on output samples — same drift-free
+    # accumulator as the passthrough fast path. See note above.
+    resampler_state.pending_ts_residue += output_sample_count * 1_000_000
+    duration_us, resampler_state.pending_ts_residue = divmod(
+        resampler_state.pending_ts_residue,
+        resampler_state.key.target_sample_rate,
+    )
     resampler_state.pending_timestamp_us += duration_us
 
     return _ResampledPCM(

--- a/aiosendspin/server/roles/player/audio_transformers.py
+++ b/aiosendspin/server/roles/player/audio_transformers.py
@@ -41,11 +41,19 @@ class PcmPassthrough:
         # Calculate frame size: samples = sample_rate * duration_s
         # For 48kHz, 25ms: 48000 * 0.025 = 1200 samples
         # Frame size = samples * frame_stride = 1200 * 4 = 4800 bytes
-        chunk_samples = int(sample_rate * chunk_duration_us / 1_000_000)
-        self._frame_size = chunk_samples * self._frame_stride
+        self._chunk_samples = int(sample_rate * chunk_duration_us / 1_000_000)
+        self._frame_size = self._chunk_samples * self._frame_stride
         self._buffer = bytearray()
         # Track timestamp of the first sample in the buffer
         self._pending_timestamp_us: int | None = None
+        # Drift-free timestamp accumulator. Each emitted frame represents exactly
+        # `chunk_samples / sample_rate` seconds of audio. For sample rates where
+        # `chunk_samples * 1_000_000` is not divisible by `sample_rate` (e.g.
+        # 44.1kHz/25ms = 1102 samples = 24988.66µs), advancing pending by a fixed
+        # `chunk_duration_us` accumulates per-frame drift (~11µs/frame at
+        # 44.1k/25ms). The residue here tracks the unconsumed numerator across
+        # frames so cumulative pending exactly matches sample-derived elapsed time.
+        self._ts_residue: int = 0
         # Track last input timestamp to detect production gaps
         self._last_input_timestamp_us: int | None = None
 
@@ -75,8 +83,11 @@ class PcmPassthrough:
         if self._last_input_timestamp_us is not None:
             input_gap = timestamp_us - self._last_input_timestamp_us
             if input_gap > 1_500_000:  # 1.5s threshold
-                # Production gap detected - reset timestamp tracking
+                # Production gap detected - reset timestamp tracking. Reset the
+                # residue too: we're rebasing pending onto a fresh anchor and any
+                # carried fractional µs from the prior segment are stale.
                 self._pending_timestamp_us = timestamp_us
+                self._ts_residue = 0
         self._last_input_timestamp_us = timestamp_us
 
         # Track timestamp of first buffered sample (only if not already set)
@@ -90,9 +101,14 @@ class PcmPassthrough:
             frame = bytes(self._buffer[: self._frame_size])
             del self._buffer[: self._frame_size]
             frames.append(frame)
-            # Advance pending timestamp by one frame duration
+            # Advance pending timestamp using rational arithmetic. Each frame
+            # represents exactly `chunk_samples / sample_rate` seconds. Tracking
+            # the residue avoids the systematic per-frame drift that occurs when
+            # `chunk_samples * 1_000_000` is not divisible by `sample_rate`.
             if self._pending_timestamp_us is not None:
-                self._pending_timestamp_us += self._chunk_duration_us
+                self._ts_residue += self._chunk_samples * 1_000_000
+                delta_us, self._ts_residue = divmod(self._ts_residue, self._sample_rate)
+                self._pending_timestamp_us += delta_us
 
         return frames
 
@@ -111,6 +127,7 @@ class PcmPassthrough:
         frame = bytes(self._buffer)
         self._buffer.clear()
         self._pending_timestamp_us = None
+        self._ts_residue = 0
         return [frame]
 
     def get_header(self) -> bytes | None:
@@ -121,6 +138,7 @@ class PcmPassthrough:
         """Reset internal buffer."""
         self._buffer.clear()
         self._pending_timestamp_us = None
+        self._ts_residue = 0
         self._last_input_timestamp_us = None
 
 
@@ -173,10 +191,18 @@ class FlacEncoder:
 
     @property
     def pending_timestamp_us(self) -> int | None:
-        """Timestamp of the next output frame, or None if stream not started."""
+        """Timestamp of the next output frame, or None if stream not started.
+
+        Uses exact rational arithmetic (`samples * 1e6 // sample_rate`) instead of
+        accumulating `chunk_duration_us` to avoid drift when sample_rate doesn't
+        divide cleanly into chunk_samples * 1e6 (e.g. 44.1kHz).
+        """
         if self._stream_start_timestamp_us is None:
             return None
-        return self._stream_start_timestamp_us + self._output_frame_count * self._chunk_duration_us
+        cumulative_samples = self._output_frame_count * self._chunk_samples
+        return self._stream_start_timestamp_us + (
+            cumulative_samples * 1_000_000 // self._sample_rate
+        )
 
     def _ensure_initialized(self) -> None:
         """Lazily initialize encoder on first use."""
@@ -282,9 +308,14 @@ class FlacEncoder:
                 if self._stream_start_timestamp_us is None:
                     assert self._first_input_timestamp_us is not None
                     encoder_delay_chunks = max(self._chunks_encoded_total - 1, 0)
-                    self._stream_start_timestamp_us = (
-                        self._first_input_timestamp_us
-                        + encoder_delay_chunks * self._chunk_duration_us
+                    # Exact rational arithmetic: total samples consumed before
+                    # the encoder produced its first packet. Using
+                    # `chunks * _chunk_duration_us` would accumulate per-frame
+                    # truncation drift at sample rates where chunk_samples * 1e6
+                    # doesn't divide evenly into sample_rate (e.g. 44.1k).
+                    delay_samples = encoder_delay_chunks * self._chunk_samples
+                    self._stream_start_timestamp_us = self._first_input_timestamp_us + (
+                        delay_samples * 1_000_000 // self._sample_rate
                     )
                 frames.append(encoded)
                 # Count output frames for timestamp calculation
@@ -386,10 +417,20 @@ class OpusEncoder:
 
     @property
     def pending_timestamp_us(self) -> int | None:
-        """Timestamp of the next output frame, or None if stream not started."""
+        """Timestamp of the next output frame, or None if stream not started.
+
+        Uses exact rational arithmetic (`samples * 1e6 // sample_rate`) instead of
+        accumulating `chunk_duration_us`. Opus only allows sample rates where the
+        product divides cleanly today (8/12/16/24/48 kHz at 960 samples), so this
+        is currently equivalent to the old formula — but the rational version is
+        future-proof against any new chunk_size or rate that doesn't divide.
+        """
         if self._stream_start_timestamp_us is None:
             return None
-        return self._stream_start_timestamp_us + self._output_frame_count * self._chunk_duration_us
+        cumulative_samples = self._output_frame_count * self._chunk_samples
+        return self._stream_start_timestamp_us + (
+            cumulative_samples * 1_000_000 // self._sample_rate
+        )
 
     def _ensure_initialized(self) -> None:
         """Lazily initialize encoder on first use."""
@@ -479,9 +520,11 @@ class OpusEncoder:
                 if self._stream_start_timestamp_us is None:
                     assert self._first_input_timestamp_us is not None
                     encoder_delay_chunks = max(self._chunks_encoded_total - 1, 0)
-                    self._stream_start_timestamp_us = (
-                        self._first_input_timestamp_us
-                        + encoder_delay_chunks * self._chunk_duration_us
+                    # Exact rational arithmetic for encoder-delay compensation;
+                    # see FlacEncoder for full rationale.
+                    delay_samples = encoder_delay_chunks * self._chunk_samples
+                    self._stream_start_timestamp_us = self._first_input_timestamp_us + (
+                        delay_samples * 1_000_000 // self._sample_rate
                     )
                 frames.append(encoded)
                 self._output_frame_count += 1

--- a/aiosendspin/server/roles/player/audio_transformers.py
+++ b/aiosendspin/server/roles/player/audio_transformers.py
@@ -191,12 +191,7 @@ class FlacEncoder:
 
     @property
     def pending_timestamp_us(self) -> int | None:
-        """Timestamp of the next output frame, or None if stream not started.
-
-        Uses exact rational arithmetic (`samples * 1e6 // sample_rate`) instead of
-        accumulating `chunk_duration_us` to avoid drift when sample_rate doesn't
-        divide cleanly into chunk_samples * 1e6 (e.g. 44.1kHz).
-        """
+        """Timestamp of the next output frame, or None if stream not started."""
         if self._stream_start_timestamp_us is None:
             return None
         cumulative_samples = self._output_frame_count * self._chunk_samples
@@ -417,14 +412,7 @@ class OpusEncoder:
 
     @property
     def pending_timestamp_us(self) -> int | None:
-        """Timestamp of the next output frame, or None if stream not started.
-
-        Uses exact rational arithmetic (`samples * 1e6 // sample_rate`) instead of
-        accumulating `chunk_duration_us`. Opus only allows sample rates where the
-        product divides cleanly today (8/12/16/24/48 kHz at 960 samples), so this
-        is currently equivalent to the old formula — but the rational version is
-        future-proof against any new chunk_size or rate that doesn't divide.
-        """
+        """Timestamp of the next output frame, or None if stream not started."""
         if self._stream_start_timestamp_us is None:
             return None
         cumulative_samples = self._output_frame_count * self._chunk_samples

--- a/tests/server/test_audio_transformers.py
+++ b/tests/server/test_audio_transformers.py
@@ -189,9 +189,8 @@ class TestPcmPassthroughTimestampDrift:
     samples per frame. The actual duration of 1102 samples at 44.1kHz is
     1102 * 1_000_000 / 44100 = 24988.66µs, not 25_000µs. Advancing
     `pending_timestamp_us` by `chunk_duration_us = 25_000` per frame accumulated
-    +11.34µs of forward drift per frame, causing the dual-stream backward-ts
-    glitch documented in `/tmp/sendspin-handoff-v4.md` after ~17 minutes of
-    playback.
+    +11.34µs of forward drift per frame, causing a dual-stream backward-ts
+    glitch after ~17 minutes of playback.
 
     The fix uses rational arithmetic: pending advances by exactly
     `chunk_samples * 1_000_000 / sample_rate` per frame, with the fractional
@@ -302,15 +301,14 @@ class TestPcmPassthroughTimestampDrift:
         assert emitted[-1] == n * 25_000
 
     def test_passthrough_88200_no_drift(self) -> None:
-        """At 88.2kHz (multiple of 44.1k, also doesn't divide cleanly)."""
+        """At 88.2kHz/25ms (2205 samples = 25000µs exact), no drift."""
         transformer = PcmPassthrough(sample_rate=88200, bit_depth=24, channels=2)
         n = 5_000
         emitted = self._drive_n_frames(
             transformer, n_frames=n, sample_rate=88200, bit_depth=24, channels=2
         )
         # int(88200 * 25_000 / 1_000_000) = 2205 samples per frame
-        # 2205 * 1_000_000 / 88200 = 25000.0 exactly! 88.2k IS clean at 25ms.
-        # But verify our formula handles it:
+        # 2205 * 1_000_000 / 88200 = 25000.0 exactly — 88.2k divides cleanly at 25ms.
         chunk_samples = 2205
         expected = n * chunk_samples * 1_000_000 // 88200
         assert emitted[-1] == expected

--- a/tests/server/test_audio_transformers.py
+++ b/tests/server/test_audio_transformers.py
@@ -182,6 +182,191 @@ class TestPcmPassthrough:
         assert transformer.flush() == []
 
 
+class TestPcmPassthroughTimestampDrift:
+    """Regression tests for the per-frame timestamp drift bug.
+
+    Background: at 44.1kHz @ 25ms chunks, `int(44100 * 25_000 / 1_000_000) == 1102`
+    samples per frame. The actual duration of 1102 samples at 44.1kHz is
+    1102 * 1_000_000 / 44100 = 24988.66µs, not 25_000µs. Advancing
+    `pending_timestamp_us` by `chunk_duration_us = 25_000` per frame accumulated
+    +11.34µs of forward drift per frame, causing the dual-stream backward-ts
+    glitch documented in `/tmp/sendspin-handoff-v4.md` after ~17 minutes of
+    playback.
+
+    The fix uses rational arithmetic: pending advances by exactly
+    `chunk_samples * 1_000_000 / sample_rate` per frame, with the fractional
+    µs carried across frames in a residue accumulator.
+    """
+
+    def _drive_n_frames(
+        self,
+        transformer: PcmPassthrough,
+        n_frames: int,
+        *,
+        sample_rate: int,
+        bit_depth: int,
+        channels: int,
+        chunk_duration_us: int = 25_000,
+        start_ts_us: int = 0,
+    ) -> list[int]:
+        """Push enough zero-PCM through transformer to emit `n_frames` frames.
+
+        Returns the per-frame `pending_timestamp_us` snapshot taken AFTER each
+        frame is emitted (i.e. each entry is the timestamp the NEXT frame would
+        carry). Drives the transformer one input chunk at a time so we can
+        sample pending precisely.
+        """
+        chunk_samples = int(sample_rate * chunk_duration_us / 1_000_000)
+        frame_size = chunk_samples * (bit_depth // 8) * channels
+        emitted: list[int] = []
+        # Accumulate input timestamps using rational math so the input side
+        # is not itself drifting.
+        ts_residue = 0
+        ts = start_ts_us
+        while len(emitted) < n_frames:
+            transformer.process(bytes(frame_size), timestamp_us=ts, duration_us=chunk_duration_us)
+            pending = transformer.pending_timestamp_us
+            assert pending is not None
+            emitted.append(pending)
+            ts_residue += chunk_samples * 1_000_000
+            delta, ts_residue = divmod(ts_residue, sample_rate)
+            ts += delta
+        return emitted
+
+    def test_passthrough_44100_no_drift_after_one_frame(self) -> None:
+        """One frame of 1102 samples at 44.1k advances pending by 24988µs (not 25000)."""
+        transformer = PcmPassthrough(sample_rate=44100, bit_depth=16, channels=2)
+        # 1 frame of 1102 stereo s16 samples = 1102 * 4 = 4408 bytes
+        result = transformer.process(bytes(4408), timestamp_us=0, duration_us=25_000)
+        assert len(result) == 1
+        # Pending advances by `1102 * 1_000_000 // 44100` = 24988 µs (NOT 25000)
+        assert transformer.pending_timestamp_us == 24988
+
+    def test_passthrough_44100_no_drift_after_one_thousand_frames(self) -> None:
+        """After 1000 frames at 44.1k, pending matches sample-derived elapsed time exactly."""
+        transformer = PcmPassthrough(sample_rate=44100, bit_depth=16, channels=2)
+        emitted = self._drive_n_frames(
+            transformer, n_frames=1000, sample_rate=44100, bit_depth=16, channels=2
+        )
+        # After N frames, true elapsed = N * 1102 * 1e6 / 44100. With residue
+        # carried, last pending == N*1102*1_000_000 // 44100 (integer-truncated
+        # cumulative, max 1µs final-rounding error vs floating-point ideal).
+        n = 1000
+        chunk_samples = 1102
+        expected = n * chunk_samples * 1_000_000 // 44100
+        assert emitted[-1] == expected, (
+            f"expected pending={expected} after {n} frames, got {emitted[-1]} "
+            f"(drift={emitted[-1] - expected}µs); regression of the +11.34µs/frame "
+            f"truncation bug"
+        )
+
+    def test_passthrough_44100_no_drift_over_glitch_window(self) -> None:
+        """After ~17 minutes of frames at 44.1k (40 frames/sec * 17*60), drift stays bounded."""
+        # Match the empirical bug window: 17 minutes at ~40 frames/sec ≈ 40_800 frames.
+        # Old code drifted +11.34µs/frame * 40_800 = +462ms — enough to trip the
+        # 500ms cliff in _encode_for_transform_key. The fix keeps drift at 0.
+        transformer = PcmPassthrough(sample_rate=44100, bit_depth=16, channels=2)
+        n = 40_800
+        emitted = self._drive_n_frames(
+            transformer, n_frames=n, sample_rate=44100, bit_depth=16, channels=2
+        )
+        chunk_samples = 1102
+        expected = n * chunk_samples * 1_000_000 // 44100
+        drift_us = emitted[-1] - expected
+        # Cumulative drift must be ZERO for our integer-residue arithmetic.
+        # (Floating-point ideal is `n * 1102 / 44100 * 1_000_000`; we compute
+        # `n * 1102 * 1_000_000 // 44100` which is the same up to one final
+        # truncation, so they're exactly equal here.)
+        assert drift_us == 0, (
+            f"drift of {drift_us}µs accumulated over {n} frames at 44.1k — "
+            f"the old +11.34µs/frame bug would produce ~{int(n * 11.34)}µs"
+        )
+
+    def test_passthrough_48000_zero_drift_at_clean_rate(self) -> None:
+        """At 48kHz/25ms (1200 samples = 25000µs exact), drift is zero with old or new code."""
+        transformer = PcmPassthrough(sample_rate=48000, bit_depth=16, channels=2)
+        n = 10_000
+        emitted = self._drive_n_frames(
+            transformer, n_frames=n, sample_rate=48000, bit_depth=16, channels=2
+        )
+        # 1200 * 1_000_000 // 48000 = 25000 exact
+        assert emitted[-1] == n * 25_000
+
+    def test_passthrough_96000_no_drift(self) -> None:
+        """At 96kHz/25ms (2400 samples = 25000µs exact), no drift."""
+        transformer = PcmPassthrough(sample_rate=96000, bit_depth=24, channels=2)
+        n = 1000
+        emitted = self._drive_n_frames(
+            transformer, n_frames=n, sample_rate=96000, bit_depth=24, channels=2
+        )
+        assert emitted[-1] == n * 25_000
+
+    def test_passthrough_88200_no_drift(self) -> None:
+        """At 88.2kHz (multiple of 44.1k, also doesn't divide cleanly)."""
+        transformer = PcmPassthrough(sample_rate=88200, bit_depth=24, channels=2)
+        n = 5_000
+        emitted = self._drive_n_frames(
+            transformer, n_frames=n, sample_rate=88200, bit_depth=24, channels=2
+        )
+        # int(88200 * 25_000 / 1_000_000) = 2205 samples per frame
+        # 2205 * 1_000_000 / 88200 = 25000.0 exactly! 88.2k IS clean at 25ms.
+        # But verify our formula handles it:
+        chunk_samples = 2205
+        expected = n * chunk_samples * 1_000_000 // 88200
+        assert emitted[-1] == expected
+
+    def test_passthrough_emitted_timestamps_strictly_monotonic_at_44100(self) -> None:
+        """Successive pending values must never go backward at any sample rate.
+
+        This is the ultimate guarantee — the dual-stream glitch was a backward
+        emission. After the fix, pending advances by either 24988 or 24989 per
+        frame (never zero, never negative).
+        """
+        transformer = PcmPassthrough(sample_rate=44100, bit_depth=16, channels=2)
+        emitted = self._drive_n_frames(
+            transformer, n_frames=5_000, sample_rate=44100, bit_depth=16, channels=2
+        )
+        for i in range(1, len(emitted)):
+            delta = emitted[i] - emitted[i - 1]
+            assert delta in (24988, 24989), (
+                f"frame {i}: pending advanced by {delta}µs; expected 24988 or 24989 "
+                f"(true value 24988.66µs/frame at 44.1k)"
+            )
+
+    def test_passthrough_residue_resets_on_production_gap(self) -> None:
+        """Long input gap rebases pending; residue must reset too."""
+        transformer = PcmPassthrough(sample_rate=44100, bit_depth=16, channels=2)
+        # Prime with a few frames at 44.1k so residue accumulates
+        self._drive_n_frames(transformer, n_frames=10, sample_rate=44100, bit_depth=16, channels=2)
+        # Simulate a 2-second production gap (>1.5s threshold)
+        # Push input timestamped 2s after the last input
+        new_ts = 2_000_000
+        transformer.process(bytes(4408), timestamp_us=new_ts, duration_us=25_000)
+        # Pending should reflect: rebased to new_ts, then advanced by exactly
+        # one frame (24988µs) with residue starting fresh
+        assert transformer.pending_timestamp_us == new_ts + 24988
+
+    def test_passthrough_residue_resets_on_explicit_reset(self) -> None:
+        """reset() clears residue so subsequent stream starts fresh."""
+        transformer = PcmPassthrough(sample_rate=44100, bit_depth=16, channels=2)
+        self._drive_n_frames(transformer, n_frames=5, sample_rate=44100, bit_depth=16, channels=2)
+        transformer.reset()
+        # Drive one fresh frame
+        transformer.process(bytes(4408), timestamp_us=10_000_000, duration_us=25_000)
+        # Should advance from the new anchor by exactly 24988 (residue was 0)
+        assert transformer.pending_timestamp_us == 10_000_000 + 24988
+
+    def test_passthrough_residue_resets_on_flush(self) -> None:
+        """flush() clears residue so subsequent stream starts fresh."""
+        transformer = PcmPassthrough(sample_rate=44100, bit_depth=16, channels=2)
+        # Push enough samples to leave a partial buffer
+        transformer.process(bytes(2000), timestamp_us=0, duration_us=10_000)
+        transformer.flush()
+        # Drive a fresh frame from new anchor
+        transformer.process(bytes(4408), timestamp_us=5_000_000, duration_us=25_000)
+        assert transformer.pending_timestamp_us == 5_000_000 + 24988
+
+
 class TestTransformerPool:
     """Tests for TransformerPool."""
 

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -2704,8 +2704,10 @@ def test_resampler_passthrough_44100_no_cumulative_drift() -> None:
 
     # Cumulative pending must equal n_calls * 1102 * 1_000_000 // 44100 exactly.
     expected = n_calls * 1102 * 1_000_000 // 44100
-    assert state.pending_timestamp_us == expected, (
-        f"resampler accumulated {state.pending_timestamp_us - expected}µs of "
+    actual = state.pending_timestamp_us
+    assert actual is not None
+    assert actual == expected, (
+        f"resampler accumulated {actual - expected}µs of "
         f"drift over {n_calls} calls — regression of the per-call truncation bug"
     )
 

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -2639,3 +2639,151 @@ async def test_zero_delay_regression_commit_audio_unchanged() -> None:
     play_start = await stream.commit_audio()
 
     assert play_start == clock.now_us() + DEFAULT_INITIAL_DELAY_US
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the resampler timestamp-drift bug.
+# ---------------------------------------------------------------------------
+#
+# `_resample_pcm_standalone` advances `pending_timestamp_us` per call by
+# `int(output_samples * 1_000_000 / target_sample_rate)`. When the divisor
+# does not divide cleanly (e.g. 44.1kHz with 1102 samples = 24988.66µs), the
+# `int(...)` truncation accumulates per-call drift. Combined with the matching
+# bug in `PcmPassthrough`, this produced the cliff at the 500ms transformer
+# drift threshold documented in `/tmp/sendspin-handoff-v4.md`.
+#
+# The fix uses an integer residue accumulator on `_ResamplerState` so cumulative
+# pending exactly matches `total_output_samples * 1_000_000 // target_rate`.
+
+
+def _make_resampler_state_passthrough(
+    *, sample_rate: int, bit_depth: int = 16, channels: int = 2
+) -> push_stream_module._ResamplerState:  # type: ignore[name-defined]
+    """Build a passthrough resampler state at the given target rate."""
+    fmt = AudioFormat(
+        sample_rate=sample_rate, bit_depth=bit_depth, channels=channels, sample_type="int"
+    )
+    key = push_stream_module._ResamplerKey(  # noqa: SLF001
+        channel_id=MAIN_CHANNEL,
+        source_format=fmt,
+        target_sample_rate=sample_rate,
+        target_channels=channels,
+        target_bit_depth=bit_depth,
+        target_sample_type="int",
+    )
+    return push_stream_module._create_resampler_state(key, fmt, fmt)  # noqa: SLF001
+
+
+def test_resampler_passthrough_44100_no_drift_per_call() -> None:
+    """Passthrough @ 44.1k with 1102 samples advances pending by 24988µs (not 24988.66)."""
+    state = _make_resampler_state_passthrough(sample_rate=44100)
+    fmt = AudioFormat(sample_rate=44100, bit_depth=16, channels=2, sample_type="int")
+    pcm = bytes(1102 * 4)  # 1102 stereo s16 samples
+    result = push_stream_module._resample_pcm_standalone(state, pcm, fmt, 0)  # noqa: SLF001
+    assert result.output_start_ts == 0
+    assert state.pending_timestamp_us == 24988  # int(1102 * 1e6 / 44100)
+
+
+def test_resampler_passthrough_44100_no_cumulative_drift() -> None:
+    """After 10k passthrough calls @ 44.1k, pending == sample-derived elapsed time exactly."""
+    state = _make_resampler_state_passthrough(sample_rate=44100)
+    fmt = AudioFormat(sample_rate=44100, bit_depth=16, channels=2, sample_type="int")
+    pcm_one_chunk = bytes(1102 * 4)
+    n_calls = 10_000
+    # Each call advances input_ts by exactly 1102 samples worth of µs (using
+    # rational arithmetic on the input side too).
+    input_residue = 0
+    input_ts = 0
+    for _ in range(n_calls):
+        push_stream_module._resample_pcm_standalone(  # noqa: SLF001
+            state, pcm_one_chunk, fmt, input_ts
+        )
+        input_residue += 1102 * 1_000_000
+        delta, input_residue = divmod(input_residue, 44100)
+        input_ts += delta
+
+    # Cumulative pending must equal n_calls * 1102 * 1_000_000 // 44100 exactly.
+    expected = n_calls * 1102 * 1_000_000 // 44100
+    assert state.pending_timestamp_us == expected, (
+        f"resampler accumulated {state.pending_timestamp_us - expected}µs of "
+        f"drift over {n_calls} calls — regression of the per-call truncation bug"
+    )
+
+
+def test_resampler_passthrough_drift_reset_clears_residue() -> None:
+    """Resampler drift-reset path (>20ms input/pending mismatch) must reset residue."""
+    state = _make_resampler_state_passthrough(sample_rate=44100)
+    fmt = AudioFormat(sample_rate=44100, bit_depth=16, channels=2, sample_type="int")
+    pcm = bytes(1102 * 4)
+    # Prime with a few calls so residue accumulates
+    for i in range(5):
+        push_stream_module._resample_pcm_standalone(state, pcm, fmt, i * 24988)  # noqa: SLF001
+    # Now jump input forward by 5 seconds — way beyond the 20ms drift threshold
+    new_input_ts = 10_000_000
+    push_stream_module._resample_pcm_standalone(state, pcm, fmt, new_input_ts)  # noqa: SLF001
+    # After the rebase + one fresh call: pending should be new_input_ts + 24988
+    # (one chunk's worth from the fresh anchor, with residue having been reset to 0)
+    assert state.pending_timestamp_us == new_input_ts + 24988
+    # And the residue carried into the next call should reflect ONE call worth
+    # (i.e. residue == 1102 * 1_000_000 % 44100 = 14800)
+    assert state.pending_ts_residue == 1102 * 1_000_000 % 44100
+
+
+def test_resampler_passthrough_48000_zero_drift() -> None:
+    """At 48kHz/25ms (clean rate), drift is zero with old or new code — sanity check."""
+    state = _make_resampler_state_passthrough(sample_rate=48000)
+    fmt = AudioFormat(sample_rate=48000, bit_depth=16, channels=2, sample_type="int")
+    pcm = bytes(1200 * 4)
+    push_stream_module._resample_pcm_standalone(state, pcm, fmt, 0)  # noqa: SLF001
+    assert state.pending_timestamp_us == 25_000
+
+
+def test_resampler_passthrough_initial_state_has_zero_residue() -> None:
+    """Freshly created _ResamplerState starts with residue=0."""
+    state = _make_resampler_state_passthrough(sample_rate=44100)
+    assert state.pending_ts_residue == 0
+    assert state.pending_timestamp_us is None
+
+
+def test_resampler_graph_path_44100_no_cumulative_drift() -> None:
+    """48k→44.1k resample via the actual PyAV graph path — the path that triggered the bug."""
+    source = AudioFormat(sample_rate=48_000, bit_depth=16, channels=2, sample_type="int")
+    target = AudioFormat(sample_rate=44_100, bit_depth=16, channels=2, sample_type="int")
+    key = push_stream_module._ResamplerKey(  # noqa: SLF001
+        channel_id=MAIN_CHANNEL,
+        source_format=source,
+        target_sample_rate=44_100,
+        target_channels=2,
+        target_bit_depth=16,
+        target_sample_type="int",
+    )
+    state = push_stream_module._create_resampler_state(key, source, target)  # noqa: SLF001
+    assert not state.is_passthrough  # exercising the graph path
+
+    # Push N calls of 25ms @ 48k = 1200 input samples each
+    n_calls = 1000
+    input_pcm = bytes(1200 * 4)
+    input_residue = 0
+    input_ts = 0
+    total_output_samples = 0
+    last_pending = 0
+    for _ in range(n_calls):
+        result = push_stream_module._resample_pcm_standalone(  # noqa: SLF001
+            state, input_pcm, source, input_ts
+        )
+        total_output_samples += result.sample_count
+        last_pending = state.pending_timestamp_us or 0
+        input_residue += 1200 * 1_000_000
+        delta, input_residue = divmod(input_residue, 48_000)
+        input_ts += delta
+
+    # Cumulative pending must exactly equal total_output_samples * 1e6 // 44100.
+    # The graph may produce a slightly variable sample count per call due to
+    # FFmpeg's filter buffering, but cumulative is what must be drift-free.
+    expected = total_output_samples * 1_000_000 // 44_100
+    drift = last_pending - expected
+    assert drift == 0, (
+        f"graph-path resampler drifted {drift}µs over {n_calls} calls "
+        f"({total_output_samples} output samples) — regression of the per-call "
+        f"truncation bug at push_stream.py:574"
+    )

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -2650,7 +2650,7 @@ async def test_zero_delay_regression_commit_audio_unchanged() -> None:
 # does not divide cleanly (e.g. 44.1kHz with 1102 samples = 24988.66µs), the
 # `int(...)` truncation accumulates per-call drift. Combined with the matching
 # bug in `PcmPassthrough`, this produced the cliff at the 500ms transformer
-# drift threshold documented in `/tmp/sendspin-handoff-v4.md`.
+# drift threshold in `_encode_for_transform_key`.
 #
 # The fix uses an integer residue accumulator on `_ResamplerState` so cumulative
 # pending exactly matches `total_output_samples * 1_000_000 // target_rate`.


### PR DESCRIPTION
I was testing my sendspin-rs changes in the desktop app against my Dev MA server when I discovered that the audio started glitching after ~17 minutes. That wasn't great! I spent a few hours trying to track down what could be wrong with the rust implementation, until I had the thought that I should try to replicate the issue with another sendspin implementation. I ended up using sendspin-cli and had the same issue. And then I was able to replicate it completely locally on my machine using sendspin-cli as both server and client. The trick: specifying 44.1kHz/16-bit on the client-side, forcing the server to transcode from the 48kHz it uses internally. The 48->44.1 transcode math had a very small drift that would build up until it hit 500ms off, which kicked in the big hammer reset, which has a bug itself (I'll be figuring that out and submitting a separate fix, I don't have it prepped yet).

You can replicate with two terminals. In one:

```
uvx sendspin serve --demo # Or any other source of audio, I also tested with local flac and mp3s, and originally reproduced with the Qobuz and Bandcamp providers in MA
```

And in the other:

```
uvx sendspin daemon --name 'sendspin-cli-debug' --url ws://localhost:8927/sendspin --audio-format pcm:44100:16:2
```

and then wait for ~18 minutes. The audio goes from 'just fine' to 'glitchy / terrible'.

As I said, *that* part (the glitchy/terrible audio) is actually a separate bug, but this prevents us from getting to that 500ms cliff in the first place. And in a synchronized group any member that was using transcoded audio would be out of sync with non-transcoded players by a half second, which would be unlistenable anyway.

We also wrote a *bunch* of tests because hoo-boy, this was *tough* to track down. Like, ~10 hours yesterday figuring out what was actually wrong and a few hours today testing the fix. And I'd hate for it to regress / show up again.

Actual math and explanation from the robot sidekick follows.

Per-frame timestamp truncation accumulates forward drift whenever `chunk_samples * 1_000_000` doesn't divide cleanly into `sample_rate`. At 44.1kHz/25ms (1102 samples = 24988.66µs actual, reported as 25000µs) the transformer's `pending_timestamp_us` drifts +11.34µs/frame; the resampler drifts -0.66µs/call in the opposite direction. The combined +12µs/commit drift crosses the 500ms `_TRANSFORMER_DRIFT_THRESHOLD_US` cliff in `_encode_for_transform_key` after ~17 minutes of playback, triggering ~475ms backward-ts emissions and audible dual-stream glitches.

Fix uses integer rational arithmetic (the same pattern as SendspinKit's `AudioPlayer.advanceCursor` at AudioPlayer.swift:92-106) so cumulative pending exactly matches `total_samples * 1_000_000 / sample_rate`:

- `_ResamplerState` gains `pending_ts_residue: int` reset on init and on the >20ms drift_reset rebase. Both passthrough and graph paths use `divmod(samples * 1e6 + residue, sample_rate)` to advance pending.
- `PcmPassthrough` gains `_ts_residue: int` reset on init/reset/flush and on production-gap rebases. Per emitted frame uses the same divmod pattern.
- `FlacEncoder.pending_timestamp_us` and the encoder-delay-compensation formula switch from `frame_count * chunk_duration_us` to `cumulative_samples * 1_000_000 // sample_rate`.
- `OpusEncoder` same fix (no-op at supported rates today since they all divide cleanly, but future-proof against new chunk sizes/rates).

Regression tests (16 new) in TestPcmPassthroughTimestampDrift assert zero drift after one frame, 1k frames, and 40_800 frames (the full 17-minute glitch window) at 44.1k, plus zero-drift sanity at 48k/96k/88.2k. New tests in test_push_stream_behavior.py exercise both passthrough and graph paths of `_resample_pcm_standalone` with cumulative-drift assertions over 1k-10k calls, plus a residue-reset assertion on the drift-reset branch.

Verified clean via two 20+ minute repro runs at 44.1kHz (one HTTP, one local file source) and a 25-minute two-daemon multi-rate group-sync run (44.1k + 48k concurrent) — all with zero backward-ts emissions.