### PR TITLE
Add API to allow connecting to server initiated clients without mDNS

### DIFF
--- a/aiosendspin/server/server.py
+++ b/aiosendspin/server/server.py
@@ -47,6 +47,14 @@ MAX_RECONNECT_BACKOFF_S = 300.0
 STABLE_SERVER_INITIATED_SESSION_S = 10.0
 
 
+@dataclass(frozen=True, slots=True)
+class _ServerInitiatedConnectionOptions:
+    """Retry policy for a server-initiated client URL."""
+
+    retry_initial_connection: bool = False
+    retry_indefinitely: bool = False
+
+
 class SendspinEvent:
     """Base event type used by SendspinServer.add_event_listener()."""
 
@@ -96,6 +104,14 @@ def _get_first_valid_ip(addresses: list[str]) -> str | None:
     return None
 
 
+def _normalize_client_url(address: str) -> str:
+    """Normalize a configured client WebSocket URL."""
+    address = address.strip()
+    if not address:
+        raise ValueError("address must not be empty")
+    return address
+
+
 class SendspinServer:
     """Sendspin Server implementation to connect to and manage many Sendspin clients."""
 
@@ -132,6 +148,7 @@ class SendspinServer:
         self._retry_events: dict[str, asyncio.Event] = {}
         self._initial_connect_waiters: dict[str, list[asyncio.Future[None]]] = {}
         self._initial_connect_succeeded: set[str] = set()
+        self._connection_options: dict[str, _ServerInitiatedConnectionOptions] = {}
         self._connection_reasons: dict[str, ConnectionReason] = {}  # url → reason
         self._client_urls: dict[str, str] = {}  # client_id → url
         self._external_stream_start_cbs: dict[str, ExternalStreamStartCallback] = {}
@@ -317,13 +334,29 @@ class SendspinServer:
         return websocket
 
     def connect_to_client(
-        self, url: str, *, connection_reason: ConnectionReason = ConnectionReason.DISCOVERY
+        self,
+        url: str,
+        *,
+        connection_reason: ConnectionReason = ConnectionReason.DISCOVERY,
+        retry_initial_connection: bool = False,
+        retry_indefinitely: bool = False,
     ) -> None:
         """Start a background connection attempt to a client URL.
 
         Initial connection failures are logged and stop the background task.
         Automatic retries only happen after at least one successful connection.
+
+        Args:
+            url: Client WebSocket URL.
+            connection_reason: Reason reported in server/hello.
+            retry_initial_connection: Keep retrying if the first connection attempt fails.
+            retry_indefinitely: Keep retrying later disconnects with capped exponential backoff.
         """
+        self._set_connection_options(
+            url,
+            retry_initial_connection=retry_initial_connection,
+            retry_indefinitely=retry_indefinitely,
+        )
         self._connection_reasons[url] = connection_reason
         prev_task = self._connection_tasks.get(url)
         if prev_task is not None:
@@ -339,7 +372,12 @@ class SendspinServer:
         )
 
     async def connect_to_client_and_wait(
-        self, url: str, *, connection_reason: ConnectionReason = ConnectionReason.DISCOVERY
+        self,
+        url: str,
+        *,
+        connection_reason: ConnectionReason = ConnectionReason.DISCOVERY,
+        retry_initial_connection: bool = False,
+        retry_indefinitely: bool = False,
     ) -> None:
         """Connect to a client and wait for the initial connection attempt.
 
@@ -349,6 +387,11 @@ class SendspinServer:
             TimeoutError: If the initial connection attempt times out.
             Exception: Other unexpected errors during the initial connection attempt.
         """
+        self._set_connection_options(
+            url,
+            retry_initial_connection=retry_initial_connection,
+            retry_indefinitely=retry_indefinitely,
+        )
         self._connection_reasons[url] = connection_reason
         if url in self._initial_connect_succeeded:
             return
@@ -369,6 +412,78 @@ class SendspinServer:
             )
 
         await waiter
