### PR TITLE
Fix audio stutter when player format requires resampling

### DIFF
--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -271,6 +271,11 @@ class _ResamplerState:
     backward drift over time. We track the unconsumed numerator across calls so
     cumulative pending exactly matches sample-derived elapsed time. Reset to 0
     whenever pending is rebased onto a fresh anchor (drift_reset, init)."""
+    pending_input_timestamp_us: int | None = None
+    """Expected timestamp of the next input frame. Advances by input duration per call
+    and is used to detect genuine input-timeline gaps independent of resampler FIR
+    latency, which can make the output-side `pending_timestamp_us` lag the input by
+    tens of ms even during steady-state operation (notably with soxr precision=30)."""
     is_passthrough: bool = False
     """True when source and target formats are identical — skip graph processing."""
 
@@ -346,7 +351,7 @@ def _create_resampler_state(
     )
 
 
-def _resample_pcm_standalone(
+def _resample_pcm_standalone(  # noqa: PLR0915
     resampler_state: _ResamplerState,
     source_pcm: bytes,
     source_format: AudioFormat,
@@ -367,13 +372,18 @@ def _resample_pcm_standalone(
     """
     av = _get_av()
 
-    # Handle timestamp tracking
-    if resampler_state.pending_timestamp_us is None:
+    # Handle timestamp tracking.
+    # Drift detection compares the *input* timeline — `pending_input_timestamp_us`
+    # tracks where the next input sample is expected to land based on previously
+    # consumed input durations. Using the output timeline would mis-fire on every
+    # call because long-FIR resamplers (e.g. soxr precision=30) emit fewer samples
+    # than the rate-conversion ratio until the graph is warmed up.
+    if resampler_state.pending_input_timestamp_us is None:
         resampler_state.pending_timestamp_us = input_timestamp_us
         resampler_state.pending_ts_residue = 0
+        resampler_state.pending_input_timestamp_us = input_timestamp_us
     else:
-        # Resync if timestamp drifts too far (e.g., resampler was idle)
-        drift_us = abs(resampler_state.pending_timestamp_us - input_timestamp_us)
+        drift_us = abs(resampler_state.pending_input_timestamp_us - input_timestamp_us)
         if drift_us > 20_000:
             # Flush the old graph to release FIR filter tails cleanly.
             # Flushed samples are discarded — they belong to the stale timeline.
