### PR TITLE
Run release-drafter only on main pushes

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
-    types:
-      - closed
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
Fork PRs get a read-only `GITHUB_TOKEN` regardless of the job's `permissions:` block, so release-drafter's release-create step 403s on every fork PR. The `push` trigger on `main` already covers post-merge draft updates, and the `closed` PR trigger never exercised the autolabeler anyway.