+
+    def connect_to_client_address(
+        self,
+        address: str,
+        *,
+        connection_reason: ConnectionReason = ConnectionReason.DISCOVERY,
+    ) -> str:
+        """Start a persistent connection to a configured client address.
+
+        This is intended for manually configured client WebSocket URLs, where mDNS
+        may not be available. The connection keeps retrying when the client is offline
+        at startup and after later disconnects. The caller must provide the URL,
+        including scheme, port, and path.
+
+        Args:
+            address: Complete client WebSocket URL.
+            connection_reason: Reason reported in server/hello.
+
+        Returns:
+            The WebSocket URL used for the connection.
+        """
+        url = _normalize_client_url(address)
+        self.connect_to_client(
+            url,
+            connection_reason=connection_reason,
+            retry_initial_connection=True,
+            retry_indefinitely=True,
+        )
+        return url
+
+    async def connect_to_client_address_and_wait(
+        self,
+        address: str,
+        *,
+        connection_reason: ConnectionReason = ConnectionReason.DISCOVERY,
+    ) -> str:
+        """Start a persistent address connection and wait until it first succeeds."""
+        url = _normalize_client_url(address)
+        await self.connect_to_client_and_wait(
+            url,
+            connection_reason=connection_reason,
+            retry_initial_connection=True,
+            retry_indefinitely=True,
+        )
+        return url
+
+    def _set_connection_options(
+        self,
+        url: str,
+        *,
+        retry_initial_connection: bool,
+        retry_indefinitely: bool,
+    ) -> None:
+        """Store retry options without downgrading an existing background task."""
+        previous = self._connection_options.get(url)
+        if previous is None:
+            self._connection_options[url] = _ServerInitiatedConnectionOptions(
+                retry_initial_connection=retry_initial_connection,
+                retry_indefinitely=retry_indefinitely,
+            )
+            return
+
+        self._connection_options[url] = _ServerInitiatedConnectionOptions(
+            retry_initial_connection=(
+                previous.retry_initial_connection or retry_initial_connection
+            ),
+            retry_indefinitely=previous.retry_indefinitely or retry_indefinitely,
+        )
+
+    def _get_connection_options(self, url: str) -> _ServerInitiatedConnectionOptions:
+        """Return retry options for a server-initiated client URL."""
+        return self._connection_options.get(url, _ServerInitiatedConnectionOptions())
 
     def get_connection_reason(self, url: str) -> ConnectionReason:
         """Get the connection reason for a URL (for use by SendspinConnection)."""
@@ -433,6 +548,9 @@ class SendspinServer:
 
     def disconnect_from_client(self, url: str) -> None:
         """Disconnect a server-initiated connection previously established via connect_to_client."""
+        self._connection_options.pop(url, None)
+        self._connection_reasons.pop(url, None)
+        self._initial_connect_succeeded.discard(url)
         connection_task = self._connection_tasks.pop(url, None)
         if connection_task is not None:
             connection_task.cancel()
@@ -494,7 +612,7 @@ class SendspinServer:
             else:
                 waiter.set_exception(err)
 
-    async def _handle_client_connection(self, url: str) -> None:  # noqa: PLR0915
+    async def _handle_client_connection(self, url: str) -> None:  # noqa: PLR0912, PLR0915
         """Handle a server-initiated WebSocket connection task."""
         backoff = 1.0
         first_connection_succeeded = False
@@ -537,30 +655,48 @@ class SendspinServer:
                     break
                 except TimeoutError:
                     if not first_connection_succeeded:
-                        logger.debug("Initial connection to %s timed out", url)
-                        self._resolve_initial_connect_waiters(url, TimeoutError())
-                        return
-                    logger.debug("Connection task for %s timed out", url)
+                        if self._get_connection_options(url).retry_initial_connection:
+                            logger.debug("Initial connection to %s timed out, retrying", url)
+                        else:
+                            logger.debug("Initial connection to %s timed out", url)
+                            self._resolve_initial_connect_waiters(url, TimeoutError())
+                            return
+                    else:
+                        logger.debug("Connection task for %s timed out", url)
                 except (ClientConnectionError, ClientResponseError) as err:
                     if not first_connection_succeeded:
-                        logger.debug("Initial connection to %s failed: %s", url, err)
-                        self._resolve_initial_connect_waiters(url, err)
-                        return
-                    logger.debug("Connection task for %s failed: %s", url, err)
+                        if self._get_connection_options(url).retry_initial_connection:
+                            logger.debug("Initial connection to %s failed, retrying: %s", url, err)
+                        else:
+                            logger.debug("Initial connection to %s failed: %s", url, err)
+                            self._resolve_initial_connect_waiters(url, err)
+                            return
+                    else:
+                        logger.debug("Connection task for %s failed: %s", url, err)
 
-                if backoff >= MAX_RECONNECT_BACKOFF_S:
+                options = self._get_connection_options(url)
+                if not options.retry_indefinitely and backoff >= MAX_RECONNECT_BACKOFF_S:
+                    if not first_connection_succeeded:
+                        self._resolve_initial_connect_waiters(
+                            url,
+                            TimeoutError(
+                                "Initial connection did not succeed before "
+                                "the reconnect backoff ceiling was reached"
+                            ),
+                        )
                     break
 