@@ -396,6 +406,11 @@ def _resample_pcm_standalone(
             # Reset the residue accumulator: pending has been rebased onto a fresh
             # anchor and any carried fractional µs from the prior segment are stale.
             resampler_state.pending_ts_residue = 0
+            resampler_state.pending_input_timestamp_us = input_timestamp_us
+
+    # Both cursors are guaranteed initialized above — narrow for mypy.
+    assert resampler_state.pending_timestamp_us is not None
+    assert resampler_state.pending_input_timestamp_us is not None
 
     # Calculate sample count from input
     bytes_per_sample = source_format.bit_depth // 8
@@ -407,6 +422,7 @@ def _resample_pcm_standalone(
         )
         raise ValueError(msg)
     sample_count = len(source_pcm) // frame_stride
+    input_duration_us = int(sample_count * 1_000_000 / source_format.sample_rate)
     av_input_pcm = (
         _convert_s24_to_s32(source_pcm)
         if source_format.sample_type == "int"
@@ -423,6 +439,8 @@ def _resample_pcm_standalone(
             needs_s32_to_s24_conversion=resampler_state.needs_s32_to_s24_conversion,
             sample_type=resampler_state.target_sample_type,
         )
+
+    resampler_state.pending_input_timestamp_us += input_duration_us
 
     # Fast path: no conversion needed — return input PCM with timestamp tracking
     if resampler_state.is_passthrough:

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -276,6 +276,8 @@ class _ResamplerState:
     and is used to detect genuine input-timeline gaps independent of resampler FIR
     latency, which can make the output-side `pending_timestamp_us` lag the input by
     tens of ms even during steady-state operation (notably with soxr precision=30)."""
+    pending_input_ts_residue: int = 0
+    """Input-side counterpart to `pending_ts_residue`. Reset on init and drift rebase."""
     is_passthrough: bool = False
     """True when source and target formats are identical — skip graph processing."""
 
@@ -382,6 +384,7 @@ def _resample_pcm_standalone(  # noqa: PLR0915
         resampler_state.pending_timestamp_us = input_timestamp_us
         resampler_state.pending_ts_residue = 0
         resampler_state.pending_input_timestamp_us = input_timestamp_us
+        resampler_state.pending_input_ts_residue = 0
     else:
         drift_us = abs(resampler_state.pending_input_timestamp_us - input_timestamp_us)
         if drift_us > 20_000:
@@ -407,6 +410,7 @@ def _resample_pcm_standalone(  # noqa: PLR0915
             # anchor and any carried fractional µs from the prior segment are stale.
             resampler_state.pending_ts_residue = 0
             resampler_state.pending_input_timestamp_us = input_timestamp_us
+            resampler_state.pending_input_ts_residue = 0
 
     # Both cursors are guaranteed initialized above — narrow for mypy.
     assert resampler_state.pending_timestamp_us is not None
@@ -422,7 +426,6 @@ def _resample_pcm_standalone(  # noqa: PLR0915
         )
         raise ValueError(msg)
     sample_count = len(source_pcm) // frame_stride
-    input_duration_us = int(sample_count * 1_000_000 / source_format.sample_rate)
     av_input_pcm = (
         _convert_s24_to_s32(source_pcm)
         if source_format.sample_type == "int"
@@ -440,6 +443,12 @@ def _resample_pcm_standalone(  # noqa: PLR0915
             sample_type=resampler_state.target_sample_type,
         )
 
+    # Drift-free input-cursor advance; mirrors `pending_ts_residue` on the output side.
+    resampler_state.pending_input_ts_residue += sample_count * 1_000_000
+    input_duration_us, resampler_state.pending_input_ts_residue = divmod(
+        resampler_state.pending_input_ts_residue,
+        source_format.sample_rate,
+    )
     resampler_state.pending_input_timestamp_us += input_duration_us
 
     # Fast path: no conversion needed — return input PCM with timestamp tracking

--- a/aiosendspin/server/roles/visualizer/features.py
+++ b/aiosendspin/server/roles/visualizer/features.py
@@ -114,7 +114,7 @@ class VisualizerFeatureExtractor:
         else:
             mono = raw.astype(np.float32)
 
-        return np.clip(mono / 32768.0, -1.0, 1.0)  # type: ignore[return-value]
+        return np.asarray(np.clip(mono / 32768.0, -1.0, 1.0))
 
     def _fft_magnitude(self, mono: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
         """Return FFT frequency bins and normalized magnitudes."""

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -424,6 +424,60 @@ def test_quantize_float_to_s16_preserves_dither_on_resampler_reset(
     assert captured_dither_methods[-1] == "triangular_hp"
 
 
+def test_resampler_drift_detection_uses_input_timeline() -> None:
+    """Drift detection must compare against an input-timeline reference.
+
+    Long-FIR resamplers (e.g. soxr precision=30) emit fewer samples than the
+    rate-conversion ratio until warmed up, so the output-side pending_timestamp_us
+    naturally lags input_timestamp_us by tens of ms even during steady-state
+    contiguous streaming. If drift detection compares that output-side cursor to
+    the input timestamp, every call exceeds the 20 ms threshold and rebuilds the
+    graph cold — which was the 5.1.0 regression that discarded ~35% of audio for
+    float@48k → flac@44.1k/16 (the MA Sendspin provider's default input path).
+    """
+    source = AudioFormat(sample_rate=48_000, bit_depth=32, channels=2, sample_type="float")
+    target = AudioFormat(sample_rate=44_100, bit_depth=32, channels=2, sample_type="float")
+    key = push_stream_module._ResamplerKey(  # noqa: SLF001
+        channel_id=MAIN_CHANNEL,
+        source_format=source,
+        target_sample_rate=44_100,
+        target_channels=2,
+        target_bit_depth=32,
+        target_sample_type="float",
+    )
+    state = push_stream_module._create_resampler_state(key, source, target)  # noqa: SLF001
+
+    chunk_samples = 4_800
+    chunk_bytes = bytes(chunk_samples * 2 * 4)  # stereo f32
+    input_duration_us = 100_000
+    first_input_ts = 250_000
+    input_ts = first_input_ts
+    num_chunks = 20
+
+    for _ in range(num_chunks):
+        push_stream_module._resample_pcm_standalone(  # noqa: SLF001
+            state, chunk_bytes, source, input_ts
+        )
+        input_ts += input_duration_us
+
+    # The input-side cursor must advance by exactly the cumulative input duration,
+    # independent of how many output samples the resampler has emitted so far.
+    expected_pending_input_us = first_input_ts + num_chunks * input_duration_us
+    assert state.pending_input_timestamp_us == expected_pending_input_us, (
+        "pending_input_timestamp_us must track the input timeline — drift detection "
+        "that uses pending_timestamp_us (which tracks output duration) mis-fires "
+        "on every call for long-FIR resamplers."
+    )
+
+    # The next contiguous call must not be flagged as drift.
+    drift_us = abs(state.pending_input_timestamp_us - input_ts)
+    assert drift_us == 0, (
+        f"Contiguous input stream should produce zero drift; got {drift_us}us. "
+        "This is the invariant that prevents the graph from being rebuilt on "
+        "every commit."
+    )
+
+
 @pytest.mark.asyncio
 async def test_stop_sends_stream_end_and_resets_buffer_tracker(mock_loop: Any) -> None:
     """Stop sends stream/end and resets BufferTracker state."""

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -2843,3 +2843,54 @@ def test_resampler_graph_path_44100_no_cumulative_drift() -> None:
         f"({total_output_samples} output samples) — regression of the per-call "
         f"truncation bug at push_stream.py:574"
     )
+
+
+def test_resampler_pending_input_ts_has_zero_cumulative_drift_at_44100_source() -> None:
+    """`pending_input_timestamp_us` must be drift-free for non-clean source rates.
+
+    Plain `int(samples * 1e6 / source_rate)` truncation accumulates per-call error
+    at rates that don't divide 1e6 evenly (e.g. 44.1k). Left unchecked, the
+    input-side cursor would eventually lag the true input timeline past the
+    20 ms drift threshold and cause a spurious graph rebuild. The divmod residue
+    accumulator must match `total_samples * 1e6 // source_sample_rate` exactly.
+    """
+    source = AudioFormat(sample_rate=44_100, bit_depth=16, channels=2, sample_type="int")
+    target = AudioFormat(sample_rate=44_100, bit_depth=16, channels=2, sample_type="int")
+    key = push_stream_module._ResamplerKey(  # noqa: SLF001
+        channel_id=MAIN_CHANNEL,
+        source_format=source,
+        target_sample_rate=44_100,
+        target_channels=2,
+        target_bit_depth=16,
+        target_sample_type="int",
+    )
+    state = push_stream_module._create_resampler_state(key, source, target)  # noqa: SLF001
+    assert state.pending_input_ts_residue == 0
+
+    # 25 ms @ 44.1k = 1102 samples → 24988.66µs actual, rounds to 24988µs.
+    # Plain `int(...)` would drop 0.66µs per call. Over 40_800 calls (17 min)
+    # the old code would accumulate ~27 ms of input-side lag — enough to cross
+    # the 20 ms rebuild threshold spuriously.
+    samples_per_call = 1102
+    input_pcm = bytes(samples_per_call * 4)
+    n_calls = 40_800
+    # The caller's `input_timestamp_us` advances along the true input timeline,
+    # which is itself drift-free (we use the same divmod pattern here).
+    external_residue = 0
+    external_ts = 0
+    for _ in range(n_calls):
+        push_stream_module._resample_pcm_standalone(  # noqa: SLF001
+            state, input_pcm, source, external_ts
+        )
+        external_residue += samples_per_call * 1_000_000
+        delta, external_residue = divmod(external_residue, 44_100)
+        external_ts += delta
+
+    expected = n_calls * samples_per_call * 1_000_000 // 44_100
+    actual = state.pending_input_timestamp_us
+    drift = (actual or 0) - expected
+    assert drift == 0, (
+        f"pending_input_timestamp_us drifted {drift}µs over {n_calls} calls — "
+        "regression of the input-side residue accumulator. This would eventually "
+        "cross the 20ms drift threshold and trigger a spurious graph rebuild."
+    )

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -2234,16 +2234,20 @@ async def test_catchup_quantizer_does_not_share_live_cache(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Catch-up path must use its own quantizer state, not the shared live cache."""
+    # Count real graph rebuilds by observing `state.graph` identity across the call,
+    # not by replaying the drift-condition check. The old output-cursor drift proxy
+    # would flag false positives under soxr (where FIR latency makes the output
+    # cursor lag the input by tens of ms even in steady state).
     drift_rebuild_count = 0
     original_resample = push_stream_module._resample_pcm_standalone  # noqa: SLF001
 
     def _tracking_resample(state: Any, pcm: bytes, fmt: Any, ts: int) -> Any:
         nonlocal drift_rebuild_count
-        if state.pending_timestamp_us is not None:
-            drift_us = abs(state.pending_timestamp_us - ts)
-            if drift_us > 20_000:
-                drift_rebuild_count += 1
-        return original_resample(state, pcm, fmt, ts)
+        graph_before = id(state.graph)
+        result = original_resample(state, pcm, fmt, ts)
+        if state.graph is not None and id(state.graph) != graph_before:
+            drift_rebuild_count += 1
+        return result
 
     monkeypatch.setattr(push_stream_module, "_resample_pcm_standalone", _tracking_resample)
 


### PR DESCRIPTION
Drift detection in `_resample_pcm_standalone` compared the output cursor to the incoming input timestamp. When the high quality soxr resampler was used, the output cursor lags the input by tens of ms even during steady state, so the 20 ms threshold fired on every call and rebuilt the graph cold, dropping up to 35% of audio on any player target that requires resampling.

Track a separate input timeline cursor with a `divmod` residue accumulator that stays numerically exact at source rates which don't divide 1e6 cleanly (e.g. 44.1k).