### PR TITLE
Fix `PushStream` timing drift and late-joiner race conditions

### DIFF
--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -655,6 +655,9 @@ class PushStream:
         # Unconsumed numerator per channel for drift-free _channel_timing advancement.
         # Reset to 0 whenever _channel_timing[channel_id] is rebased to a new absolute value.
         self._channel_timing_residue: dict[UUID, int] = {}
+        # Sample rate of the last _advance_channel_timing call per channel. Residue is
+        # modulo this rate, so changes invalidate it and force a residue reset.
+        self._channel_timing_rate: dict[UUID, int] = {}
         # Channels that have committed real audio (live or historical), not just synthetic timing.
         self._channels_with_committed_audio: set[UUID] = set()
         # Role-based streaming tracking (for hook-based flow)
@@ -1113,7 +1116,7 @@ class PushStream:
             channel_play_start[channel_id] = self._channel_timing[channel_id]
         return channel_play_start
 
-    async def _process_historical_buffers(
+    async def _process_historical_buffers(  # noqa: PLR0915
         self,
         historical: dict[UUID, list[tuple[bytes, AudioFormat]]],
         historical_start_us: dict[UUID, int] | None = None,
@@ -1141,10 +1144,14 @@ class PushStream:
             # Avoid drifting by keeping track of the fraction, must match _advance_channel_timing
             chunk_durations: list[int] = []
             residue = 0
+            last_rate: int | None = None
             for pcm_bytes, fmt in chunks:
                 bytes_per_sample = fmt.bit_depth // 8
                 frame_stride = bytes_per_sample * fmt.channels
                 sample_count = len(pcm_bytes) // frame_stride
+                if last_rate != fmt.sample_rate:
+                    residue = 0
+                    last_rate = fmt.sample_rate
                 numerator = residue + sample_count * 1_000_000
                 chunk_duration_us, residue = divmod(numerator, fmt.sample_rate)
                 chunk_durations.append(chunk_duration_us)
@@ -1234,6 +1241,10 @@ class PushStream:
     def _advance_channel_timing(self, channel_id: UUID, sample_count: int, sample_rate: int) -> int:
         """Advance _channel_timing drift-free via residue accumulator. Return µs added."""
         assert channel_id in self._channel_timing, f"channel {channel_id} not initialised"
+        if self._channel_timing_rate.get(channel_id) != sample_rate:
+            # Residue is modulo the previous rate; reset on rate change to keep units consistent.
+            self._channel_timing_residue[channel_id] = 0
+            self._channel_timing_rate[channel_id] = sample_rate
         numerator = self._channel_timing_residue.get(channel_id, 0) + sample_count * 1_000_000
         delta_us, self._channel_timing_residue[channel_id] = divmod(numerator, sample_rate)
         self._channel_timing[channel_id] += delta_us
@@ -1643,6 +1654,7 @@ class PushStream:
                 continue
             del self._channel_timing[ch]
             self._channel_timing_residue.pop(ch, None)
+            self._channel_timing_rate.pop(ch, None)
             self._channels_with_committed_audio.discard(ch)
 
     def _ensure_role_started(self, role: Role) -> None:
@@ -2215,6 +2227,7 @@ class PushStream:
         # Reset per-channel timing
         self._channel_timing.clear()
         self._channel_timing_residue.clear()
+        self._channel_timing_rate.clear()
         self._channels_with_committed_audio.clear()
 
         # Clear chunk cache

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -1041,8 +1041,9 @@ class PushStream:
             return min(channel_play_start.values())
         finally:
             self._commit_in_flight -= 1
-            # Resend cached audio only on success to avoid replaying from cache missing chunks
-            if commit_completed and self._pending_join_roles:
+            # Resend cached audio only on success to avoid replaying from cache missing chunks.
+            # In case there are multiple parallel commits, only flush once the last one finishes.
+            if commit_completed and self._commit_in_flight == 0 and self._pending_join_roles:
                 pending = list(self._pending_join_roles)
                 self._pending_join_roles.clear()
                 for role in pending:

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -1139,19 +1139,16 @@ class PushStream:
             if not self._is_generation_active(commit_generation):
                 return
             # Avoid drifting by keeping track of the fraction, must match _advance_channel_timing
-            total_duration_us = 0
-            duration_residue_by_rate: dict[int, int] = {}
+            chunk_durations: list[int] = []
+            residue = 0
             for pcm_bytes, fmt in chunks:
                 bytes_per_sample = fmt.bit_depth // 8
                 frame_stride = bytes_per_sample * fmt.channels
                 sample_count = len(pcm_bytes) // frame_stride
-                numerator = (
-                    duration_residue_by_rate.get(fmt.sample_rate, 0) + sample_count * 1_000_000
-                )
-                chunk_duration_us, duration_residue_by_rate[fmt.sample_rate] = divmod(
-                    numerator, fmt.sample_rate
-                )
-                total_duration_us += chunk_duration_us
+                numerator = residue + sample_count * 1_000_000
+                chunk_duration_us, residue = divmod(numerator, fmt.sample_rate)
+                chunk_durations.append(chunk_duration_us)
+            total_duration_us = sum(chunk_durations)
 
             if historical_start_us is not None and channel_id in historical_start_us:
                 self._channel_timing[channel_id] = historical_start_us[channel_id]

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -652,6 +652,9 @@ class PushStream:
         self._channel_buffers: dict[UUID, tuple[bytes, AudioFormat]] = {}
         # Per-channel timing: channel_id -> next_chunk_start_us
         self._channel_timing: dict[UUID, int] = {}
+        # Unconsumed numerator per channel for drift-free _channel_timing advancement.
+        # Reset to 0 whenever _channel_timing[channel_id] is rebased to a new absolute value.
+        self._channel_timing_residue: dict[UUID, int] = {}
         # Channels that have committed real audio (live or historical), not just synthetic timing.
         self._channels_with_committed_audio: set[UUID] = set()
         # Role-based streaming tracking (for hook-based flow)
@@ -933,6 +936,7 @@ class PushStream:
                 self._channel_timing[MAIN_CHANNEL] = (
                     now_us + DEFAULT_INITIAL_DELAY_US + self._max_active_static_delay_us()
                 )
+                self._channel_timing_residue[MAIN_CHANNEL] = 0
             return min(self._channel_timing.values())
 
         # Process historical buffers first: assign timestamps and inject into caches.
@@ -966,9 +970,14 @@ class PushStream:
             play_start_us=play_start_us,
         )
 
-        # Advance each channel's timing by its duration
-        for channel_id, duration_us in durations_us.items():
-            self._channel_timing[channel_id] += duration_us
+        # Advance channel timing by overwriting durations_us with drift-free values.
+        for channel_id, (pcm, fmt) in prepared.items():
+            bytes_per_sample = fmt.bit_depth // 8
+            frame_stride = bytes_per_sample * fmt.channels
+            sample_count = len(pcm) // frame_stride
+            durations_us[channel_id] = self._advance_channel_timing(
+                channel_id, sample_count, fmt.sample_rate
+            )
             self._channels_with_committed_audio.add(channel_id)
 
         # Keep non-prepared active channels on the shared timeline.
@@ -985,6 +994,7 @@ class PushStream:
                     continue
                 if channel_id not in self._channel_timing:
                     self._channel_timing[channel_id] = base_start_us
+                    self._channel_timing_residue[channel_id] = 0
                 self._channel_timing[channel_id] += reference_duration_us
 
         # Cache PCM chunks before encoding (if enabled)
@@ -1037,6 +1047,7 @@ class PushStream:
                 channel_play_start[channel_id] = play_start_us
                 if channel_id not in self._channel_timing:
                     self._channel_timing[channel_id] = play_start_us
+                    self._channel_timing_residue[channel_id] = 0
             return channel_play_start
 
         # Auto-calculate mode (existing behavior).
@@ -1058,8 +1069,10 @@ class PushStream:
                     # instead of restarting from now+delay behind active channels.
                     shared_timing_us = min(shared_candidates)
                     self._channel_timing[channel_id] = max(shared_timing_us, target_min_us)
+                    self._channel_timing_residue[channel_id] = 0
                 else:
                     self._channel_timing[channel_id] = target_min_us
+                    self._channel_timing_residue[channel_id] = 0
 
         # If audio production stalls (e.g., the upstream source blocks), the scheduled
         # play timeline can drift into the past. Rebase the timeline so new audio is
@@ -1108,15 +1121,24 @@ class PushStream:
         for channel_id, chunks in historical.items():
             if not self._is_generation_active(commit_generation):
                 return
+            # Avoid drifting by keeping track of the fraction, must match _advance_channel_timing
             total_duration_us = 0
+            duration_residue_by_rate: dict[int, int] = {}
             for pcm_bytes, fmt in chunks:
                 bytes_per_sample = fmt.bit_depth // 8
                 frame_stride = bytes_per_sample * fmt.channels
                 sample_count = len(pcm_bytes) // frame_stride
-                total_duration_us += int(sample_count * 1_000_000 / fmt.sample_rate)
+                numerator = (
+                    duration_residue_by_rate.get(fmt.sample_rate, 0) + sample_count * 1_000_000
+                )
+                chunk_duration_us, duration_residue_by_rate[fmt.sample_rate] = divmod(
+                    numerator, fmt.sample_rate
+                )
+                total_duration_us += chunk_duration_us
 
             if historical_start_us is not None and channel_id in historical_start_us:
                 self._channel_timing[channel_id] = historical_start_us[channel_id]
+                self._channel_timing_residue[channel_id] = 0
             elif channel_id in self._channel_timing:
                 if channel_id not in self._channels_with_committed_audio:
                     # Synthetic timing (from alignment of missing channels) should not block
@@ -1125,6 +1147,7 @@ class PushStream:
                     self._channel_timing[channel_id] = max(
                         0, self._channel_timing[channel_id] - total_duration_us
                     )
+                    self._channel_timing_residue[channel_id] = 0
             elif self._channel_timing:
                 # Align injected history so it ends at the current shared timeline.
                 # This avoids leaving newly injected channels permanently behind live.
@@ -1141,19 +1164,22 @@ class PushStream:
                     anchor_candidates = list(self._channel_timing.values())
                 anchor_timing_us = min(anchor_candidates)
                 self._channel_timing[channel_id] = max(0, anchor_timing_us - total_duration_us)
+                self._channel_timing_residue[channel_id] = 0
             else:
                 self._channel_timing[channel_id] = (
                     now_us + DEFAULT_INITIAL_DELAY_US + self._max_active_static_delay_us()
                 )
+                self._channel_timing_residue[channel_id] = 0
 
             for pcm_bytes, fmt in chunks:
                 chunk_start_us = self._channel_timing[channel_id]
 
-                # Calculate duration
                 bytes_per_sample = fmt.bit_depth // 8
                 frame_stride = bytes_per_sample * fmt.channels
                 sample_count = len(pcm_bytes) // frame_stride
-                duration_us = int(sample_count * 1_000_000 / fmt.sample_rate)
+                duration_us = self._advance_channel_timing(
+                    channel_id, sample_count, fmt.sample_rate
+                )
 
                 # Cache PCM (if enabled)
                 channel_int = channel_id.int
@@ -1168,9 +1194,6 @@ class PushStream:
                         sample_type=fmt.sample_type,
                     )
                     self._pcm_chunk_cache.setdefault(channel_int, deque()).append(pcm_chunk)
