### PR TITLE
Compensate for the Opus codec lookahead delay

### DIFF
--- a/aiosendspin/server/roles/player/audio_transformers.py
+++ b/aiosendspin/server/roles/player/audio_transformers.py
@@ -582,3 +582,4 @@ class OpusEncoder:
         self._first_input_timestamp_us = None
         self._chunks_encoded_total = 0
         self._last_input_timestamp_us = None
+        self._lookahead_us = 0

--- a/aiosendspin/server/roles/player/audio_transformers.py
+++ b/aiosendspin/server/roles/player/audio_transformers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+import struct
 from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
@@ -9,6 +11,8 @@ from aiosendspin.server.audio import AudioFormat, _get_av, _validate_pcm_buffer_
 
 if TYPE_CHECKING:
     import av
+
+logger = logging.getLogger(__name__)
 
 
 class PcmPassthrough:
@@ -404,6 +408,8 @@ class OpusEncoder:
         self._chunks_encoded_total: int = 0
         # Track last input timestamp to detect production gaps
         self._last_input_timestamp_us: int | None = None
+        # libopus codec lookahead, populated from the OpusHead pre_skip after open()
+        self._lookahead_us: int = 0
 
     @property
     def frame_duration_us(self) -> int:
@@ -440,6 +446,23 @@ class OpusEncoder:
         if self._encoder.frame_size:
             self._chunk_samples = self._encoder.frame_size
             self._chunk_duration_us = int(self._chunk_samples / self._sample_rate * 1_000_000)
+
+        # Extract libopus's encoder lookahead from the OpusHead pre_skip field
+        # so the stream anchor can be shifted earlier to keep decoded audio aligned
+        # with input PCM. RFC 7845 §5.1 places pre_skip (LE u16, samples @ 48 kHz)
+        # at bytes 10-11 of the OpusHead, which FFmpeg's libopusenc populates from
+        # OPUS_GET_LOOKAHEAD. PyAV does not surface this via ctx.delay or
+        # ctx.initial_padding, but exposes the raw OpusHead via ctx.extradata.
+        extradata = self._encoder.extradata
+        if extradata and len(extradata) >= 12 and extradata[:8] == b"OpusHead":
+            pre_skip_samples = struct.unpack_from("<H", extradata, 10)[0]
+            self._lookahead_us = pre_skip_samples * 1_000_000 // 48_000
+        else:
+            logger.debug(
+                "Opus extradata missing or unrecognized; skipping lookahead "
+                "compensation (extradata=%r)",
+                extradata,
+            )
 
         self._initialized = True
 
@@ -511,8 +534,10 @@ class OpusEncoder:
                     # Exact rational arithmetic for encoder-delay compensation;
                     # see FlacEncoder for full rationale.
                     delay_samples = encoder_delay_chunks * self._chunk_samples
