### PR TITLE
Fix mid-stream joiner desync from catchup encoding

### DIFF
--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 __all__ = ["MAIN_CHANNEL", "PushStream"]
 
 import asyncio
+import contextlib
 import logging
 import weakref
 from collections import defaultdict, deque
@@ -509,6 +510,57 @@ def _resample_pcm_standalone(  # noqa: PLR0915
     )
     resampler_state.pending_timestamp_us += duration_us
 
+    return _ResampledPCM(
+        pcm_data=bytes(out_pcm),
+        output_start_ts=output_start_ts,
+        sample_count=output_sample_count,
+        needs_s32_to_s24_conversion=resampler_state.needs_s32_to_s24_conversion,
+        sample_type=resampler_state.target_sample_type,
+    )
+
+
+def _flush_resampler(resampler_state: _ResamplerState) -> _ResampledPCM:
+    """Push EOF into the resampler graph and capture drained output PCM.
+
+    Returns an empty result when the state has no graph (passthrough or already
+    flushed). Advances `pending_timestamp_us` for the drained samples so the
+    caller can timestamp them in line with the running output timeline. The
+    graph is dropped after flush — the state is single-use after this call.
+    """
+    if (
+        resampler_state.graph is None
+        or resampler_state.is_passthrough
+        or resampler_state.pending_timestamp_us is None
+    ):
+        return _ResampledPCM(
+            pcm_data=b"",
+            output_start_ts=resampler_state.pending_timestamp_us or 0,
+            sample_count=0,
+            needs_s32_to_s24_conversion=resampler_state.needs_s32_to_s24_conversion,
+            sample_type=resampler_state.target_sample_type,
+        )
+
+    output_start_ts = resampler_state.pending_timestamp_us
+    with contextlib.suppress(EOFError, OSError):
+        resampler_state.graph.push(None)
+    out_frames = _drain_audio_graph(resampler_state.graph)
+    out_pcm = bytearray()
+    output_sample_count = 0
+    for out_frame in out_frames:
+        expected = resampler_state.target_av_frame_stride * out_frame.samples
+        pcm_bytes = bytes(out_frame.planes[0])[:expected]
+        out_pcm.extend(pcm_bytes)
+        output_sample_count += out_frame.samples
+
+    if output_sample_count > 0:
+        resampler_state.pending_ts_residue += output_sample_count * 1_000_000
+        duration_us, resampler_state.pending_ts_residue = divmod(
+            resampler_state.pending_ts_residue,
+            resampler_state.key.target_sample_rate,
+        )
+        resampler_state.pending_timestamp_us += duration_us
+
+    resampler_state.graph = None
     return _ResampledPCM(
         pcm_data=bytes(out_pcm),
         output_start_ts=output_start_ts,
@@ -1931,13 +1983,21 @@ class PushStream:
         encoder: AudioTransformer | None,
         req: AudioRequirements,
         channel_id: UUID,
+        *,
+        resamplers: dict[_ResamplerKey, _ResamplerState] | None = None,
+        quantizers: dict[_ResamplerKey, _ResamplerState] | None = None,
     ) -> list[CachedChunk]:
-        """Resample PCM chunks to the target format and encode them sequentially."""
+        """Resample PCM chunks to the target format and encode them sequentially.
+
+        Pass `resamplers`/`quantizers` to share state across calls (single resampler,
+        drainable via `_drain_catchup_resamplers`).
+        """
         tkey = self._build_transform_key(req, channel_id)
         cached: list[CachedChunk] = []
-        resampler_state: _ResamplerState | None = None
-        resampler_cache_key: _ResamplerKey | None = None
-        quantizer_cache: dict[_ResamplerKey, _ResamplerState] = {}
+        if resamplers is None:
+            resamplers = {}
+        if quantizers is None:
+            quantizers = {}
 
         for chunk in pcm_chunks:
             source_format = AudioFormat(
@@ -1960,17 +2020,14 @@ class PushStream:
                 target_bit_depth=target_format.bit_depth,
                 target_sample_type=target_format.sample_type,
             )
-            if (
-                resampler_state is None
-                or resampler_cache_key is None
-                or resampler_cache_key != current_resampler_key
-            ):
+            resampler_state = resamplers.get(current_resampler_key)
+            if resampler_state is None:
                 resampler_state = _create_resampler_state(
                     current_resampler_key,
                     source_format,
                     target_format,
                 )