-
-                # Advance timing even if we skip delivery for stale chunks.
-                self._channel_timing[channel_id] += duration_us
 
                 # For late-join injection, historical chunks may already be too old by the
                 # time they're processed. Keep timeline/cache continuity, but don't deliver
@@ -1193,6 +1216,14 @@ class PushStream:
                 # Yield so historical injection doesn't starve the event loop.
                 await asyncio.sleep(0)
             self._channels_with_committed_audio.add(channel_id)
+
+    def _advance_channel_timing(self, channel_id: UUID, sample_count: int, sample_rate: int) -> int:
+        """Advance _channel_timing drift-free via residue accumulator. Return µs added."""
+        assert channel_id in self._channel_timing, f"channel {channel_id} not initialised"
+        numerator = self._channel_timing_residue.get(channel_id, 0) + sample_count * 1_000_000
+        delta_us, self._channel_timing_residue[channel_id] = divmod(numerator, sample_rate)
+        self._channel_timing[channel_id] += delta_us
+        return delta_us
 
     def _calculate_channel_durations(
         self,
@@ -1597,6 +1628,7 @@ class PushStream:
                 # sleep_to_limit_buffer from throttling the commit loop.
                 continue
             del self._channel_timing[ch]
+            self._channel_timing_residue.pop(ch, None)
             self._channels_with_committed_audio.discard(ch)
 
     def _ensure_role_started(self, role: Role) -> None:
@@ -1847,6 +1879,7 @@ class PushStream:
         self._channel_timing[channel_id] = max(
             self._channel_timing[channel_id], reference_timing_us
         )
+        self._channel_timing_residue[channel_id] = 0
 
     def _rebase_far_ahead_join_tail(self, channel_id: UUID, joining_role: Role) -> None:
         """Clamp far-ahead solo-channel timing so a rejoin can resume promptly."""
@@ -1863,6 +1896,7 @@ class PushStream:
         self._channel_timing[channel_id] = min(
             self._channel_timing[channel_id], max_resume_start_us
         )
+        self._channel_timing_residue[channel_id] = 0
 
     def _encode_pcm_sequence(
         self,
@@ -2162,6 +2196,7 @@ class PushStream:
 
         # Reset per-channel timing
         self._channel_timing.clear()
+        self._channel_timing_residue.clear()
         self._channels_with_committed_audio.clear()
 
         # Clear chunk cache

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -946,6 +946,7 @@ class PushStream:
                         now_us + DEFAULT_INITIAL_DELAY_US + self._max_active_static_delay_us()
                     )
                     self._channel_timing_residue[MAIN_CHANNEL] = 0
+                commit_completed = True
                 return min(self._channel_timing.values())
 
             # Process historical buffers first: assign timestamps and inject into caches.

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -677,6 +677,9 @@ class PushStream:
         self._transform_last_input_end_us: dict[TransformKey, int] = {}
         # Roles awaiting delayed join; excluded from live delivery until join executes.
         self._pending_join_roles: weakref.WeakSet[Role] = weakref.WeakSet()
+        # >0 while commit_audio() is between the _channel_timing advance and _role_chunk_cache
+        # update, joiners should be delayed during that
+        self._commit_in_flight: int = 0
         # Historical audio buffers: channel_id -> list of (pcm_bytes, audio_format)
         self._historical_buffers: dict[UUID, list[tuple[bytes, AudioFormat]]] = {}
         # Optional start timestamps for historical channels (set on first historical chunk).
@@ -894,7 +897,7 @@ class PushStream:
                 return max(channel_tail_us, target_us)
         return target_us
 
-    async def commit_audio(self, *, play_start_us: int | None = None) -> int:
+    async def commit_audio(self, *, play_start_us: int | None = None) -> int:  # noqa: PLR0915
         """
         Encode and send all prepared audio to players.
 
@@ -923,114 +926,127 @@ class PushStream:
             raise StreamStoppedError("Cannot commit audio on a stopped stream")
         commit_generation = self._stream_generation
 
-        # Drain historical buffers
-        historical = dict(self._historical_buffers)
-        self._historical_buffers.clear()
-        historical_start_us = dict(self._historical_start_us)
-        self._historical_start_us.clear()
+        self._commit_in_flight += 1
+        commit_completed = False
+        try:
+            # Drain historical buffers
+            historical = dict(self._historical_buffers)
+            self._historical_buffers.clear()
+            historical_start_us = dict(self._historical_start_us)
+            self._historical_start_us.clear()
 
-        # If no pending audio (live or historical), return earliest channel timing
-        if not self._channel_buffers and not historical:
-            now_us = self._clock.now_us()
-            if not self._channel_timing:
-                self._channel_timing[MAIN_CHANNEL] = (
-                    now_us + DEFAULT_INITIAL_DELAY_US + self._max_active_static_delay_us()
+            # If no pending audio (live or historical), return earliest channel timing
+            if not self._channel_buffers and not historical:
+                now_us = self._clock.now_us()
+                if not self._channel_timing:
+                    self._channel_timing[MAIN_CHANNEL] = (
+                        now_us + DEFAULT_INITIAL_DELAY_US + self._max_active_static_delay_us()
+                    )
+                    self._channel_timing_residue[MAIN_CHANNEL] = 0
+                return min(self._channel_timing.values())
+
+            # Process historical buffers first: assign timestamps and inject into caches.
+            # This initializes _channel_timing for historical channels so the live chunk
+            # (if any) continues seamlessly after.
+            if historical:
+                await self._process_historical_buffers(
+                    historical,
+                    historical_start_us,
+                    commit_generation=commit_generation,
                 )
-                self._channel_timing_residue[MAIN_CHANNEL] = 0
-            return min(self._channel_timing.values())
+                if not self._is_generation_active(commit_generation):
+                    return self._stopped_commit_return_value()
 
-        # Process historical buffers first: assign timestamps and inject into caches.
-        # This initializes _channel_timing for historical channels so the live chunk
-        # (if any) continues seamlessly after.
-        if historical:
-            await self._process_historical_buffers(
-                historical,
-                historical_start_us,
+            # Drain live channel buffers
+            prepared = dict(self._channel_buffers)
+            self._channel_buffers.clear()
+
+            if not prepared:
+                # Historical-only commit: cache updated by _process_historical_buffers().
+                self._prune_role_chunk_cache()
+                commit_completed = True
+                return min(self._channel_timing.values())
+
+            # Calculate duration for each channel and warn on misalignment
+            durations_us = self._calculate_channel_durations(prepared)
+            self._warn_duration_misalignment(durations_us)
+
+            # Capture play_start_us for each channel
+            channel_play_start = self._resolve_channel_play_start(
+                prepared,
+                play_start_us=play_start_us,
+            )
+
+            # Advance channel timing by overwriting durations_us with drift-free values.
+            for channel_id, (pcm, fmt) in prepared.items():
+                bytes_per_sample = fmt.bit_depth // 8
+                frame_stride = bytes_per_sample * fmt.channels
+                sample_count = len(pcm) // frame_stride
+                durations_us[channel_id] = self._advance_channel_timing(
+                    channel_id, sample_count, fmt.sample_rate
+                )
+                self._channels_with_committed_audio.add(channel_id)
+
+            # Keep non-prepared active channels on the shared timeline.
+            #
+            # This avoids channel drift when an upstream channel (e.g., per-device DSP)
+            # times out and we commit only a subset of channels for one or more cycles.
+            # Those channels skip audio for this commit but should remain clock-aligned
+            # when they resume.
+            reference_duration_us = max(durations_us.values(), default=0)
+            if reference_duration_us > 0:
+                base_start_us = min(channel_play_start.values())
+                for channel_id in self._get_active_audio_channels():
+                    if channel_id in prepared:
+                        continue
+                    if channel_id not in self._channel_timing:
+                        self._channel_timing[channel_id] = base_start_us
+                        self._channel_timing_residue[channel_id] = 0
+                    self._channel_timing[channel_id] += reference_duration_us
+
+            # Cache PCM chunks before encoding (if enabled)
+            for channel_id, (pcm_bytes, fmt) in prepared.items():
+                channel_int = channel_id.int
+                if channel_int not in self._pcm_cache_enabled_channels:
+                    continue
+                pcm_chunk = CachedPCMChunk(
+                    timestamp_us=channel_play_start[channel_id],
+                    duration_us=durations_us[channel_id],
+                    pcm_data=pcm_bytes,
+                    sample_rate=fmt.sample_rate,
+                    bit_depth=fmt.bit_depth,
+                    channels=fmt.channels,
+                    sample_type=fmt.sample_type,
+                )
+                self._pcm_chunk_cache.setdefault(channel_int, deque()).append(pcm_chunk)
+
+            # Role-based audio delivery via hooks
+            role_cache_results = await self._deliver_audio_to_roles(
+                prepared,
+                channel_play_start,
                 commit_generation=commit_generation,
             )
             if not self._is_generation_active(commit_generation):
                 return self._stopped_commit_return_value()
+            # Merge role-based cache results into the cache
+            for cache_key, chunks in role_cache_results.items():
+                self._role_chunk_cache[cache_key].extend(chunks)
 
-        # Drain live channel buffers
-        prepared = dict(self._channel_buffers)
-        self._channel_buffers.clear()
-
-        if not prepared:
-            # Historical-only commit: cache is updated by _process_historical_buffers().
+            # Prune old chunks from cache
             self._prune_role_chunk_cache()
-            return min(self._channel_timing.values())
+            self._prune_stale_channel_timing()
 
-        # Calculate duration for each channel and warn on misalignment
-        durations_us = self._calculate_channel_durations(prepared)
-        self._warn_duration_misalignment(durations_us)
-
-        # Capture play_start_us for each channel
-        channel_play_start = self._resolve_channel_play_start(
-            prepared,
-            play_start_us=play_start_us,
-        )
-
-        # Advance channel timing by overwriting durations_us with drift-free values.
-        for channel_id, (pcm, fmt) in prepared.items():
-            bytes_per_sample = fmt.bit_depth // 8
-            frame_stride = bytes_per_sample * fmt.channels
-            sample_count = len(pcm) // frame_stride
-            durations_us[channel_id] = self._advance_channel_timing(
-                channel_id, sample_count, fmt.sample_rate
-            )
-            self._channels_with_committed_audio.add(channel_id)
-
-        # Keep non-prepared active channels on the shared timeline.
-        #
-        # This avoids channel drift when an upstream channel (e.g., per-device DSP)
-        # times out and we commit only a subset of channels for one or more cycles.
-        # Those channels skip audio for this commit but should remain clock-aligned
-        # when they resume.
-        reference_duration_us = max(durations_us.values(), default=0)
-        if reference_duration_us > 0:
-            base_start_us = min(channel_play_start.values())
-            for channel_id in self._get_active_audio_channels():
-                if channel_id in prepared:
-                    continue
-                if channel_id not in self._channel_timing:
-                    self._channel_timing[channel_id] = base_start_us
-                    self._channel_timing_residue[channel_id] = 0
-                self._channel_timing[channel_id] += reference_duration_us
-
-        # Cache PCM chunks before encoding (if enabled)
-        for channel_id, (pcm_bytes, fmt) in prepared.items():
-            channel_int = channel_id.int
-            if channel_int not in self._pcm_cache_enabled_channels:
-                continue
-            pcm_chunk = CachedPCMChunk(
-                timestamp_us=channel_play_start[channel_id],
-                duration_us=durations_us[channel_id],
-                pcm_data=pcm_bytes,
-                sample_rate=fmt.sample_rate,
-                bit_depth=fmt.bit_depth,
-                channels=fmt.channels,
-                sample_type=fmt.sample_type,
-            )
-            self._pcm_chunk_cache.setdefault(channel_int, deque()).append(pcm_chunk)
-
-        # Role-based audio delivery via hooks
-        role_cache_results = await self._deliver_audio_to_roles(
-            prepared,
-            channel_play_start,
-            commit_generation=commit_generation,
-        )
-        if not self._is_generation_active(commit_generation):
-            return self._stopped_commit_return_value()
-        # Merge role-based cache results into the cache
-        for cache_key, chunks in role_cache_results.items():
-            self._role_chunk_cache[cache_key].extend(chunks)
-
-        # Prune old chunks from cache
-        self._prune_role_chunk_cache()
-        self._prune_stale_channel_timing()
-
-        # Return earliest play_start_us
-        return min(channel_play_start.values())
+            # Return earliest play_start_us
+            commit_completed = True
+            return min(channel_play_start.values())
+        finally:
+            self._commit_in_flight -= 1
+            # Resend cached audio only on success to avoid replaying from cache missing chunks
+            if commit_completed and self._pending_join_roles:
+                pending = list(self._pending_join_roles)
+                self._pending_join_roles.clear()
+                for role in pending:
+                    self._do_role_join(role)
 
     def _resolve_channel_play_start(
         self,
@@ -1744,6 +1760,10 @@ class PushStream:
         """
         # Join immediately so replay anchors to the current shared timeline.
         # Deferring by wall-clock time can desynchronize grouped players.
+        if self._commit_in_flight > 0:
+            # _role_chunk_cache not yet updated for the in-flight chunk, run once commit is done.
+            self._pending_join_roles.add(role)
+            return
         self._do_role_join(role)
 
     def _do_role_join(self, role: Role) -> None:

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -930,7 +930,6 @@ class PushStream:
         commit_generation = self._stream_generation
 
         self._commit_in_flight += 1
-        commit_completed = False
         try:
             # Drain historical buffers
             historical = dict(self._historical_buffers)
@@ -946,7 +945,6 @@ class PushStream:
                         now_us + DEFAULT_INITIAL_DELAY_US + self._max_active_static_delay_us()
                     )
                     self._channel_timing_residue[MAIN_CHANNEL] = 0
