### PR TITLE
Fix playback drift at sample rates that don't divide evenly into 1µs

### DIFF
--- a/aiosendspin/server/audio_transformers.py
+++ b/aiosendspin/server/audio_transformers.py
@@ -26,7 +26,7 @@ class AudioTransformer(Protocol):
         """Duration of each output frame in microseconds."""
         ...
 
-    def process(self, pcm: bytes, timestamp_us: int, duration_us: int) -> list[bytes]:
+    def process(self, pcm: bytes, timestamp_us: int, duration_us: int) -> list[tuple[bytes, int]]:
         """Transform PCM chunk into output frames.
 
         Args:
@@ -35,16 +35,17 @@ class AudioTransformer(Protocol):
             duration_us: Duration of this chunk in microseconds.
 
         Returns:
-            List of encoded frames. May be empty if buffering incomplete frame.
-            May contain multiple frames if input spans multiple frame boundaries.
+            List of `(frame_bytes, frame_duration_us)` pairs. May be empty if
+            buffering incomplete frame. May contain multiple frames if input
+            spans multiple frame boundaries.
         """
         ...
 
-    def flush(self) -> list[bytes]:
+    def flush(self) -> list[tuple[bytes, int]]:
         """Flush remaining buffered audio at stream end.
 
         Returns:
-            Final frame(s), possibly padded with silence.
+            Final `(frame_bytes, frame_duration_us)` pairs, possibly padded with silence.
         """
         ...
 

--- a/aiosendspin/server/audio_transformers.py
+++ b/aiosendspin/server/audio_transformers.py
@@ -23,7 +23,11 @@ class AudioTransformer(Protocol):
 
     @property
     def frame_duration_us(self) -> int:
