### PR TITLE
Add DeviceInfo.connections for hardware-identity advertising

### DIFF
--- a/aiosendspin/models/core.py
+++ b/aiosendspin/models/core.py
@@ -90,6 +90,26 @@ class DeviceInfo(DataClassORJSONMixin):
     """Device manufacturer name."""
     software_version: str | None = None
     """Software version of the client (not the Sendspin version)."""
+    connections: list[tuple[str, str]] | None = None
+    """Optional list of ``(connection_type, value)`` tuples advertising the
+    device's hardware identity to the Sendspin server.
+
+    Mirrors Home Assistant's open-ended ``device_registry`` connections
+    shape — any string ``connection_type`` is valid; common values include
+    ``"mac"``, ``"bluetooth"``, ``"zigbee"``, ``"upnp"``, ``"cast"``, but
+    bridges may declare arbitrary types for transports the protocol has not
+    seen before. Servers that integrate with Home Assistant should forward
+    this list verbatim into HA's ``DeviceInfo.connections`` so HA's
+    device-registry can dedupe device cards across integrations that know
+    the same hardware (e.g. a Bluetooth bridge and HA's native ``bluetooth``
+    integration both pointing at the same speaker).
+
+    Example values:
+
+    - ``[("bluetooth", "AA:BB:CC:DD:EE:FF")]`` — BT-A2DP bridge.
+    - ``[("mac", "AA:BB:CC:DD:EE:FF")]`` — Wi-Fi bridge.
+    - ``[("zigbee", "00:0d:6f:00:00:00:11:22")]`` — future Zigbee transport.
+    """
 
     class Config(BaseConfig):
         """Config for parsing json messages."""