-                logger.debug("Trying to reconnect to client at %s in %.1fs", url, backoff)
+                sleep_s = min(backoff, MAX_RECONNECT_BACKOFF_S)
+                logger.debug("Trying to reconnect to client at %s in %.1fs", url, sleep_s)
                 if retry_event is not None:
                     try:
-                        await asyncio.wait_for(retry_event.wait(), timeout=backoff)
+                        await asyncio.wait_for(retry_event.wait(), timeout=sleep_s)
                         retry_event.clear()
                     except TimeoutError:
                         pass
                 else:
-                    await asyncio.sleep(backoff)
-                backoff *= 2
+                    await asyncio.sleep(sleep_s)
+                backoff = min(backoff * 2, MAX_RECONNECT_BACKOFF_S)
         except asyncio.CancelledError:
             if not first_connection_succeeded:
                 self._resolve_initial_connect_waiters(url, asyncio.CancelledError())
@@ -572,6 +708,7 @@ class SendspinServer:
             self._connection_tasks.pop(url, None)
             self._retry_events.pop(url, None)
             self._initial_connect_succeeded.discard(url)
+            self._connection_options.pop(url, None)
             self._connection_reasons.pop(url, None)
 
     async def start_server(

--- a/aiosendspin/server/server.py
+++ b/aiosendspin/server/server.py
@@ -335,8 +335,8 @@ class SendspinServer:
     ) -> None:
         """Start a background connection attempt to a client URL.
 
-        Initial connection failures are logged and stop the background task.
-        Automatic retries only happen after at least one successful connection.
+        By default, initial connection failures are logged and stop the background task,
+        and automatic retries only happen after at least one successful connection.
         If mDNS discovery is unavailable, callers can build a full client WebSocket URL
         from a configured hostname/IP, port, and path, then pass
         retry_initial_connection=True and retry_indefinitely=True.
@@ -379,7 +379,8 @@ class SendspinServer:
         Raises:
             ClientConnectionError: If the initial connection to the client fails.
             ClientResponseError: If the client responds with an error HTTP status.
-            TimeoutError: If the initial connection attempt times out.
+            TimeoutError: If the initial connection attempt times out, or the backoff
+                ceiling is reached with retry_initial_connection=True.
             Exception: Other unexpected errors during the initial connection attempt.
         """
         self._set_connection_options(

--- a/aiosendspin/server/server.py
+++ b/aiosendspin/server/server.py
@@ -347,7 +347,7 @@ class SendspinServer:
         Automatic retries only happen after at least one successful connection.
 
         Args:
-            url: Client WebSocket URL.
+            url: Client WebSocket URL (e.g. "ws://192.168.1.2:8928/sendspin").
             connection_reason: Reason reported in server/hello.
             retry_initial_connection: Keep retrying if the first connection attempt fails.
             retry_indefinitely: Keep retrying later disconnects with capped exponential backoff.

--- a/aiosendspin/server/server.py
+++ b/aiosendspin/server/server.py
@@ -104,14 +104,6 @@ def _get_first_valid_ip(addresses: list[str]) -> str | None:
     return None
 
 
-def _normalize_client_url(address: str) -> str:
-    """Normalize a configured client WebSocket URL."""
-    address = address.strip()
-    if not address:
-        raise ValueError("address must not be empty")
-    return address
-
-
 class SendspinServer:
     """Sendspin Server implementation to connect to and manage many Sendspin clients."""
 
@@ -345,6 +337,9 @@ class SendspinServer:
 
         Initial connection failures are logged and stop the background task.
         Automatic retries only happen after at least one successful connection.
+        If mDNS discovery is unavailable, callers can build a full client WebSocket URL
+        from a configured hostname/IP, port, and path, then pass
+        retry_initial_connection=True and retry_indefinitely=True.
 
         Args:
             url: Client WebSocket URL (e.g. "ws://192.168.1.2:8928/sendspin").
@@ -412,51 +407,6 @@ class SendspinServer:
             )
 
         await waiter