-                resampler_cache_key = current_resampler_key
+                resamplers[current_resampler_key] = resampler_state
 
             resampled = _resample_pcm_standalone(
                 resampler_state,
@@ -1994,7 +2051,7 @@ class PushStream:
                     sample_rate=req.sample_rate,
                     channels=req.channels,
                     target_bit_depth=req.bit_depth,
-                    resampler_cache=quantizer_cache,
+                    resampler_cache=quantizers,
                 )
                 resampled_pcm = edge_quantized.pcm_data
                 needs_s32_to_s24_conversion = edge_quantized.needs_s32_to_s24_conversion
@@ -2034,15 +2091,89 @@ class PushStream:
         encoder: AudioTransformer | None,
         req: AudioRequirements,
         channel_id: UUID,
+        *,
+        resamplers: dict[_ResamplerKey, _ResamplerState] | None = None,
+        quantizers: dict[_ResamplerKey, _ResamplerState] | None = None,
     ) -> list[CachedChunk]:
         return self._encode_pcm_sequence(
             pcm_chunks,
             encoder,
             req,
             channel_id,
+            resamplers=resamplers,
+            quantizers=quantizers,
         )
 
-    async def _start_catchup_encoding(
+    def _drain_catchup_resamplers(
+        self,
+        resamplers: dict[_ResamplerKey, _ResamplerState],
+        quantizers: dict[_ResamplerKey, _ResamplerState],
+        encoder: AudioTransformer | None,
+        req: AudioRequirements,
+        channel_id: UUID,
+    ) -> list[CachedChunk]:
+        """Flush each catchup resampler's FIR tail and encode the drained PCM.
+
+        Without draining, the resampler's FIR holds samples past the catchup
+        tail, leaving a content gap before the first live chunk. Drain emits
+        those held samples on the live timeline so live picks up seamlessly.
+        """
+        tkey = self._build_transform_key(req, channel_id)
+        cached: list[CachedChunk] = []
+        for resampler_state in resamplers.values():
+            drained = _flush_resampler(resampler_state)
+            if drained.sample_count == 0 or not drained.pcm_data:
+                continue
+
+            resampled_pcm = drained.pcm_data
+            needs_s32_to_s24_conversion = drained.needs_s32_to_s24_conversion
+            output_start_ts = drained.output_start_ts
+            sample_count = drained.sample_count
+
+            if drained.sample_type == "float":
+                edge_quantized = _quantize_float_pcm(
+                    channel_id=channel_id,
+                    pcm_data=resampled_pcm,
+                    output_ts=output_start_ts,
+                    sample_rate=req.sample_rate,
+                    channels=req.channels,
+                    target_bit_depth=req.bit_depth,
+                    resampler_cache=quantizers,
+                )
+                resampled_pcm = edge_quantized.pcm_data
+                needs_s32_to_s24_conversion = edge_quantized.needs_s32_to_s24_conversion
+                output_start_ts = edge_quantized.output_start_ts
+                sample_count = edge_quantized.sample_count
+                if sample_count == 0 or not resampled_pcm:
+                    continue
+
+            if (
+                needs_s32_to_s24_conversion
+                and req.bit_depth == 24
+                and isinstance(encoder, PcmPassthrough)
+            ):
+                resampled_pcm = _convert_s32_to_s24(resampled_pcm)
+            duration_us = int(sample_count * 1_000_000 / req.sample_rate) if sample_count > 0 else 0
+
+            encoded_frames = self._encode_transform_for_key(
+                tkey,
+                encoder,
+                resampled_pcm,
+                output_start_ts,
+                duration_us,
+            )
+            for data, ts, dur in encoded_frames:
+                cached.append(
+                    CachedChunk(
+                        timestamp_us=ts,
+                        duration_us=dur,
+                        payload=data,
+                        byte_count=len(data),
+                    )
+                )
+        return cached
+
+    async def _start_catchup_encoding(  # noqa: PLR0915
         self,
         role: Role,
         req: AudioRequirements,
@@ -2052,6 +2183,12 @@ class PushStream:
         """Start catch-up encoding from PCM cache for a new TransformKey."""
         channel_int = channel_id.int
         encoder = req.transformer
+        # Catchup-local caches: one resampler/quantizer state spans the full PCM
+        # cache to avoid per-batch FIR transients. Drained at the end so encoder
+        # pending reaches the live timeline; otherwise `_encode_for_transform_key`
+        # back-shifts the first live chunk via candidate_base.
+        catchup_resamplers: dict[_ResamplerKey, _ResamplerState] = {}
+        catchup_quantizers: dict[_ResamplerKey, _ResamplerState] = {}
 
         try:
             if encoder is not None:
@@ -2084,6 +2221,8 @@ class PushStream:
                 encoder,
                 req,
                 channel_id,
+                resamplers=catchup_resamplers,
+                quantizers=catchup_quantizers,
             )
 
             if encoded:
@@ -2126,11 +2265,25 @@ class PushStream:
                     encoder,
                     req,
                     channel_id,
+                    resamplers=catchup_resamplers,
+                    quantizers=catchup_quantizers,
                 )
 
                 if new_encoded:
                     self._role_chunk_cache[cache_key].extend(new_encoded)
                     last_encoded_end_us = new_encoded[-1].timestamp_us + new_encoded[-1].duration_us