--- a/tests/models/test_device_info_connections.py
+++ b/tests/models/test_device_info_connections.py
@@ -1,0 +1,148 @@
+"""Tests for ``DeviceInfo.connections`` round-trip across the Sendspin protocol wire format."""
+
+from __future__ import annotations
+
+import pytest
+
+from aiosendspin.models.core import (
+    ClientHelloPayload,
+    DeviceInfo,
+)
+from aiosendspin.models.player import (
+    ClientHelloPlayerSupport,
+    SupportedAudioFormat,
+)
+from aiosendspin.models.types import AudioCodec
+
+
+def _player_support() -> ClientHelloPlayerSupport:
+    """Build a minimal valid ``player@v1_support`` block for hello payloads."""
+    return ClientHelloPlayerSupport(
+        supported_formats=[
+            SupportedAudioFormat(
+                codec=AudioCodec.PCM, sample_rate=48000, bit_depth=16, channels=2
+            )
+        ],
+        buffer_capacity=100_000,
+        supported_commands=[],
+    )
+
+
+def test_device_info_connections_default_none() -> None:
+    """A bare ``DeviceInfo`` defaults ``connections`` to ``None`` so the
+    field is omitted from the on-wire JSON for clients that don't set it."""
+    info = DeviceInfo(product_name="Test", manufacturer="Acme")
+    assert info.connections is None
+
+
+def test_device_info_connections_omitted_from_json_when_none() -> None:
+    """``omit_none = True`` keeps the wire format unchanged for old clients."""
+    info = DeviceInfo(product_name="Test", manufacturer="Acme")
+    payload = info.to_dict()
+    assert "connections" not in payload
+
+
+def test_device_info_connections_round_trip_bluetooth_mac() -> None:
+    """A BT bridge can advertise the speaker's MAC and parse it back."""
+    info = DeviceInfo(
+        product_name="ENEBY20",
+        manufacturer="Sendspin BT Bridge",
+        connections=[("bluetooth", "AA:BB:CC:DD:EE:FF")],
+    )
+    restored = DeviceInfo.from_dict(info.to_dict())
+    assert restored.connections == [("bluetooth", "AA:BB:CC:DD:EE:FF")]
+
+
+def test_device_info_connections_round_trip_arbitrary_type() -> None:
+    """Connection types are pure strings — protocol does NOT filter to a known
+    taxonomy. Future transports (Zigbee EUI-64, Matter device-id, custom)
+    pass through verbatim."""
+    info = DeviceInfo(
+        product_name="Future Bridge",
+        connections=[
+            ("zigbee", "00:0d:6f:00:00:00:11:22"),
+            ("matter", "vendor-1234/product-5678"),
+            ("custom_proto", "any-string"),
+        ],
+    )
+    restored = DeviceInfo.from_dict(info.to_dict())
+    assert restored.connections == [
+        ("zigbee", "00:0d:6f:00:00:00:11:22"),
+        ("matter", "vendor-1234/product-5678"),
+        ("custom_proto", "any-string"),
+    ]
+
+
+def test_device_info_connections_multiple_per_device() -> None:
+    """A device with multiple hardware identities advertises all of them."""
+    info = DeviceInfo(
+        connections=[
+            ("mac", "AA:BB:CC:DD:EE:FF"),
+            ("bluetooth", "11:22:33:44:55:66"),
+        ],
+    )
+    restored = DeviceInfo.from_dict(info.to_dict())
+    assert restored.connections == [
+        ("mac", "AA:BB:CC:DD:EE:FF"),
+        ("bluetooth", "11:22:33:44:55:66"),
+    ]
+
+
+def test_device_info_connections_empty_list_round_trips() -> None:
+    """Explicit empty list survives — distinct from absent (None)."""
+    info = DeviceInfo(connections=[])
+    restored = DeviceInfo.from_dict(info.to_dict())
+    assert restored.connections == []
+
+
+def test_device_info_old_client_payload_parses() -> None:
+    """A payload from an older client without the ``connections`` key still
+    deserializes — backwards compat for protocol consumers."""
+    legacy_payload = {
+        "product_name": "Old client",
+        "manufacturer": "Vendor",
+        "software_version": "1.0.0",
+    }
+    info = DeviceInfo.from_dict(legacy_payload)
+    assert info.product_name == "Old client"
+    assert info.connections is None
+
+
+def test_client_hello_carries_device_info_connections() -> None:
+    """End-to-end: ``client/hello`` with ``device_info.connections`` round-trips."""
+    payload = ClientHelloPayload(
+        client_id="bridge-001",
+        name="Sendspin BT Bridge",
+        version=1,
+        supported_roles=["player@v1"],
+        device_info=DeviceInfo(
+            product_name="Sendspin BT Bridge v9.9.9",
+            manufacturer="HostName",
+            connections=[("bluetooth", "AA:BB:CC:DD:EE:FF")],
+        ),
+        player_support=_player_support(),
+    )
+    restored = ClientHelloPayload.from_dict(payload.to_dict())
+    assert restored.device_info is not None
+    assert restored.device_info.connections == [
+        ("bluetooth", "AA:BB:CC:DD:EE:FF")
+    ]
+
+
+@pytest.mark.parametrize(
+    "raw_value",
+    [
+        "AA:BB:CC:DD:EE:FF",
+        "aa-bb-cc-dd-ee-ff",
+        "AABBCCDDEEFF",
+        "00:0d:6f:00:00:00:11:22",  # 8-byte EUI-64 — wider than MAC
+    ],
+)
+def test_device_info_connections_value_passthrough(raw_value: str) -> None:
+    """Whatever raw value the bridge sends is preserved verbatim — protocol
+    layer does not normalize. Normalization is the receiving server's
+    responsibility (e.g. MA's ``DeviceInfo.add_connection`` helper does
+    canonical lowercase-with-colons for MAC-shaped values)."""
+    info = DeviceInfo(connections=[("bluetooth", raw_value)])
+    restored = DeviceInfo.from_dict(info.to_dict())
+    assert restored.connections == [("bluetooth", raw_value)]


### PR DESCRIPTION
# `DeviceInfo`: add optional `connections` field for hardware-identity advertising

## Summary

Adds an optional `connections: list[tuple[str, str]] | None` field to
`DeviceInfo` (in `client/hello`). Mirrors Home Assistant's open-ended
`device_registry.DeviceInfo.connections` shape so any Sendspin client
can advertise hardware identity (Bluetooth MAC, Wi-Fi MAC, Zigbee
EUI-64, Matter device-id, …) through the protocol; servers that
integrate with HA forward the list verbatim into HA's
`DeviceInfo.connections`, letting HA's device-registry dedupe device
cards across integrations that know the same hardware.

## Motivation

The protocol currently has no way for a client to advertise the
underlying hardware it bridges to. `DeviceInfo` carries human-readable
metadata only (`product_name`, `manufacturer`, `software_version`).
That gap is fine for the protocol itself, but it leaves server-side
providers without the information they need to populate cross-
integration identity in their host platform's device registry.

Concrete user-visible symptom on the Music Assistant + Home Assistant
stack: every Bluetooth speaker exposed via a BT bridge appears as
**two device cards** in HA — one from MA's `media_player` (no
`connections`) and one from the bridge's own integration that knows
the BT MAC. HA can't merge them because there's no shared connection
tuple between the two device-registry records.

