### PR TITLE
Fix `pre-commit install` failing in devcontainers

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,4 +16,6 @@ echo "Installing development dependencies..."
 uv sync --group dev --all-extras
 
 echo "Installing pre-commit hooks..."
+# Clear stale local core.hooksPath (e.g. from bind-mounted .git/config); pre-commit refuses install otherwise.
+git config --local --unset-all core.hooksPath 2>/dev/null || true
 uv run pre-commit install


### PR DESCRIPTION
Opening the repo in a devcontainer after `pre-commit install` ran on the host leaves `.git/config` with a `core.hooksPath` pointing at a host-only path. `pre-commit install` then refuses with "Cowardly refusing to install hooks with `core.hooksPath` set", failing `postCreateCommand`.

`scripts/setup.sh` now clears the local value before installing, scoped to the repo so global/system settings (e.g. user-managed husky/lefthook configs) are untouched.