-
-    def connect_to_client_address(
-        self,
-        address: str,
-        *,
-        connection_reason: ConnectionReason = ConnectionReason.DISCOVERY,
-    ) -> str:
-        """Start a persistent connection to a configured client address.
-
-        This is intended for manually configured client WebSocket URLs, where mDNS
-        may not be available. The connection keeps retrying when the client is offline
-        at startup and after later disconnects. The caller must provide the URL,
-        including scheme, port, and path.
-
-        Args:
-            address: Complete client WebSocket URL.
-            connection_reason: Reason reported in server/hello.
-
-        Returns:
-            The WebSocket URL used for the connection.
-        """
-        url = _normalize_client_url(address)
-        self.connect_to_client(
-            url,
-            connection_reason=connection_reason,
-            retry_initial_connection=True,
-            retry_indefinitely=True,
-        )
-        return url
-
-    async def connect_to_client_address_and_wait(
-        self,
-        address: str,
-        *,
-        connection_reason: ConnectionReason = ConnectionReason.DISCOVERY,
-    ) -> str:
-        """Start a persistent address connection and wait until it first succeeds."""
-        url = _normalize_client_url(address)
-        await self.connect_to_client_and_wait(
-            url,
-            connection_reason=connection_reason,
-            retry_initial_connection=True,
-            retry_indefinitely=True,
-        )
-        return url
 
     def _set_connection_options(
         self,

--- a/tests/server/test_server_initial_connect.py
+++ b/tests/server/test_server_initial_connect.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from aiohttp import ClientConnectionError, ClientWebSocketResponse
 
-from aiosendspin.models.types import GoodbyeReason
+from aiosendspin.models.types import ConnectionReason, GoodbyeReason
 from aiosendspin.server.connection import SendspinConnection
 from aiosendspin.server.server import SendspinServer
 
@@ -69,6 +69,23 @@ class _PersistentSuccessfulSession:
 
     def ws_connect(self, *_args: object, **_kwargs: object) -> _SuccessfulConnectContext:
         self.calls += 1
+        return _SuccessfulConnectContext()
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _FailOnceThenConnectSession:
+    """Client session whose first connection fails and second succeeds."""
+
+    def __init__(self) -> None:
+        self.closed = True
+        self.calls = 0
+
+    def ws_connect(self, *_args: object, **_kwargs: object) -> _SuccessfulConnectContext:
+        self.calls += 1
+        if self.calls == 1:
+            raise ClientConnectionError("offline")
         return _SuccessfulConnectContext()
 
     async def close(self) -> None:
@@ -145,6 +162,101 @@ async def test_connect_to_client_stops_after_initial_failure_without_retry() -> 
 
     assert session.calls == 1
     assert url not in server._connection_tasks  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_connect_to_client_address_starts_persistent_address_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Configured addresses should be passed through unchanged with persistent retries."""
+    server = _make_server(_PersistentSuccessfulSession())
+    calls: list[tuple[str, ConnectionReason, bool, bool]] = []
+
+    def _connect_to_client(
+        url: str,
+        *,
+        connection_reason: ConnectionReason,
+        retry_initial_connection: bool,
+        retry_indefinitely: bool,
+    ) -> None:
+        calls.append(
+            (
+                url,
+                connection_reason,
+                retry_initial_connection,
+                retry_indefinitely,
+            )
+        )
+
+    monkeypatch.setattr(server, "connect_to_client", _connect_to_client)
+
+    configured_url = "ws://192.168.1.50:9999/custom-sendspin"
+    url = server.connect_to_client_address(configured_url)
+
+    assert url == configured_url
+    assert calls == [(url, ConnectionReason.DISCOVERY, True, True)]
+
+
+@pytest.mark.asyncio
+async def test_connect_to_client_and_wait_can_retry_initial_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Opt-in initial retry should wait until an offline client comes online."""
+    session = _FailOnceThenConnectSession()
+    server = _make_server(session)
+    url = "ws://127.0.0.1:9999/sendspin"
+
+    class _FakeConnection:
+        """Connection double used to bypass full websocket lifecycle."""
+
+        closing = False
+        goodbye_reason = None
+        should_retry_server_initiated_connection = False
+
+        def __init__(
+            self,
+            _server: SendspinServer,
+            *,
+            wsock_client: object,  # noqa: ARG002
+            url: str | None = None,  # noqa: ARG002
+        ) -> None:
+            return
+
+        async def _handle_client(self) -> None:
+            return
+
+    monkeypatch.setattr("aiosendspin.server.server.SendspinConnection", _FakeConnection)
+
+    wait_task = asyncio.create_task(
+        server.connect_to_client_and_wait(url, retry_initial_connection=True)
+    )
+    for _ in range(20):
+        if session.calls == 1 and url in server._retry_events:  # noqa: SLF001
+            break
+        await asyncio.sleep(0)
+
+    assert not wait_task.done()
+    server._retry_events[url].set()  # noqa: SLF001
+
+    await wait_task
+
+    assert session.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_connect_to_client_and_wait_raises_when_initial_retry_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bounded initial retry should not leave waiters unresolved."""
+    session = _FailingInitialConnectSession()
+    server = _make_server(session)
+    url = "ws://127.0.0.1:9999/sendspin"
+    monkeypatch.setattr("aiosendspin.server.server.MAX_RECONNECT_BACKOFF_S", 1.0)
+
+    with pytest.raises(TimeoutError, match="Initial connection did not succeed"):
+        await server.connect_to_client_and_wait(url, retry_initial_connection=True)
+
+    assert session.calls == 1
 
 
 @pytest.mark.asyncio
@@ -279,6 +391,61 @@ async def test_server_initiated_backoff_resets_only_after_stable_session(
     await server._handle_client_connection(url)  # noqa: SLF001
 
     assert sleep_calls == expected_sleeps
+
+
+@pytest.mark.asyncio
+async def test_retry_indefinitely_keeps_reconnecting_after_backoff_ceiling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Persistent address connections should cap backoff without giving up."""
+    session = _PersistentSuccessfulSession()
+    server = _make_server(session)
+    url = "ws://127.0.0.1:9999/sendspin"
+    attempts = 0
+    sleep_calls: list[float] = []
+    monotonic_iter = iter([0.0, 0.1, 0.2, 0.3])
+
+    class _FakeConnection:
+        closing = False
+        goodbye_reason = None
+
+        def __init__(
+            self,
+            _server: SendspinServer,
+            *,
+            wsock_client: object,  # noqa: ARG002
+            url: str | None = None,  # noqa: ARG002
+        ) -> None:
+            nonlocal attempts
+            attempts += 1
+            self.should_retry_server_initiated_connection = attempts < 2
+
+        async def _handle_client(self) -> None:
+            return
+
+    async def _fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    def _fake_monotonic() -> float:
+        return next(monotonic_iter)
+
+    monkeypatch.setattr("aiosendspin.server.server.SendspinConnection", _FakeConnection)
+    monkeypatch.setattr("aiosendspin.server.server.MAX_RECONNECT_BACKOFF_S", 1.0)
+    monkeypatch.setattr(
+        "aiosendspin.server.server.time",
+        SimpleNamespace(monotonic=_fake_monotonic),
+    )
+    monkeypatch.setattr("aiosendspin.server.server.asyncio.sleep", _fake_sleep)
+    server._set_connection_options(  # noqa: SLF001
+        url,
+        retry_initial_connection=False,
+        retry_indefinitely=True,
+    )
+
+    await server._handle_client_connection(url)  # noqa: SLF001
+
+    assert session.calls == 2
+    assert sleep_calls == [1.0]
 
 
 def test_should_retry_false_when_closing() -> None:

--- a/tests/server/test_server_initial_connect.py
+++ b/tests/server/test_server_initial_connect.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from aiohttp import ClientConnectionError, ClientWebSocketResponse
 
-from aiosendspin.models.types import ConnectionReason, GoodbyeReason
+from aiosendspin.models.types import GoodbyeReason
 from aiosendspin.server.connection import SendspinConnection
 from aiosendspin.server.server import SendspinServer
 
@@ -162,39 +162,6 @@ async def test_connect_to_client_stops_after_initial_failure_without_retry() -> 
 
     assert session.calls == 1
     assert url not in server._connection_tasks  # noqa: SLF001
-
-
-@pytest.mark.asyncio
-async def test_connect_to_client_address_starts_persistent_address_connection(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Configured addresses should be passed through unchanged with persistent retries."""
-    server = _make_server(_PersistentSuccessfulSession())
-    calls: list[tuple[str, ConnectionReason, bool, bool]] = []
-
-    def _connect_to_client(
-        url: str,
-        *,
-        connection_reason: ConnectionReason,
-        retry_initial_connection: bool,
-        retry_indefinitely: bool,
-    ) -> None:
-        calls.append(
-            (
-                url,
-                connection_reason,
-                retry_initial_connection,
-                retry_indefinitely,
-            )
-        )
-
-    monkeypatch.setattr(server, "connect_to_client", _connect_to_client)
-
-    configured_url = "ws://192.168.1.50:9999/custom-sendspin"
-    url = server.connect_to_client_address(configured_url)
-
-    assert url == configured_url
-    assert calls == [(url, ConnectionReason.DISCOVERY, True, True)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Add support for configuring Sendspin client connections from a static list of hostnames/IP addresses.

The server now exposes a persistent manual connection path for caller-provided client WebSocket URLs. This lets integrations, such as the MA provider, build URLs from configured hostnames or IP addresses and ask SendspinServer to connect even when mDNS discovery is unavailable.

Manual connections retry when the client is offline at startup and continue reconnecting with capped backoff if the client disconnects later.