### PR TITLE
Fix clients with `player` and `artwork` roles clearing artwork on stop

### DIFF
--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -361,8 +361,7 @@ class PlayerV1Role(Role):
         if not self.has_connection():
             return
 
-        # End all streams (roles omitted) for best client compatibility.
-        stream_end = StreamEndMessage(payload=StreamEndPayload(roles=None))
+        stream_end = StreamEndMessage(payload=StreamEndPayload(roles=["player"]))
         self.send_message(stream_end)
         self._stream_started = False
         self._pending_stream_start = False

--- a/tests/server/roles/test_player_v1.py
+++ b/tests/server/roles/test_player_v1.py
@@ -557,8 +557,7 @@ def test_player_role_on_stream_end_sends_message() -> None:
     client.send_role_message.assert_called_once()
     _role, msg = client.send_role_message.call_args.args
     assert isinstance(msg, StreamEndMessage)
-    # stream/end omits roles (ends all streams)
-    assert msg.payload.roles is None
+    assert msg.payload.roles == ["player"]
 
 
 def test_player_role_on_stream_end_resets_stream_started() -> None:

--- a/tests/server/test_player_role_stream_messages.py
+++ b/tests/server/test_player_role_stream_messages.py
@@ -27,7 +27,7 @@ def test_player_role_on_stream_clear_uses_role_family() -> None:
 
 
 def test_player_role_on_stream_end_uses_role_family() -> None:
-    """PlayerV1Role.on_stream_end() omits roles (end all streams)."""
+    """PlayerV1Role.on_stream_end() targets the player role family."""
     client = MagicMock()
     client.send_role_message = MagicMock()
 
@@ -38,7 +38,7 @@ def test_player_role_on_stream_end_uses_role_family() -> None:
 
     _role, msg = client.send_role_message.call_args.args
     assert isinstance(msg, StreamEndMessage)
-    assert msg.payload.roles is None
+    assert msg.payload.roles == ["player"]
 
 
 def test_player_role_on_audio_chunk_packs_header_and_tracks_duration() -> None:


### PR DESCRIPTION
Clients that had the `player` and `artwork` roles, always got the artwork stream rest (for compatibility reasons).
Remove this workaround so the `player` role only sends messages related to its own role.