+
+            # Drain FIR-held tail so encoder.pending and the role chunk cache reach the
+            # live timeline before live encoding begins.
+            drained = self._drain_catchup_resamplers(
+                catchup_resamplers,
+                catchup_quantizers,
+                encoder,
+                req,
+                channel_id,
+            )
+            if drained:
+                self._role_chunk_cache[cache_key].extend(drained)
 
             now_us = self._clock.now_us()
             encoded_cache = self._role_chunk_cache.get(cache_key, [])

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -2225,7 +2225,7 @@ class PushStream:
                 quantizers=catchup_quantizers,
             )
 
-            if encoded:
+            if encoded and self._catchup_state.get(cache_key) == "catching_up":
                 self._role_chunk_cache[cache_key].extend(encoded)
 
             last_encoded_end_us = (
@@ -2269,7 +2269,7 @@ class PushStream:
                     quantizers=catchup_quantizers,
                 )
 
-                if new_encoded:
+                if new_encoded and self._catchup_state.get(cache_key) == "catching_up":
                     self._role_chunk_cache[cache_key].extend(new_encoded)
                     last_encoded_end_us = new_encoded[-1].timestamp_us + new_encoded[-1].duration_us
 
@@ -2282,7 +2282,7 @@ class PushStream:
                 req,
                 channel_id,
             )
-            if drained:
+            if drained and self._catchup_state.get(cache_key) == "catching_up":
                 self._role_chunk_cache[cache_key].extend(drained)
 
             now_us = self._clock.now_us()
@@ -2293,8 +2293,15 @@ class PushStream:
             self._catchup_state[cache_key] = "live"
         finally:
             if self._catchup_state.get(cache_key) != "live":
+                # Catchup was cancelled (e.g. role left mid-catchup). Clear partial state
+                # so a future re-join doesn't hit a stale cache or stale encoder pending
+                # that would back-shift live chunks via candidate_base.
                 self._catchup_state.pop(cache_key, None)
                 self._catchup_roles.pop(cache_key, None)
+                self._role_chunk_cache.pop(cache_key, None)
+                self._transform_last_input_end_us.pop(cache_key, None)
+                if encoder is not None:
+                    encoder.reset()
             self._catchup_tasks.pop(cache_key, None)
 
     def _cancel_catchup_tasks(self) -> None:

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -1998,6 +1998,7 @@ class PushStream:
             resamplers = {}
         if quantizers is None:
             quantizers = {}
+        prev_resampler_key: _ResamplerKey | None = None
 
         for chunk in pcm_chunks:
             source_format = AudioFormat(
@@ -2020,6 +2021,16 @@ class PushStream:
                 target_bit_depth=target_format.bit_depth,
                 target_sample_type=target_format.sample_type,
             )
+            # Format changed: flush prior resampler now to keep output timestamp-ordered.
+            if prev_resampler_key is not None and prev_resampler_key != current_resampler_key:
+                prev_state = resamplers.pop(prev_resampler_key, None)
+                if prev_state is not None:
+                    cached.extend(
+                        self._flush_resampler_to_chunks(
+                            prev_state, quantizers, encoder, req, channel_id
+                        )
+                    )
+
             resampler_state = resamplers.get(current_resampler_key)
             if resampler_state is None:
                 resampler_state = _create_resampler_state(
@@ -2028,6 +2039,7 @@ class PushStream:
                     target_format,
                 )
                 resamplers[current_resampler_key] = resampler_state