-                commit_completed = True
                 return min(self._channel_timing.values())
 
             # Process historical buffers first: assign timestamps and inject into caches.
@@ -968,7 +966,6 @@ class PushStream:
             if not prepared:
                 # Historical-only commit: cache updated by _process_historical_buffers().
                 self._prune_role_chunk_cache()
-                commit_completed = True
                 return min(self._channel_timing.values())
 
             # Calculate duration for each channel and warn on misalignment
@@ -1041,13 +1038,12 @@ class PushStream:
             self._prune_stale_channel_timing()
 
             # Return earliest play_start_us
-            commit_completed = True
             return min(channel_play_start.values())
         finally:
             self._commit_in_flight -= 1
-            # Resend cached audio only on success to avoid replaying from cache missing chunks.
-            # In case there are multiple parallel commits, only flush once the last one finishes.
-            if commit_completed and self._commit_in_flight == 0 and self._pending_join_roles:
+            # Flush deferred joins with last commit (in case there ever were multiple
+            # simultaneous commit calls).
+            if self._commit_in_flight == 0 and self._pending_join_roles:
                 pending = list(self._pending_join_roles)
                 self._pending_join_roles.clear()
                 for role in pending:

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -2957,3 +2957,23 @@ async def test_commit_audio_advances_channel_timing_drift_free(mock_loop: Any) -
     )
     lossy = (n_commits - 1) * total_after_1
     assert expected - lossy >= 1
