### PR TITLE
Install all dev dependencies with `./scripts/setup.sh`

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -13,7 +13,7 @@ if ! command -v uv >/dev/null 2>&1; then
 fi
 
 echo "Installing development dependencies..."
-uv sync --group dev
+uv sync --group dev --all-extras
 
 echo "Installing pre-commit hooks..."
 uv run pre-commit install


### PR DESCRIPTION
With #206 some dependencies required for development were moved into optional extras.
Install them by default when running `./scripts/setup.sh` so we have a fully working dev environment.