### PR TITLE
Allow keeping the Sendspin stream open after a `PushStream.stop()`

### DIFF
--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -2451,7 +2451,9 @@ class PushStream:
         Resets transformers and sends stream/end via role hooks. Pass
         ``keep_stream=True`` to skip the stream/end emission when the
         caller will immediately create a new PushStream and wants clients
-        to treat the transition as continuous.
+        to treat the transition as continuous. In that case, call
+        ``clear()`` first if buffered client audio should be discarded
+        before the successor PushStream takes over.
 
         Does not change the owning group's logical playback state. Call
         group.stop() to stop transport and also set playback state to STOPPED.

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -2443,17 +2443,18 @@ class PushStream:
         self._catchup_state.clear()
         self._catchup_roles.clear()
 
-    def stop(self) -> None:
+    def stop(self, *, keep_stream: bool = False) -> None:
         """
         Stop only this PushStream transport.
 
         After calling stop(), commit_audio() will raise StreamStoppedError.
-        Resets transformers and sends stream/end to all roles via hooks.
+        Resets transformers and sends stream/end via role hooks. Pass
+        ``keep_stream=True`` to skip the stream/end emission when the
+        caller will immediately create a new PushStream and wants clients
+        to treat the transition as continuous.
 
-        This does not change the owning group's logical playback state.
-        Use this when you are about to immediately start another stream and
-        want clients to remain in PLAYING state during the transition.
-        Call group.stop() to stop transport and also set playback state to STOPPED.
+        Does not change the owning group's logical playback state. Call
+        group.stop() to stop transport and also set playback state to STOPPED.
         """
         if self._is_stopped:
             return
@@ -2471,9 +2472,10 @@ class PushStream:
         for transformer in transformers_by_key.values():
             transformer.reset()
 
-        # Send stream/end to all roles with audio requirements via hooks
-        for _client, role in self._get_audio_roles():
-            role.on_stream_end()
+        if not keep_stream:
+            # Send stream/end to all roles with audio requirements via hooks
+            for _client, role in self._get_audio_roles():
+                role.on_stream_end()
 
         # Clear role tracking state
         self._started_roles.clear()
@@ -2489,8 +2491,8 @@ class PushStream:
         """
         Clear all pending audio and reset timing.
 
-        This is used for seek operations where buffered audio is discarded.
-        Sends stream/clear to all roles via hooks.
+        This is used for seek operations or track changes where buffered
+        audio is discarded. Sends stream/clear to all roles via hooks.
         """
         # Clear pending audio
         self._channel_buffers.clear()

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -664,6 +664,42 @@ async def test_stop_resets_transformers_without_delivering_tail_frames(mock_loop
 
 
 @pytest.mark.asyncio
+async def test_clear_does_not_send_stream_end(mock_loop: Any) -> None:
+    """Clear must not emit stream/end (spec forbids it during transitions)."""
+    group = _DummyGroup(clients=[])
+    _, conn = _make_connected_player(mock_loop, group, "p1")
+
+    stream = PushStream(loop=mock_loop, clock=LoopClock(mock_loop), group=group)
+    stream.prepare_audio(
+        bytes(4800),
+        AudioFormat(sample_rate=48000, bit_depth=16, channels=2),
+    )
+    await stream.commit_audio()
+
+    stream.clear()
+    assert not any(isinstance(m, StreamEndMessage) for m in conn.sent_json)
+
+
+@pytest.mark.asyncio
+async def test_stop_with_keep_stream_suppresses_stream_end(mock_loop: Any) -> None:
+    """stop(keep_stream=True) tears down transport without emitting stream/end."""
+    group = _DummyGroup(clients=[])
+    _, conn = _make_connected_player(mock_loop, group, "p1")
+
+    stream = PushStream(loop=mock_loop, clock=LoopClock(mock_loop), group=group)
+    stream.prepare_audio(
+        bytes(4800),
+        AudioFormat(sample_rate=48000, bit_depth=16, channels=2),
+    )
+    await stream.commit_audio()
+
+    stream.stop(keep_stream=True)
+
+    assert stream.is_stopped
+    assert not any(isinstance(m, StreamEndMessage) for m in conn.sent_json)
+
+
+@pytest.mark.asyncio
 async def test_transient_disconnect_keeps_role_in_audio_pipeline(mock_loop: Any) -> None:
     """Transient disconnect keeps role processing active, but transport send remains no-op."""
     group = _DummyGroup(clients=[])


### PR DESCRIPTION
While the Sendspin specification has a `stream/clear` message that is
meant for seek operations, `aiosendspin` provided no way to replace
a `PushStream` without emitting `stream/end`.

Servers like Music Assistant therefore sent `stream/end` followed by
`stream/start` on seeks and other immediate stream replacements.

This PR lets callers tear down the transport without emitting
`stream/end` so a new `PushStream` can be created without notifying
clients that playback ended.

Related:
- https://github.com/Sendspin/spec/pull/83