+
+
+def test_advance_channel_timing_resets_residue_on_rate_change() -> None:
+    """Residue is modulo the previous rate; switching rates must reset it."""
+    group = _DummyGroup(clients=[])
+    stream = PushStream(loop=MagicMock(), clock=ManualClock(), group=group)
+    channel_id = MAIN_CHANNEL
+    stream._channel_timing[channel_id] = 0  # noqa: SLF001
+
+    # 1024 samples @ 44100 leaves a non-zero residue (42100, modulo 44100).
+    delta1 = stream._advance_channel_timing(channel_id, 1024, 44_100)  # noqa: SLF001
+    assert delta1 == 1024 * 1_000_000 // 44_100  # 23219
+
+    # Switching to 48000 must not carry the 44100-modulus residue into the new
+    # divmod, otherwise delta would be 21334 instead of 21333.
+    delta2 = stream._advance_channel_timing(channel_id, 1024, 48_000)  # noqa: SLF001
+    assert delta2 == 1024 * 1_000_000 // 48_000, (
+        f"residue from prior rate bled into new-rate computation: "
+        f"got {delta2}µs, expected {1024 * 1_000_000 // 48_000}µs"
+    )

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -2898,3 +2898,62 @@ def test_resampler_pending_input_ts_has_zero_cumulative_drift_at_44100_source() 
         "regression of the input-side residue accumulator. This would eventually "
         "cross the 20ms drift threshold and trigger a spurious graph rebuild."
     )