-        """Duration of each output frame in microseconds."""
+        """Static frame duration used for `TransformKey` identity.
+
+        Per-frame wire duration is emitted by `process` / `flush` and may
+        vary by ±1µs at non-divisible rates.
+        """
         ...
 
     def process(self, pcm: bytes, timestamp_us: int, duration_us: int) -> list[tuple[bytes, int]]:

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -209,15 +209,20 @@ def _encode_for_transform_key(
     if not frames:
         return []
 
-    frame_dur = transformer.frame_duration_us
+    total_dur = sum(dur for _, dur in frames)
     base_ts = output_ts
     pending = transformer.pending_timestamp_us
     if pending is not None:
-        candidate_base = pending - (len(frames) * frame_dur)
+        candidate_base = pending - total_dur
         if abs(candidate_base - output_ts) <= _TRANSFORMER_DRIFT_THRESHOLD_US:
             base_ts = candidate_base
 
-    return [(data, base_ts + i * frame_dur, frame_dur) for i, data in enumerate(frames)]
+    result: list[tuple[bytes, int, int]] = []
+    ts = base_ts
+    for data, dur in frames:
+        result.append((data, ts, dur))
+        ts += dur
+    return result
 
 
 class _ResamplerKey(NamedTuple):
@@ -2470,8 +2475,7 @@ class PushStream:
         for tkey, transformer in transformers_by_key.items():
             final_frames = transformer.flush()
             if final_frames:
-                frame_duration_us = transformer.frame_duration_us
-                for frame_data in final_frames:
+                for frame_data, frame_duration_us in final_frames:
                     chunk = AudioChunk(
                         data=frame_data,
                         timestamp_us=0,  # Timestamp doesn't matter at stream end

--- a/aiosendspin/server/roles/player/audio_transformers.py
+++ b/aiosendspin/server/roles/player/audio_transformers.py
@@ -65,7 +65,12 @@ class PcmPassthrough:
 
     @property
     def frame_duration_us(self) -> int:
-        """Duration of each output frame in microseconds."""
+        """Static frame duration used for `TransformKey` identity.
+
+        Per-frame wire duration is emitted by `process` / `flush` and may
+        vary by ±1µs at rates where `chunk_samples * 1_000_000` does not
+        divide cleanly into `sample_rate` (e.g. 44.1kHz/25ms).
+        """
         return self._chunk_duration_us
 
     @property
@@ -198,7 +203,12 @@ class FlacEncoder:
 
     @property
     def frame_duration_us(self) -> int:
-        """Duration of each output frame in microseconds."""
+        """Static frame duration used for `TransformKey` identity.
+
+        Per-frame wire duration is emitted by `process` / `flush` and may
+        vary by ±1µs at rates where `chunk_samples * 1_000_000` does not
+        divide cleanly into `sample_rate` (e.g. 44.1kHz/25ms).
+        """
         return self._chunk_duration_us
 
     @property
@@ -429,7 +439,12 @@ class OpusEncoder:
 
     @property
     def frame_duration_us(self) -> int:
-        """Duration of each output frame in microseconds."""
+        """Static frame duration used for `TransformKey` identity.
+
+        Per-frame wire duration is emitted by `process` / `flush` and may
+        vary by ±1µs at rates where `chunk_samples * 1_000_000` does not
+        divide cleanly into `sample_rate` (e.g. 44.1kHz/25ms).
+        """
         return self._chunk_duration_us
 
     @property

--- a/aiosendspin/server/roles/player/audio_transformers.py
+++ b/aiosendspin/server/roles/player/audio_transformers.py
@@ -39,13 +39,15 @@ class PcmPassthrough:
             chunk_duration_us: Duration of each output frame in microseconds.
         """
         self._sample_rate = sample_rate
-        self._chunk_duration_us = chunk_duration_us
         self._frame_stride = (bit_depth // 8) * channels
         self._options = options
         # Calculate frame size: samples = sample_rate * duration_s
         # For 48kHz, 25ms: 48000 * 0.025 = 1200 samples
         # Frame size = samples * frame_stride = 1200 * 4 = 4800 bytes
         self._chunk_samples = int(sample_rate * chunk_duration_us / 1_000_000)
+        # Derive duration from the integer sample count so the wire label matches
+        # the real audio per frame at non-divisible rates (e.g. 44.1k/25ms).
+        self._chunk_duration_us = self._chunk_samples * 1_000_000 // sample_rate
         self._frame_size = self._chunk_samples * self._frame_stride
         self._buffer = bytearray()
         # Track timestamp of the first sample in the buffer
@@ -71,7 +73,7 @@ class PcmPassthrough:
         """Timestamp of the first buffered sample, or None if buffer is empty."""
         return self._pending_timestamp_us
 
-    def process(self, pcm: bytes, timestamp_us: int, duration_us: int) -> list[bytes]:  # noqa: ARG002
+    def process(self, pcm: bytes, timestamp_us: int, duration_us: int) -> list[tuple[bytes, int]]:  # noqa: ARG002
         """Chunk PCM into fixed-size frames.
 
         Args:
@@ -80,7 +82,7 @@ class PcmPassthrough:
             duration_us: Duration of this chunk in microseconds (unused).
 
         Returns:
-            List of fixed-size PCM frames. May be empty if buffering.
+            List of `(frame_bytes, frame_duration_us)` pairs. May be empty if buffering.
         """
         # Detect production gaps: if input timestamp jumped by >1.5s, reset timeline
         # This handles cases where audio production stopped and resumed
@@ -99,24 +101,25 @@ class PcmPassthrough:
             self._pending_timestamp_us = timestamp_us
 
         self._buffer.extend(pcm)
-        frames: list[bytes] = []
+        frames: list[tuple[bytes, int]] = []
 
         while len(self._buffer) >= self._frame_size:
             frame = bytes(self._buffer[: self._frame_size])
             del self._buffer[: self._frame_size]
-            frames.append(frame)
             # Advance pending timestamp using rational arithmetic. Each frame
             # represents exactly `chunk_samples / sample_rate` seconds. Tracking
             # the residue avoids the systematic per-frame drift that occurs when
-            # `chunk_samples * 1_000_000` is not divisible by `sample_rate`.
+            # `chunk_samples * 1_000_000` is not divisible by `sample_rate`. The
+            # same delta is reported as the frame's wire duration.
+            self._ts_residue += self._chunk_samples * 1_000_000
+            delta_us, self._ts_residue = divmod(self._ts_residue, self._sample_rate)
             if self._pending_timestamp_us is not None:
-                self._ts_residue += self._chunk_samples * 1_000_000
-                delta_us, self._ts_residue = divmod(self._ts_residue, self._sample_rate)
                 self._pending_timestamp_us += delta_us
+            frames.append((frame, delta_us))
 
         return frames
 
-    def flush(self) -> list[bytes]:
+    def flush(self) -> list[tuple[bytes, int]]:
         """Flush remaining buffered audio, padded with silence.
 
         Returns:
@@ -130,9 +133,12 @@ class PcmPassthrough:
         self._buffer.extend(bytes(padding_needed))
         frame = bytes(self._buffer)
         self._buffer.clear()
+        # Same residue-aware advance as `process` so cumulative dur stays exact.
+        self._ts_residue += self._chunk_samples * 1_000_000
+        delta_us, self._ts_residue = divmod(self._ts_residue, self._sample_rate)
         self._pending_timestamp_us = None
         self._ts_residue = 0
-        return [frame]
+        return [(frame, delta_us)]
 
     def get_header(self) -> bytes | None:
         """No codec header for raw PCM."""
@@ -187,6 +193,8 @@ class FlacEncoder:
         self._chunks_encoded_total: int = 0
         # Track last input timestamp to detect production gaps
         self._last_input_timestamp_us: int | None = None
+        # Residue for drift-free per-frame duration (matches PcmPassthrough).
+        self._dur_residue: int = 0
 
     @property
     def frame_duration_us(self) -> int:
@@ -231,7 +239,7 @@ class FlacEncoder:
         # regardless of what input frame sizes we use.
         if self._encoder.frame_size:
             self._chunk_samples = self._encoder.frame_size
-            self._chunk_duration_us = int(self._chunk_samples / self._sample_rate * 1_000_000)
+            self._chunk_duration_us = self._chunk_samples * 1_000_000 // self._sample_rate
 
         header = bytes(self._encoder.extradata) if self._encoder.extradata else b""
         if header:
@@ -265,7 +273,7 @@ class FlacEncoder:
             output.extend(bytes(packet))
         return bytes(output)
 
-    def process(self, pcm: bytes, timestamp_us: int, duration_us: int) -> list[bytes]:  # noqa: ARG002
+    def process(self, pcm: bytes, timestamp_us: int, duration_us: int) -> list[tuple[bytes, int]]:  # noqa: ARG002
         """Encode PCM to FLAC frames.
 
         Args:
@@ -274,7 +282,7 @@ class FlacEncoder:
             duration_us: Duration of this chunk in microseconds (unused).
 
         Returns:
-            List of encoded FLAC frames. May be empty if buffering.
+            List of `(frame_bytes, frame_duration_us)` pairs. May be empty if buffering.
         """
         self._ensure_initialized()
 
@@ -288,6 +296,7 @@ class FlacEncoder:
                 self._output_frame_count = 0
                 self._first_input_timestamp_us = timestamp_us
                 self._chunks_encoded_total = 0
+                self._dur_residue = 0
         self._last_input_timestamp_us = timestamp_us
 
         # Track first input timestamp for encoder-delay compensation
@@ -295,7 +304,7 @@ class FlacEncoder:
             self._first_input_timestamp_us = timestamp_us
 
         self._buffer.extend(pcm)
-        frames: list[bytes] = []
+        frames: list[tuple[bytes, int]] = []
         chunk_size = self._chunk_samples * self._frame_stride
 
         while len(self._buffer) >= chunk_size:
@@ -316,13 +325,15 @@ class FlacEncoder:
                     self._stream_start_timestamp_us = self._first_input_timestamp_us + (
                         delay_samples * 1_000_000 // self._sample_rate
                     )
-                frames.append(encoded)
+                self._dur_residue += self._chunk_samples * 1_000_000
+                delta_us, self._dur_residue = divmod(self._dur_residue, self._sample_rate)
+                frames.append((encoded, delta_us))
                 # Count output frames for timestamp calculation
                 self._output_frame_count += 1
 
         return frames
 
-    def flush(self) -> list[bytes]:
+    def flush(self) -> list[tuple[bytes, int]]:
         """Flush remaining buffered audio, padded with silence.
 
         Returns:
@@ -343,7 +354,9 @@ class FlacEncoder:
         encoded = self._encode_chunk(chunk_pcm)
         if encoded:
             self._output_frame_count += 1
-            return [encoded]
+            self._dur_residue += self._chunk_samples * 1_000_000
+            delta_us, self._dur_residue = divmod(self._dur_residue, self._sample_rate)
+            return [(encoded, delta_us)]
         return []
 
     def get_header(self) -> bytes | None:
@@ -361,6 +374,7 @@ class FlacEncoder:
         self._first_input_timestamp_us = None
         self._chunks_encoded_total = 0
         self._last_input_timestamp_us = None
+        self._dur_residue = 0
 
 
 class OpusEncoder:
@@ -410,6 +424,8 @@ class OpusEncoder:
         self._last_input_timestamp_us: int | None = None
         # libopus codec lookahead, populated from the OpusHead pre_skip after open()
         self._lookahead_us: int = 0
+        # Residue for drift-free per-frame duration (matches PcmPassthrough).
+        self._dur_residue: int = 0
 
     @property
     def frame_duration_us(self) -> int:
@@ -445,7 +461,7 @@ class OpusEncoder:
         # Opus typically uses 960 samples = 20ms at 48kHz
         if self._encoder.frame_size:
             self._chunk_samples = self._encoder.frame_size
-            self._chunk_duration_us = int(self._chunk_samples / self._sample_rate * 1_000_000)
+            self._chunk_duration_us = self._chunk_samples * 1_000_000 // self._sample_rate
 
         # Extract libopus's encoder lookahead from the OpusHead pre_skip field
         # so the stream anchor can be shifted earlier to keep decoded audio aligned
@@ -490,7 +506,7 @@ class OpusEncoder:
             output.extend(bytes(packet))
         return bytes(output)
 
-    def process(self, pcm: bytes, timestamp_us: int, duration_us: int) -> list[bytes]:  # noqa: ARG002
+    def process(self, pcm: bytes, timestamp_us: int, duration_us: int) -> list[tuple[bytes, int]]:  # noqa: ARG002
         """Encode PCM to Opus frames.
 
         Args:
@@ -499,7 +515,7 @@ class OpusEncoder:
             duration_us: Duration of this chunk in microseconds (unused).
 
         Returns:
-            List of encoded Opus frames. May be empty if buffering.
+            List of `(frame_bytes, frame_duration_us)` pairs. May be empty if buffering.
         """
         self._ensure_initialized()
 
@@ -512,6 +528,7 @@ class OpusEncoder:
                 self._output_frame_count = 0
                 self._first_input_timestamp_us = timestamp_us
                 self._chunks_encoded_total = 0
+                self._dur_residue = 0
         self._last_input_timestamp_us = timestamp_us
 
         # Track first input timestamp for encoder-delay compensation
@@ -519,7 +536,7 @@ class OpusEncoder:
             self._first_input_timestamp_us = timestamp_us
 
         self._buffer.extend(pcm)
-        frames: list[bytes] = []
+        frames: list[tuple[bytes, int]] = []
         chunk_size = self._chunk_samples * self._frame_stride
 
         while len(self._buffer) >= chunk_size:
@@ -539,12 +556,14 @@ class OpusEncoder:
                         + (delay_samples * 1_000_000 // self._sample_rate)
                         - self._lookahead_us
                     )
-                frames.append(encoded)
+                self._dur_residue += self._chunk_samples * 1_000_000
+                delta_us, self._dur_residue = divmod(self._dur_residue, self._sample_rate)
+                frames.append((encoded, delta_us))
                 self._output_frame_count += 1
 
         return frames
 
-    def flush(self) -> list[bytes]:
+    def flush(self) -> list[tuple[bytes, int]]:
         """Flush remaining buffered audio, padded with silence.
 
         Returns:
@@ -565,7 +584,9 @@ class OpusEncoder:
         encoded = self._encode_chunk(chunk_pcm)
         if encoded:
             self._output_frame_count += 1
-            return [encoded]
+            self._dur_residue += self._chunk_samples * 1_000_000
+            delta_us, self._dur_residue = divmod(self._dur_residue, self._sample_rate)
+            return [(encoded, delta_us)]
         return []
 
     def get_header(self) -> bytes | None:
@@ -583,3 +604,4 @@ class OpusEncoder:
         self._chunks_encoded_total = 0
         self._last_input_timestamp_us = None
         self._lookahead_us = 0
+        self._dur_residue = 0

--- a/tests/server/test_audio_transformers.py
+++ b/tests/server/test_audio_transformers.py
@@ -527,10 +527,10 @@ class TestTransformerPool:
             def frame_duration_us(self) -> int:
                 return 25_000
 
-            def process(self, pcm: bytes, _ts: int, _dur: int) -> list[bytes]:
-                return [pcm]
+            def process(self, pcm: bytes, _ts: int, _dur: int) -> list[tuple[bytes, int]]:
+                return [(pcm, 25_000)]
 
-            def flush(self) -> list[bytes]:
+            def flush(self) -> list[tuple[bytes, int]]:
                 return []
 
             def get_header(self) -> bytes | None:
@@ -569,7 +569,7 @@ class TestFlacEncoder:
         # 25ms of silence at 48kHz stereo 16-bit = 1200 samples * 4 bytes = 4800 bytes
         # Send multiple chunks to ensure encoder produces output (FLAC buffers initial frames)
         pcm = bytes(4800)
-        total_output: list[bytes] = []
+        total_output: list[tuple[bytes, int]] = []
         for i in range(4):
             result = encoder.process(pcm, timestamp_us=i * 25_000, duration_us=25_000)
             total_output.extend(result)
@@ -580,7 +580,7 @@ class TestFlacEncoder:
         encoder = FlacEncoder(sample_rate=48000, bit_depth=32, channels=2)
         # 25ms at 48kHz stereo 32-bit: 1200 samples * 8 bytes = 9600 bytes.
         pcm = bytes(9600)
-        total_output: list[bytes] = []
+        total_output: list[tuple[bytes, int]] = []
         for i in range(4):
             result = encoder.process(pcm, timestamp_us=i * 25_000, duration_us=25_000)
             total_output.extend(result)
@@ -620,7 +620,7 @@ class TestFlacEncoder:
         # FLAC codec buffers ~4 frames before emitting output
         # Feed enough frames to guarantee output
         pcm = bytes(4800)  # 25ms per chunk
-        all_results: list[bytes] = []
+        all_results: list[tuple[bytes, int]] = []
         for i in range(8):  # 200ms total
             result = encoder.process(pcm, timestamp_us=i * 25_000, duration_us=25_000)
             assert isinstance(result, list)

--- a/tests/server/test_audio_transformers.py
+++ b/tests/server/test_audio_transformers.py
@@ -27,10 +27,12 @@ class TestAudioTransformerProtocol:
             def frame_duration_us(self) -> int:
                 return 25_000
 
-            def process(self, pcm: bytes, _timestamp_us: int, _duration_us: int) -> list[bytes]:
-                return [pcm]
+            def process(
+                self, pcm: bytes, _timestamp_us: int, _duration_us: int
+            ) -> list[tuple[bytes, int]]:
+                return [(pcm, 25_000)]
 
-            def flush(self) -> list[bytes]:
+            def flush(self) -> list[tuple[bytes, int]]:
                 return []
 
             def reset(self) -> None:
@@ -38,7 +40,7 @@ class TestAudioTransformerProtocol:
 
         # Should be recognized as implementing the protocol
         transformer: AudioTransformer = ValidTransformer()
-        assert transformer.process(b"test", 0, 1000) == [b"test"]
+        assert transformer.process(b"test", 0, 1000) == [(b"test", 25_000)]
 
     def test_protocol_defines_reset_method(self) -> None:
         """AudioTransformer requires reset() method."""
@@ -51,10 +53,12 @@ class TestAudioTransformerProtocol:
             def frame_duration_us(self) -> int:
                 return 25_000
 
-            def process(self, pcm: bytes, _timestamp_us: int, _duration_us: int) -> list[bytes]:
-                return [pcm]
+            def process(
+                self, pcm: bytes, _timestamp_us: int, _duration_us: int
+            ) -> list[tuple[bytes, int]]:
+                return [(pcm, 25_000)]
 
-            def flush(self) -> list[bytes]:
+            def flush(self) -> list[tuple[bytes, int]]:
                 return []
 
             def reset(self) -> None:
@@ -72,10 +76,12 @@ class TestAudioTransformerProtocol:
             def frame_duration_us(self) -> int:
                 return 25_000
 
-            def process(self, pcm: bytes, _timestamp_us: int, _duration_us: int) -> list[bytes]:
-                return [pcm]
+            def process(
+                self, pcm: bytes, _timestamp_us: int, _duration_us: int
+            ) -> list[tuple[bytes, int]]:
+                return [(pcm, 25_000)]
 
-            def flush(self) -> list[bytes]:
+            def flush(self) -> list[tuple[bytes, int]]:
                 return []
 
             def reset(self) -> None:
@@ -92,17 +98,19 @@ class TestAudioTransformerProtocol:
             def frame_duration_us(self) -> int:
                 return 25_000
 
-            def process(self, pcm: bytes, _timestamp_us: int, _duration_us: int) -> list[bytes]:
-                return [pcm]
+            def process(
+                self, pcm: bytes, _timestamp_us: int, _duration_us: int
+            ) -> list[tuple[bytes, int]]:
+                return [(pcm, 25_000)]
 
-            def flush(self) -> list[bytes]:
-                return [b"final"]
+            def flush(self) -> list[tuple[bytes, int]]:
+                return [(b"final", 25_000)]
 
             def reset(self) -> None:
                 pass
 
         transformer: AudioTransformer = TransformerWithFlush()
-        assert transformer.flush() == [b"final"]
+        assert transformer.flush() == [(b"final", 25_000)]
 
 
 class TestPcmPassthrough:
@@ -137,7 +145,7 @@ class TestPcmPassthrough:
         result = transformer.process(pcm, timestamp_us=0, duration_us=25_000)
         assert isinstance(result, list)
         assert len(result) == 1
-        assert result[0] == pcm
+        assert result[0] == (pcm, 25_000)
 
     def test_passthrough_splits_large_input(self) -> None:
         """PcmPassthrough splits large input into multiple frames."""
@@ -145,8 +153,8 @@ class TestPcmPassthrough:
         pcm = bytes(9600)  # 50ms = 2 frames
         result = transformer.process(pcm, timestamp_us=0, duration_us=50_000)
         assert len(result) == 2
-        assert len(result[0]) == 4800
-        assert len(result[1]) == 4800
+        assert len(result[0][0]) == 4800
+        assert len(result[1][0]) == 4800
 
     def test_passthrough_buffers_incomplete_frame(self) -> None:
         """PcmPassthrough buffers incomplete frames."""
@@ -164,7 +172,7 @@ class TestPcmPassthrough:
             bytes(2880), timestamp_us=15_000, duration_us=15_000
         )  # +15ms = 30ms total
         assert len(result2) == 1
-        assert len(result2[0]) == 4800
+        assert len(result2[0][0]) == 4800
 
     def test_passthrough_flush_emits_remainder_padded(self) -> None:
         """PcmPassthrough flush emits remaining buffer padded with silence."""
@@ -172,7 +180,7 @@ class TestPcmPassthrough:
         transformer.process(bytes(1920), timestamp_us=0, duration_us=10_000)
         result = transformer.flush()
         assert len(result) == 1
-        assert len(result[0]) == 4800  # Padded to 25ms
+        assert len(result[0][0]) == 4800  # Padded to 25ms
 
     def test_passthrough_flush_empty_buffer(self) -> None:
         """PcmPassthrough flush returns empty list when buffer is empty."""

--- a/tests/server/test_audio_transformers.py
+++ b/tests/server/test_audio_transformers.py
@@ -254,6 +254,37 @@ class TestPcmPassthroughTimestampDrift:
         assert len(result) == 1
         # Pending advances by `1102 * 1_000_000 // 44100` = 24988 µs (NOT 25000)
         assert transformer.pending_timestamp_us == 24988
+        # Wire duration on returned tuple matches advance — no scalar 25_000.
+        assert result[0][1] == 24988
+
+    def test_passthrough_44100_returned_dur_alternates(self) -> None:
+        """Per-frame returned `frame_duration_us` alternates 24988/24989 at 44.1k.
+
+        Guards against regression where pending advances correctly via residue
+        but the emitted tuple reports a stale scalar `chunk_duration_us`.
+        """
+        transformer = PcmPassthrough(sample_rate=44100, bit_depth=16, channels=2)
+        chunk_samples = 1102
+        frame_size = chunk_samples * 4  # stereo s16
+        n = 1000
+        durs: list[int] = []
+        ts_residue = 0
+        ts = 0
+        while len(durs) < n:
+            for _, dur in transformer.process(
+                bytes(frame_size), timestamp_us=ts, duration_us=25_000
+            ):
+                durs.append(dur)
+            ts_residue += chunk_samples * 1_000_000
+            delta, ts_residue = divmod(ts_residue, 44100)
+            ts += delta
+        # Every per-frame duration is exactly one of the two valid divmod outputs.
+        assert set(durs) <= {24988, 24989}, (
+            f"unexpected per-frame durs: {set(durs) - {24988, 24989}}"
+        )
+        # Cumulative duration matches sample-derived elapsed time exactly.
+        expected = n * chunk_samples * 1_000_000 // 44100
+        assert sum(durs) == expected, f"sum(durs)={sum(durs)} expected={expected}"
 
     def test_passthrough_44100_no_drift_after_one_thousand_frames(self) -> None:
         """After 1000 frames at 44.1k, pending matches sample-derived elapsed time exactly."""

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -675,10 +675,10 @@ async def test_pcm_cache_catchup_for_uncached_codec() -> None:
         def frame_duration_us(self) -> int:
             return 25_000
 
-        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[bytes]:
-            return [pcm]
+        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[tuple[bytes, int]]:
+            return [(pcm, 25_000)]
 
-        def flush(self) -> list[bytes]:
+        def flush(self) -> list[tuple[bytes, int]]:
             return []
 
         def get_header(self) -> bytes | None:
@@ -752,10 +752,10 @@ async def test_non_main_pcm_catchup_does_not_anchor_to_far_channel_tail() -> Non
         def frame_duration_us(self) -> int:
             return 25_000
 
-        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[bytes]:
-            return [pcm]
+        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[tuple[bytes, int]]:
+            return [(pcm, 25_000)]
 
-        def flush(self) -> list[bytes]:
+        def flush(self) -> list[tuple[bytes, int]]:
             return []
 
         def get_header(self) -> bytes | None:
@@ -841,10 +841,10 @@ async def test_non_main_join_without_cache_rebases_far_ahead_tail() -> None:
         def frame_duration_us(self) -> int:
             return 25_000
 
-        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[bytes]:
-            return [pcm]
+        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[tuple[bytes, int]]:
+            return [(pcm, 25_000)]
 
-        def flush(self) -> list[bytes]:
+        def flush(self) -> list[tuple[bytes, int]]:
             return []
 
         def get_header(self) -> bytes | None:
@@ -954,11 +954,11 @@ async def test_transform_dedup_uses_transform_key_not_instance(mock_loop: Any) -
         def frame_duration_us(self) -> int:
             return self._frame_duration_us
 
-        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[bytes]:
+        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[tuple[bytes, int]]:
             CountingTransformer.calls += 1
-            return [pcm]
+            return [(pcm, self._frame_duration_us)]
 
-        def flush(self) -> list[bytes]:
+        def flush(self) -> list[tuple[bytes, int]]:
             return []
 
         def get_header(self) -> bytes | None:
@@ -1016,11 +1016,11 @@ async def test_transform_key_separates_frame_duration(mock_loop: Any) -> None:
         def frame_duration_us(self) -> int:
             return self._frame_duration_us
 
-        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[bytes]:
+        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[tuple[bytes, int]]:
             CountingTransformer.calls += 1
-            return [pcm]
+            return [(pcm, self._frame_duration_us)]
 
-        def flush(self) -> list[bytes]:
+        def flush(self) -> list[tuple[bytes, int]]:
             return []
 
         def get_header(self) -> bytes | None:
@@ -1077,10 +1077,10 @@ async def test_long_gap_reset_is_handled_in_push_stream() -> None:
         def frame_duration_us(self) -> int:
             return 25_000
 
-        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[bytes]:
-            return [pcm]
+        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[tuple[bytes, int]]:
+            return [(pcm, 25_000)]
 
-        def flush(self) -> list[bytes]:
+        def flush(self) -> list[tuple[bytes, int]]:
             return []
 
         def get_header(self) -> bytes | None:
@@ -1132,10 +1132,10 @@ async def test_medium_gap_does_not_reset_transformer() -> None:
         def frame_duration_us(self) -> int:
             return 25_000
 
-        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[bytes]:
-            return [pcm]
+        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[tuple[bytes, int]]:
+            return [(pcm, 25_000)]
 
-        def flush(self) -> list[bytes]:
+        def flush(self) -> list[tuple[bytes, int]]:
             return []
 
         def get_header(self) -> bytes | None:
@@ -1184,10 +1184,10 @@ async def test_late_join_uses_cached_chunks_across_role_recreation(mock_loop: An
         def frame_duration_us(self) -> int:
             return 25_000
 
-        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[bytes]:
-            return [pcm]
+        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[tuple[bytes, int]]:
+            return [(pcm, 25_000)]
 
-        def flush(self) -> list[bytes]:
+        def flush(self) -> list[tuple[bytes, int]]:
             return []
 
         def get_header(self) -> bytes | None:
@@ -1283,11 +1283,11 @@ async def test_stop_flush_fans_out_to_all_roles(mock_loop: Any) -> None:
         def frame_duration_us(self) -> int:
             return 25_000
 
-        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[bytes]:
-            return [pcm]
+        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[tuple[bytes, int]]:
+            return [(pcm, 25_000)]
 
-        def flush(self) -> list[bytes]:
-            return [b"final"]
+        def flush(self) -> list[tuple[bytes, int]]:
+            return [(b"final", 25_000)]
 
         def get_header(self) -> bytes | None:
             return None
@@ -1340,11 +1340,11 @@ async def test_transform_key_separates_channels(mock_loop: Any) -> None:
         def frame_duration_us(self) -> int:
             return self._frame_duration_us
 
-        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[bytes]:
+        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[tuple[bytes, int]]:
             CountingTransformer.calls += 1
-            return [pcm]
+            return [(pcm, self._frame_duration_us)]
 
-        def flush(self) -> list[bytes]:
+        def flush(self) -> list[tuple[bytes, int]]:
             return []
 
         def get_header(self) -> bytes | None:
@@ -2258,10 +2258,10 @@ async def test_catchup_quantizer_does_not_share_live_cache(
         def frame_duration_us(self) -> int:
             return 25_000
 
-        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[bytes]:
-            return [pcm]
+        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[tuple[bytes, int]]:
+            return [(pcm, 25_000)]
 
-        def flush(self) -> list[bytes]:
+        def flush(self) -> list[tuple[bytes, int]]:
             return []
 
         def get_header(self) -> bytes | None:
@@ -2999,19 +2999,19 @@ async def test_catchup_drain_advances_encoder_pending_to_live_tip() -> None:
         def frame_duration_us(self) -> int:
             return 25_000
 
-        def process(self, pcm: bytes, ts: int, _dur: int) -> list[bytes]:
+        def process(self, pcm: bytes, ts: int, _dur: int) -> list[tuple[bytes, int]]:
             if self.pending_timestamp_us is None:
                 self.pending_timestamp_us = ts
             self._buffer.extend(pcm)
-            frames: list[bytes] = []
+            frames: list[tuple[bytes, int]] = []
             while len(self._buffer) >= self._frame_size:
-                frames.append(bytes(self._buffer[: self._frame_size]))
+                frames.append((bytes(self._buffer[: self._frame_size]), 25_000))
                 del self._buffer[: self._frame_size]
                 if self.pending_timestamp_us is not None:
                     self.pending_timestamp_us += 25_000
             return frames
 
-        def flush(self) -> list[bytes]:
+        def flush(self) -> list[tuple[bytes, int]]:
             return []
 
         def get_header(self) -> bytes | None:
@@ -3097,10 +3097,10 @@ async def test_catchup_mid_pass_format_change_keeps_chunks_ordered() -> None:
         def frame_duration_us(self) -> int:
             return 25_000
 
-        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[bytes]:
-            return [pcm]
+        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[tuple[bytes, int]]:
+            return [(pcm, 25_000)]
 
-        def flush(self) -> list[bytes]:
+        def flush(self) -> list[tuple[bytes, int]]:
             return []
 
         def get_header(self) -> bytes | None:


### PR DESCRIPTION
At non-divisible rates (e.g. 44.1kHz/25ms → 1102 samples = 24988.66µs), `PcmPassthrough`/`FlacEncoder`/`OpusEncoder` advertised the requested 25000µs, accumulating ~454µs/s drift in client-side buffer accounting (~1.6s/hour).

`AudioTransformer.process()`/`flush()` now return `(frame_bytes, frame_duration_us)` pairs; per-frame duration comes from the same residue accumulator used for `pending_timestamp_us`, so cumulative duration tracks sample-derived elapsed time exactly. Cleanly-dividing rates (e.g. 48k/25ms) are unchanged.

Technically a breaking change for third-party `AudioTransformer` implementers, but neither cli or MA implement custom ones.