### PR TITLE
Drop dead tail flush from `PushStream.stop()`

### DIFF
--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -2448,8 +2448,7 @@ class PushStream:
         Stop only this PushStream transport.
 
         After calling stop(), commit_audio() will raise StreamStoppedError.
-        Flushes remaining audio from transformers, then sends stream/end message
-        to all roles via hooks.
+        Resets transformers and sends stream/end to all roles via hooks.
 
         This does not change the owning group's logical playback state.
         Use this when you are about to immediately start another stream and
@@ -2461,29 +2460,15 @@ class PushStream:
         self._is_stopped = True
         self._stream_generation += 1
 
-        # Flush remaining audio from transformers and reset them
-        roles_by_transform: defaultdict[TransformKey, list[Role]] = defaultdict(list)
+        # Reset transformers so any internal encoder state is discarded.
         transformers_by_key: dict[TransformKey, AudioTransformer] = {}
         for _client, role in self._get_audio_roles():
             req = role.get_audio_requirements()
             if req and req.transformer:
                 channel_id = req.channel_id or MAIN_CHANNEL
                 tkey = self._build_transform_key(req, channel_id, role)
-                roles_by_transform[tkey].append(role)
                 transformers_by_key.setdefault(tkey, req.transformer)
-
-        for tkey, transformer in transformers_by_key.items():
-            final_frames = transformer.flush()
-            if final_frames:
-                for frame_data, frame_duration_us in final_frames:
-                    chunk = AudioChunk(
-                        data=frame_data,
-                        timestamp_us=0,  # Timestamp doesn't matter at stream end
-                        duration_us=frame_duration_us,
-                        byte_count=len(frame_data),
-                    )
-                    for role in roles_by_transform.get(tkey, []):
-                        role.on_audio_chunk(chunk)
+        for transformer in transformers_by_key.values():
             transformer.reset()
 
         # Send stream/end to all roles with audio requirements via hooks

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -614,6 +614,56 @@ async def test_clear_sends_stream_clear(mock_loop: Any) -> None:
 
 
 @pytest.mark.asyncio
+async def test_stop_resets_transformers_without_delivering_tail_frames(mock_loop: Any) -> None:
+    """stop() resets transformers but never delivers flushed tail frames.
+
+    Flushed frames carry timestamp_us=0, which has no scheduling
+    semantics, so emitting them would only pollute the client's
+    buffer tracker without serving any playback purpose.
+    """
+    reset_calls = 0
+
+    class FlushingTransformer:
+        pending_timestamp_us: int | None = None
+
+        @property
+        def frame_duration_us(self) -> int:
+            return 25_000
+
+        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[tuple[bytes, int]]:
+            return [(pcm, 25_000)]
+
+        def flush(self) -> list[tuple[bytes, int]]:
+            return [(b"tail", 25_000)]
+
+        def get_header(self) -> bytes | None:
+            return None
+
+        def reset(self) -> None:
+            nonlocal reset_calls
+            reset_calls += 1
+
+    group = _DummyGroup(clients=[])
+    role = _DummyRole(
+        AudioRequirements(
+            sample_rate=48000,
+            bit_depth=16,
+            channels=2,
+            transformer=FlushingTransformer(),
+            channel_id=MAIN_CHANNEL,
+            frame_duration_us=25_000,
+        )
+    )
+    group.clients.append(_DummyClient([role]))
+
+    stream = PushStream(loop=mock_loop, clock=LoopClock(mock_loop), group=group)
+    stream.stop()
+
+    assert role.received == []
+    assert reset_calls == 1
+
+
+@pytest.mark.asyncio
 async def test_transient_disconnect_keeps_role_in_audio_pipeline(mock_loop: Any) -> None:
     """Transient disconnect keeps role processing active, but transport send remains no-op."""
     group = _DummyGroup(clients=[])
@@ -1270,59 +1320,6 @@ async def test_send_cached_chunks_keeps_chunk_overlapping_now(mock_loop: Any) ->
     )
     assert len(role.received) == 2
     assert role.received[0].timestamp_us == overlapping.timestamp_us
-
-
-@pytest.mark.asyncio
-async def test_stop_flush_fans_out_to_all_roles(mock_loop: Any) -> None:
-    """stop() flush frames to all roles sharing a TransformKey."""
-
-    class FlushingTransformer:
-        pending_timestamp_us: int | None = None
-
-        @property
-        def frame_duration_us(self) -> int:
-            return 25_000
-
-        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[tuple[bytes, int]]:
-            return [(pcm, 25_000)]
-
-        def flush(self) -> list[tuple[bytes, int]]:
-            return [(b"final", 25_000)]
-
-        def get_header(self) -> bytes | None:
-            return None
-
-        def reset(self) -> None:
-            return
-
-    group = _DummyGroup(clients=[])
-    role1 = _DummyRole(
-        AudioRequirements(
-            sample_rate=48000,
-            bit_depth=16,
-            channels=2,
-            transformer=FlushingTransformer(),
-            channel_id=MAIN_CHANNEL,
-            frame_duration_us=25_000,
-        )
-    )
-    role2 = _DummyRole(
-        AudioRequirements(
-            sample_rate=48000,
-            bit_depth=16,
-            channels=2,
-            transformer=FlushingTransformer(),
-            channel_id=MAIN_CHANNEL,
-            frame_duration_us=25_000,
-        )
-    )
-    group.clients.extend([_DummyClient([role1]), _DummyClient([role2])])
-
-    stream = PushStream(loop=mock_loop, clock=LoopClock(mock_loop), group=group)
-    stream.stop()
-
-    assert len(role1.received) == 1
-    assert len(role2.received) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The flush loop in `PushStream.stop()` produced transformer tail frames
with `timestamp_us=0`, which the connection layer late-dropped before
reaching any client.

Removing it also closes a bug with #237, where the `PushStream` can be stopped without emitting `stream/end`. In that case those audio chunks would land on the active timeline instead of being discarded by the `stream/end`.