+
+
+def test_advance_channel_timing_is_drift_free() -> None:
+    """Cumulative `_channel_timing` advance must equal `total_samples * 1e6 // rate`."""
+    group = _DummyGroup(clients=[])
+    stream = PushStream(loop=MagicMock(), clock=ManualClock(), group=group)
+    channel_id = MAIN_CHANNEL
+    stream._channel_timing[channel_id] = 0  # noqa: SLF001
+
+    # 1024 samples @ 44.1k ≈ 23219.95µs; lossy int(...) drops ≈0.95µs/chunk.
+    samples_per_chunk = 1024
+    sample_rate = 44_100
+    n_chunks = 1_000
+    total_added = 0
+    for _ in range(n_chunks):
+        total_added += stream._advance_channel_timing(  # noqa: SLF001
+            channel_id, samples_per_chunk, sample_rate
+        )
+
+    expected = n_chunks * samples_per_chunk * 1_000_000 // sample_rate
+    assert stream._channel_timing[channel_id] == expected  # noqa: SLF001
+    assert total_added == expected
+    lossy = n_chunks * (samples_per_chunk * 1_000_000 // sample_rate)
+    assert expected - lossy >= 1, "test rate must produce observable drift"
+
+
+@pytest.mark.asyncio
+async def test_commit_audio_advances_channel_timing_drift_free(mock_loop: Any) -> None:
+    """End-to-end: residue accumulator must carry truncation across `commit_audio` calls."""
+    group = _DummyGroup(clients=[])
+    _client, _conn = _make_connected_player(mock_loop, group, "p1")
+
+    clock = LoopClock(mock_loop)
+    stream = PushStream(loop=mock_loop, clock=clock, group=group)
+
+    samples_per_chunk = 1024
+    sample_rate = 44_100
+    pcm = bytes(samples_per_chunk * 4)
+    fmt = AudioFormat(sample_rate=sample_rate, bit_depth=16, channels=2)
+
+    n_commits = 100
+    timings: list[int] = []
+    for _ in range(n_commits):
+        stream.prepare_audio(pcm, fmt)
+        await stream.commit_audio()
+        timings.append(stream._channel_timing[MAIN_CHANNEL])  # noqa: SLF001
+
+    # Initial timing depends on wall clock (set by _resolve_channel_play_start);
+    # subtract the post-first-commit baseline to isolate the residue invariant.
+    elapsed = timings[-1] - timings[0]
+    total_after_n = (n_commits * samples_per_chunk * 1_000_000) // sample_rate
+    total_after_1 = (samples_per_chunk * 1_000_000) // sample_rate
+    expected = total_after_n - total_after_1
+    assert elapsed == expected, (
+        f"channel timing drifted: got {elapsed}µs, expected {expected}µs over "
+        f"{n_commits - 1} subsequent commits"
+    )
+    lossy = (n_commits - 1) * total_after_1
+    assert expected - lossy >= 1


### PR DESCRIPTION
`_channel_timing` was still advanced via lossy `int(samples * 1e6 / rate)` per chunk, causing audible drift over long streams. Replace with a residue accumulator that carries the unconsumed numerator across calls (analogous to #217)

Late joiners replaying mid-commit could read from `_role_chunk_cache` before the in-flight chunk was appended, causing a missed chunk on join. Defer joins via `_pending_join_roles` until commits complete.

Also align `_process_historical_buffers`' precomputed total with the per-chunk residue advance so mixed sample-rate history doesn't desync.