-                    self._stream_start_timestamp_us = self._first_input_timestamp_us + (
-                        delay_samples * 1_000_000 // self._sample_rate
+                    self._stream_start_timestamp_us = (
+                        self._first_input_timestamp_us
+                        + (delay_samples * 1_000_000 // self._sample_rate)
+                        - self._lookahead_us
                     )
                 frames.append(encoded)
                 self._output_frame_count += 1

--- a/tests/server/test_audio_transformers.py
+++ b/tests/server/test_audio_transformers.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import struct
+
 from aiosendspin.server.audio_transformers import (
     AudioTransformer,
     TransformerPool,
 )
 from aiosendspin.server.channels import MAIN_CHANNEL
-from aiosendspin.server.roles.player.audio_transformers import FlacEncoder, PcmPassthrough
+from aiosendspin.server.roles.player.audio_transformers import (
+    FlacEncoder,
+    OpusEncoder,
+    PcmPassthrough,
+)
 
 
 class TestAudioTransformerProtocol:
@@ -651,3 +657,73 @@ class TestFlacEncoder:
                 f"Frame {i}: gap={gap}us, expected {frame_dur}us. "
                 f"Timestamps around gap: {timestamps[max(0, i - 2) : i + 2]}"
             )
+
+
+class TestOpusEncoderLookaheadCompensation:
+    """Tests for OpusEncoder codec-lookahead timestamp compensation."""
+
+    def test_lookahead_matches_pre_skip_from_extradata(self) -> None:
+        """_lookahead_us is parsed from the OpusHead pre_skip field."""
+        encoder = OpusEncoder(sample_rate=48000, bit_depth=16, channels=2)
+        encoder._ensure_initialized()  # noqa: SLF001
+
+        extradata = encoder._encoder.extradata  # noqa: SLF001
+        assert extradata is not None
+        assert extradata[:8] == b"OpusHead"
+        pre_skip_samples = struct.unpack_from("<H", extradata, 10)[0]
+        assert pre_skip_samples > 0, "libopus should report a non-zero lookahead"
+        assert encoder._lookahead_us == pre_skip_samples * 1_000_000 // 48_000  # noqa: SLF001
+
+    def test_stream_anchor_shifted_earlier_by_lookahead(self) -> None:
+        """First emitted packet's anchor timestamp is pulled earlier by _lookahead_us."""
+        encoder = OpusEncoder(sample_rate=48000, bit_depth=16, channels=2)
+        encoder._ensure_initialized()  # noqa: SLF001
+        lookahead_us = encoder._lookahead_us  # noqa: SLF001
+        assert lookahead_us > 0
+
+        # Use a first input timestamp comfortably above the lookahead so the anchor
+        # remains positive regardless of libopus version.
+        first_input_ts = 1_000_000_000
+        chunk_size = encoder._chunk_samples * encoder._frame_stride  # noqa: SLF001
+        frames = encoder.process(bytes(chunk_size), first_input_ts, encoder.frame_duration_us)
+
+        # Anchor is only set once a packet is emitted; assert the precondition
+        # explicitly so a future change in libopus first-packet latency surfaces here.
+        assert frames, "Expected libopus to emit a packet on the first chunk"
+
+        # First packet has encoder_delay_chunks == 0, so the anchor reduces to
+        # first_input_ts - lookahead_us.
+        assert encoder._stream_start_timestamp_us == first_input_ts - lookahead_us  # noqa: SLF001
+        assert encoder.pending_timestamp_us == (
+            first_input_ts - lookahead_us + encoder.frame_duration_us
+        )
+
+    def test_lookahead_reapplied_after_production_gap(self) -> None:
+        """Lookahead shift is re-applied to the new anchor after a production-gap reset."""
+        encoder = OpusEncoder(sample_rate=48000, bit_depth=16, channels=2)
+        encoder._ensure_initialized()  # noqa: SLF001
+        lookahead_us = encoder._lookahead_us  # noqa: SLF001
+
+        chunk_size = encoder._chunk_samples * encoder._frame_stride  # noqa: SLF001
+        frame_dur = encoder.frame_duration_us
+
+        # First burst establishes the initial anchor.
+        first_ts = 1_000_000_000
+        frames = encoder.process(bytes(chunk_size), first_ts, frame_dur)
+        assert frames
+        assert encoder._stream_start_timestamp_us == first_ts - lookahead_us  # noqa: SLF001
+
+        # Second burst more than 1.5 s later triggers the production-gap reset path.
+        second_ts = first_ts + 2_000_000
+        frames = encoder.process(bytes(chunk_size), second_ts, frame_dur)
+        assert frames
+        assert encoder._stream_start_timestamp_us == second_ts - lookahead_us  # noqa: SLF001
+
+    def test_reset_clears_lookahead(self) -> None:
+        """reset() clears _lookahead_us so a re-init cannot reuse a stale value."""
+        encoder = OpusEncoder(sample_rate=48000, bit_depth=16, channels=2)
+        encoder._ensure_initialized()  # noqa: SLF001
+        assert encoder._lookahead_us > 0  # noqa: SLF001
+
+        encoder.reset()
+        assert encoder._lookahead_us == 0  # noqa: SLF001


### PR DESCRIPTION
The Opus codec has a built-in lookahead delay/overall latency. It depends on the exact encoding mode, but for the default one we use it is 312 samples (at 48 kHz), so 6.5 ms. This causes clients playing Opus audio to be out of sync by 6.5 ms no matter what (making this a bugfix)!

This PR extracts the lookahead value by parsing the raw OpusHead (in case the Opus codec ever changes in the future or a different encoding mode is used). It then adjusts the stream start timestamp by that amount to compensate for the added latency.

Technically, clients are supposed to discard the first 312 samples (or whatever the amount is depending on the specific encoder settings), but in practice I don't think this is necessarily worth the effort. These samples aren't "real", but they are used to help build up the proper overlap-add for the real audio. Since the overlap-add is combined with zeros, these samples will already be very quiet. If we ever do want to do this properly, then we could send the OpusHead packet as the codec header in `stream/start`. Then the client would be able to parse it and understand how many samples to discard. If we do decide to do that, I still think the server should do this compensation so that clients that ignore the OpusHead data will still play in sync.