+            prev_resampler_key = current_resampler_key
 
             resampled = _resample_pcm_standalone(
                 resampler_state,
@@ -2104,6 +2116,67 @@ class PushStream:
             quantizers=quantizers,
         )
 
+    def _flush_resampler_to_chunks(
+        self,
+        resampler_state: _ResamplerState,
+        quantizers: dict[_ResamplerKey, _ResamplerState],
+        encoder: AudioTransformer | None,
+        req: AudioRequirements,
+        channel_id: UUID,
+    ) -> list[CachedChunk]:
+        """Drain one resampler's FIR tail and run it through quantizer/encoder."""
+        tkey = self._build_transform_key(req, channel_id)
+        drained = _flush_resampler(resampler_state)
+        if drained.sample_count == 0 or not drained.pcm_data:
+            return []
+
+        resampled_pcm = drained.pcm_data
+        needs_s32_to_s24_conversion = drained.needs_s32_to_s24_conversion
+        output_start_ts = drained.output_start_ts
+        sample_count = drained.sample_count
+
+        if drained.sample_type == "float":
+            edge_quantized = _quantize_float_pcm(
+                channel_id=channel_id,
+                pcm_data=resampled_pcm,
+                output_ts=output_start_ts,
+                sample_rate=req.sample_rate,
+                channels=req.channels,
+                target_bit_depth=req.bit_depth,
+                resampler_cache=quantizers,
+            )
+            resampled_pcm = edge_quantized.pcm_data
+            needs_s32_to_s24_conversion = edge_quantized.needs_s32_to_s24_conversion
+            output_start_ts = edge_quantized.output_start_ts
+            sample_count = edge_quantized.sample_count
+            if sample_count == 0 or not resampled_pcm:
+                return []
+
+        if (
+            needs_s32_to_s24_conversion
+            and req.bit_depth == 24
+            and isinstance(encoder, PcmPassthrough)
+        ):
+            resampled_pcm = _convert_s32_to_s24(resampled_pcm)
+        duration_us = int(sample_count * 1_000_000 / req.sample_rate) if sample_count > 0 else 0
+
+        encoded_frames = self._encode_transform_for_key(
+            tkey,
+            encoder,
+            resampled_pcm,
+            output_start_ts,
+            duration_us,
+        )
+        return [
+            CachedChunk(
+                timestamp_us=ts,
+                duration_us=dur,
+                payload=data,
+                byte_count=len(data),
+            )
+            for data, ts, dur in encoded_frames
+        ]
+
     def _drain_catchup_resamplers(
         self,
         resamplers: dict[_ResamplerKey, _ResamplerState],
@@ -2118,59 +2191,13 @@ class PushStream:
         tail, leaving a content gap before the first live chunk. Drain emits
         those held samples on the live timeline so live picks up seamlessly.
         """
-        tkey = self._build_transform_key(req, channel_id)
         cached: list[CachedChunk] = []
         for resampler_state in resamplers.values():
-            drained = _flush_resampler(resampler_state)
-            if drained.sample_count == 0 or not drained.pcm_data:
-                continue
-
-            resampled_pcm = drained.pcm_data
-            needs_s32_to_s24_conversion = drained.needs_s32_to_s24_conversion
-            output_start_ts = drained.output_start_ts
-            sample_count = drained.sample_count
-
-            if drained.sample_type == "float":
-                edge_quantized = _quantize_float_pcm(
-                    channel_id=channel_id,
-                    pcm_data=resampled_pcm,
-                    output_ts=output_start_ts,
-                    sample_rate=req.sample_rate,
-                    channels=req.channels,
-                    target_bit_depth=req.bit_depth,
-                    resampler_cache=quantizers,
+            cached.extend(
+                self._flush_resampler_to_chunks(
+                    resampler_state, quantizers, encoder, req, channel_id
                 )
-                resampled_pcm = edge_quantized.pcm_data
-                needs_s32_to_s24_conversion = edge_quantized.needs_s32_to_s24_conversion
-                output_start_ts = edge_quantized.output_start_ts
-                sample_count = edge_quantized.sample_count
-                if sample_count == 0 or not resampled_pcm:
-                    continue
-
-            if (
-                needs_s32_to_s24_conversion
-                and req.bit_depth == 24
-                and isinstance(encoder, PcmPassthrough)
-            ):
-                resampled_pcm = _convert_s32_to_s24(resampled_pcm)
-            duration_us = int(sample_count * 1_000_000 / req.sample_rate) if sample_count > 0 else 0
-
-            encoded_frames = self._encode_transform_for_key(
-                tkey,
-                encoder,
-                resampled_pcm,
-                output_start_ts,
-                duration_us,
             )
-            for data, ts, dur in encoded_frames:
-                cached.append(
-                    CachedChunk(
-                        timestamp_us=ts,
-                        duration_us=dur,
-                        payload=data,
-                        byte_count=len(data),
-                    )
-                )
         return cached
 
     async def _start_catchup_encoding(  # noqa: PLR0915

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -2977,3 +2977,196 @@ def test_advance_channel_timing_resets_residue_on_rate_change() -> None:
         f"residue from prior rate bled into new-rate computation: "
         f"got {delta2}µs, expected {1024 * 1_000_000 // 48_000}µs"
     )
+
+
+@pytest.mark.asyncio
+async def test_catchup_drain_advances_encoder_pending_to_live_tip() -> None:
+    """Drained FIR tail must advance encoder.pending_timestamp_us to the live tip.
+
+    Without draining, the resampler's FIR holds samples past the catchup tail and
+    `encoder.pending_timestamp_us` stays behind the live timeline. The next live
+    commit then back-shifts its first chunk via `candidate_base` in
+    `_encode_for_transform_key`, putting the joiner ahead of peers.
+    """
+
+    class Transformer:
+        def __init__(self) -> None:
+            self.pending_timestamp_us: int | None = None
+            self._buffer = bytearray()
+            self._frame_size = 25 * 44_100 * 2 * 2 // 1000  # 25ms @ 44.1kHz stereo s16
+
+        @property
+        def frame_duration_us(self) -> int:
+            return 25_000
+
+        def process(self, pcm: bytes, ts: int, _dur: int) -> list[bytes]:
+            if self.pending_timestamp_us is None:
+                self.pending_timestamp_us = ts
+            self._buffer.extend(pcm)
+            frames: list[bytes] = []
+            while len(self._buffer) >= self._frame_size:
+                frames.append(bytes(self._buffer[: self._frame_size]))
+                del self._buffer[: self._frame_size]
+                if self.pending_timestamp_us is not None:
+                    self.pending_timestamp_us += 25_000
+            return frames
+
+        def flush(self) -> list[bytes]:
+            return []
+
+        def get_header(self) -> bytes | None:
+            return None
+
+        def reset(self) -> None:
+            self._buffer.clear()
+            self.pending_timestamp_us = None
+
+    group = _DummyGroup(clients=[])
+    role1 = _DummyRole(
+        AudioRequirements(
+            sample_rate=48_000,
+            bit_depth=16,
+            channels=2,
+            transformer=Transformer(),
+            channel_id=MAIN_CHANNEL,
+            frame_duration_us=25_000,
+        )
+    )
+    group.clients.append(_DummyClient([role1]))
+
+    loop = asyncio.get_running_loop()
+    clock = ManualClock(now_us_value=0)
+    stream = PushStream(loop=loop, clock=clock, group=group)
+    stream.enable_pcm_cache_for_channel(MAIN_CHANNEL)
+
+    for _ in range(8):
+        stream.prepare_audio(
+            bytes(19_200),  # 100ms @ 48kHz stereo f32
+            AudioFormat(sample_rate=48_000, bit_depth=32, channels=2, sample_type="float"),
+        )
+        await stream.commit_audio()
+        clock.advance_us(100_000)
+
+    joining_transformer = Transformer()
+    role2 = _DummyRole(
+        AudioRequirements(
+            sample_rate=44_100,  # rate change forces a real soxr/swr FIR
+            bit_depth=16,
+            channels=2,
+            transformer=joining_transformer,
+            channel_id=MAIN_CHANNEL,
+            frame_duration_us=25_000,
+        )
+    )
+    group.clients.append(_DummyClient([role2]))
+    stream.on_role_join(role2)
+
+    for _ in range(50):
+        if role2.received:
+            break
+        await asyncio.sleep(0.01)
+
+    assert role2.received, "catchup produced no chunks"
+    catchup_last_end_us = role2.received[-1].timestamp_us + role2.received[-1].duration_us
+    channel_tip_us = stream._channel_timing[MAIN_CHANNEL]  # noqa: SLF001
+    # Without drain the gap is roughly one FIR group delay (a few ms with swr,
+    # ~20 ms with libsoxr at precision=30). With drain it should land within one
+    # encoder frame_dur of the live tip.
+    gap_us = channel_tip_us - catchup_last_end_us
+    assert 0 <= gap_us <= 25_000, (
+        f"catchup tail too far behind live tip after drain: "
+        f"channel_tip={channel_tip_us}, catchup_last_end={catchup_last_end_us}, "
+        f"gap={gap_us}µs"
+    )
+
+
+@pytest.mark.asyncio
+async def test_catchup_mid_pass_format_change_keeps_chunks_ordered() -> None:
+    """Source-format change mid-catchup must flush the prior resampler in place.
+
+    The PCM cache can hold chunks from multiple source formats (e.g. a sample-rate
+    change earlier in the stream). With end-of-pass-only draining, the prior
+    resampler's FIR tail would be appended after the new resampler's chunks,
+    producing out-of-order timestamps. Flushing on key switch keeps output ordered.
+    """
+
+    class Transformer:
+        pending_timestamp_us: int | None = None
+
+        @property
+        def frame_duration_us(self) -> int:
+            return 25_000
+
+        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[bytes]:
+            return [pcm]
+
+        def flush(self) -> list[bytes]:
+            return []
+
+        def get_header(self) -> bytes | None:
+            return None
+
+        def reset(self) -> None:
+            return
+
+    group = _DummyGroup(clients=[])
+    role1 = _DummyRole(
+        AudioRequirements(
+            sample_rate=44_100,
+            bit_depth=16,
+            channels=2,
+            transformer=Transformer(),
+            channel_id=MAIN_CHANNEL,
+            frame_duration_us=25_000,
+        )
+    )
+    group.clients.append(_DummyClient([role1]))
+
+    loop = asyncio.get_running_loop()
+    clock = ManualClock(now_us_value=0)
+    stream = PushStream(loop=loop, clock=clock, group=group)
+    stream.enable_pcm_cache_for_channel(MAIN_CHANNEL)
+
+    # Two batches of 48k float, then 44.1k float, then back to 48k float — the
+    # PCM cache will end up with mixed source formats requiring two distinct
+    # resampler keys during catchup.
+    formats = [
+        (48_000, 4),
+        (44_100, 4),
+        (48_000, 4),
+    ]
+    for sample_rate, count in formats:
+        # 100 ms of stereo float32 at the chosen rate.
+        chunk_bytes = bytes(sample_rate * 2 * 4 // 10)
+        for _ in range(count):
+            stream.prepare_audio(
+                chunk_bytes,
+                AudioFormat(sample_rate=sample_rate, bit_depth=32, channels=2, sample_type="float"),
+            )
+            await stream.commit_audio()
+            clock.advance_us(100_000)
+
+    role2 = _DummyRole(
+        AudioRequirements(
+            sample_rate=44_100,
+            bit_depth=16,
+            channels=2,
+            transformer=Transformer(),
+            channel_id=MAIN_CHANNEL,
+            frame_duration_us=25_000,
+        )
+    )
+    group.clients.append(_DummyClient([role2]))
+    stream.on_role_join(role2)
+
+    for _ in range(50):
+        if role2.received:
+            break
+        await asyncio.sleep(0.01)
+
+    assert role2.received, "catchup produced no chunks"
+    for prev, nxt in zip(role2.received, role2.received[1:], strict=False):
+        assert nxt.timestamp_us >= prev.timestamp_us, (
+            f"timestamps out of order across format change: "
+            f"{prev.timestamp_us} -> {nxt.timestamp_us}"
+        )


### PR DESCRIPTION
Catchup encoding created a fresh resampler per batch, so each batch got out of sync more and more due to the FIR warmup. Across a long catchup the cumulative short output left `encoder.pending_timestamp_us` behind the live tip, back-shifting the joiner's first live chunk via candidate_base and putting it ahead of peers.

This PR fixes that by creating a single resampler across the catchup pass, and explicitly draining the tail at the end.

Also fixes a catchup race condition: `task.cancel()` in `on_role_leave` returns immediately, but the catchup task could still extend `_role_chunk_cache` or mutate `encoder.pending_timestamp_us` before reaching the next await.