This is **not** a single-bridge-specific issue — any future Sendspin
client that has hardware identity (an AirPlay-via-Sendspin bridge, a
Snapcast-via-Sendspin bridge, a Roon transport, custom hardware sending
Zigbee/Thread/Matter device-ids) hits the same dead end at the protocol
layer. Adding a single open-ended field on `DeviceInfo` solves it for
the whole class of clients.

## Design

The field shape mirrors HA's
`homeassistant.helpers.device_registry.DeviceInfo.connections` directly:

```python
connections: list[tuple[str, str]] | None = None
```

Each tuple is `(connection_type, value)`. Connection types are pure
strings — the protocol does **not** define a closed taxonomy. Standard
HA values include `"mac"`, `"bluetooth"`, `"zigbee"`, `"upnp"`, but
bridges may declare arbitrary types for transports the protocol has
not seen before. The receiving server is free to ignore unknown types
or pass them through.

Why open-ended over a closed enum: a closed enum forces a protocol
revision every time a new transport ships (Matter, Thread, Z-Wave, …).
HA already solved this by accepting any string in its registry. We
mirror that precedent.

`omit_none = True` (the existing `DeviceInfo` `Config`) keeps the
on-wire JSON unchanged for clients that don't set the field — full
backwards compatibility for the entire deployed fleet.

## Tests

`tests/models/test_device_info_connections.py` (12 cases):

- Default `None`, omitted from `to_dict` output (backwards-compat
  guarantee).
- Round-trip for `bluetooth` MAC.
- Round-trip for arbitrary unknown connection types — verifies
  protocol-level type-agnosticism (`zigbee` EUI-64, `matter` device-id,
  `custom_proto`).
- Multiple connections per device.
- Empty list distinct from absent (`None`).
- Legacy payload (no `connections` key) parses cleanly.
- End-to-end via `ClientHelloPayload` round-trip.
- Parametrized passthrough across MAC formats and EUI-64 widths to
  confirm the protocol layer does **not** normalize values —
  normalization is the receiving server's responsibility.

All 12 pass; full pre-existing suite (554 cases) continues to pass
serially. (xdist parallel runs surface unrelated test-pollution
flakes that also reproduce on `main` — not introduced by this change.)

## Backwards compatibility

- New optional field defaults to `None` → `omit_none = True` keeps
  it absent from the on-wire JSON for clients that don't set it.
- Servers parsing `client/hello` from older clients (no `connections`
  key) deserialize cleanly — the test
  `test_device_info_old_client_payload_parses` codifies this contract.
- No other field, method, or message type touched.

## Coordination

Companion PRs landing this end-to-end across the ecosystem:

- [`music-assistant/models#215`](https://github.com/music-assistant/models/pull/215)
  — adds `connections: set[tuple[str, str]]` to
  `music_assistant_models.player.DeviceInfo` (mirrors HA's shape on
  the model side, plus an `add_connection()` helper with MAC
  normalization).
- [`music-assistant/server#3813`](https://github.com/music-assistant/server/pull/3813)
  — Sendspin provider reads `client_hello.device_info.connections` and
  forwards into the player's new `DeviceInfo.connections`, plus an
  opportunistic mirror into `IdentifierType.MAC_ADDRESS` for
  `mac`/`bluetooth` tuples.
- [`home-assistant/core#169541`](https://github.com/home-assistant/core/pull/169541)
  — MA integration forwards player `device_info.connections` verbatim
  into HA's `DeviceInfo`.

**Umbrella discussion** with full design context and status:
https://github.com/orgs/music-assistant/discussions/5415

PR-D (MA server) and the bridge consumer depend on this PR landing &
an `aiosendspin` PyPI release. PR-A (HA core) and the MA models PR
are independent of this PR.

## Spec PR follow-up

The protocol spec lives in [`Sendspin/spec`](https://github.com/Sendspin/spec)
(the `Sendspin-Protocol/spec` URL in the README redirects there). Per
the existing `before-spec-pr-50` deprecation comments in
`models/player.py` and `models/types.py`, the convention appears to
be spec-first then code. This PR is **code-only**; happy to file a
companion spec PR documenting the new field if maintainers prefer the
spec-first flow — let me know in review and I'll spin one up.

## Test plan locally

```sh
./scripts/setup.sh
uv run pre-commit run --all-files
uv run pytest -q -o addopts= -n0    # serial run; xdist surfaces unrelated flakes
uv run pytest tests/models/test_device_info_connections.py -v
```

Output captured in `.local-ci-output.txt` next to this description.
