### PR TITLE
Preserve `stream/start` config across `stream/clear`

### DIFF
--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -2496,6 +2496,10 @@ class PushStream:
         This is used for seek operations or track changes where buffered
         audio is discarded. Sends stream/clear to all roles via hooks.
         """
+        # Bump the stream generation so any in-flight commit_audio()
+        # coroutine bails out before delivering chunks under the new epoch.
+        self._stream_generation += 1
+
         # Clear pending audio
         self._channel_buffers.clear()
         self._historical_buffers.clear()

--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -109,6 +109,8 @@ class PlayerV1Role(Role):
         self._cached_state: PlayerPersistentState | None = None
         # Deferred stream start: set True by on_stream_start(), sent on first audio chunk
         self._pending_stream_start = False
+        # Last format announced to the client via stream/start.
+        self._last_sent_format: tuple[AudioCodec, int, int, int, str | None] | None = None
 
     @property
     def role_id(self) -> str:
@@ -188,6 +190,7 @@ class PlayerV1Role(Role):
         """Reset stream state and subscribe to PlayerGroupRole."""
         self._subscribe_to_group_role()
         self._stream_started = False
+        self._last_sent_format = None
         state = self._state()
         if state.buffer_reset_handle is not None:
             state.buffer_reset_handle.cancel()
@@ -204,6 +207,7 @@ class PlayerV1Role(Role):
         """Clean up, apply delayed buffer reset policy, and unsubscribe from PlayerGroupRole."""
         self._unsubscribe_from_group_role()
         self._stream_started = False
+        self._last_sent_format = None
 
         state = self._state()
         state.disconnect_time_us = self._client._server.clock.now_us()  # noqa: SLF001
@@ -244,6 +248,7 @@ class PlayerV1Role(Role):
             state.buffer_tracker.reset()
         self._stream_started = False
         self._pending_stream_start = False
+        self._last_sent_format = None
         self.reset_binary_timing()
         self._ensure_audio_requirements(force=True)
 
@@ -271,7 +276,11 @@ class PlayerV1Role(Role):
         self._pending_stream_start = True
 
     def _send_stream_start_message(self) -> None:
-        """Send stream/start message with codec header from transformer."""
+        """Send stream/start message with codec header from transformer.
+
+        Skips the send when the client already has an active stream with
+        an identical format.
+        """
         req = self.get_audio_requirements()
         if req is None or not self.has_connection():
             return
@@ -288,6 +297,11 @@ class PlayerV1Role(Role):
         else:
             codec = AudioCodec.PCM
 
+        current_format = (codec, req.sample_rate, req.channels, req.bit_depth, header_b64)
+        if self._stream_started and self._last_sent_format == current_format:
+            # Client already configured for this exact format
+            return
+
         stream_start = StreamStartMessage(
             payload=StreamStartPayload(
                 player=StreamStartPlayer(
@@ -302,6 +316,7 @@ class PlayerV1Role(Role):
         self.send_message(stream_start)
         is_initial = not self._stream_started
         self._stream_started = True
+        self._last_sent_format = current_format
 
         # Allow client to process stream/start before first binary audio (initial only).
         if is_initial and self._buffer_tracker is not None:
@@ -314,7 +329,7 @@ class PlayerV1Role(Role):
             self._send_stream_start_message()
             self._pending_stream_start = False
 
-        # Guard against stale delivery after stream/end or stream/clear.
+        # Guard against stale delivery after stream/end.
         if not self._stream_started:
             if self.has_connection():
                 self._client._logger.debug(  # noqa: SLF001
@@ -343,13 +358,12 @@ class PlayerV1Role(Role):
         )
 
     def on_stream_clear(self) -> None:
-        """Send stream/clear and reset state."""
+        """Send stream/clear and reset buffer-tracking state."""
         if not self.has_connection():
             return
 
         stream_clear = StreamClearMessage(payload=StreamClearPayload(roles=["player"]))
         self.send_message(stream_clear)
-        self._stream_started = False
         self._pending_stream_start = False
         self.reset_binary_timing()
 
@@ -365,6 +379,7 @@ class PlayerV1Role(Role):
         self.send_message(stream_end)
         self._stream_started = False
         self._pending_stream_start = False
+        self._last_sent_format = None
         self.reset_binary_timing()
 
         if self._buffer_tracker is not None:

--- a/aiosendspin/server/roles/visualizer/v1.py
+++ b/aiosendspin/server/roles/visualizer/v1.py
@@ -120,7 +120,8 @@ class VisualizerV1Role(Role):
         self.reset_binary_timing()
         # stream/end clears client-side visualizer config, so resend stream/start
         # at each new stream boundary.
-        self._send_stream_start()
+        if not self._stream_started:
+            self._send_stream_start()
         req = self.get_audio_requirements()
         self._extractor = VisualizerFeatureExtractor(
             sample_rate=req.sample_rate,

--- a/tests/server/roles/test_player_v1.py
+++ b/tests/server/roles/test_player_v1.py
@@ -497,8 +497,13 @@ def test_player_role_on_stream_clear_sends_message() -> None:
     assert msg.payload.roles == ["player"]
 
 
-def test_player_role_on_stream_clear_resets_stream_started() -> None:
-    """on_stream_clear() resets _stream_started flag."""
+def test_player_role_on_stream_clear_keeps_stream_started() -> None:
+    """on_stream_clear() preserves _stream_started per spec.
+
+    stream/clear discards buffered audio but does not end the stream, so
+    the previously announced format stays valid and the role remains
+    "started" from the client's perspective.
+    """
     client = MagicMock()
     client.send_message = MagicMock()
 
@@ -509,7 +514,7 @@ def test_player_role_on_stream_clear_resets_stream_started() -> None:
 
     role.on_stream_clear()
 
-    assert role._stream_started is False  # noqa: SLF001
+    assert role._stream_started is True  # noqa: SLF001
 
 
 def test_player_role_on_stream_clear_resets_buffer_tracker() -> None:

--- a/tests/server/roles/visualizer/test_v1.py
+++ b/tests/server/roles/visualizer/test_v1.py
@@ -326,6 +326,24 @@ def test_visualizer_role_stream_start_is_resent_after_stream_end() -> None:
     assert len(stream_start_calls) == 2
 
 
+def test_visualizer_role_stream_start_skipped_after_stream_clear() -> None:
+    """stream/clear preserves stream/start config, so no resend is needed."""
+    client = _make_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+
+    role.on_stream_start()
+    role.on_stream_clear()
+    role.on_stream_start()
+
+    stream_start_calls = [
+        call
+        for call in client.send_role_message.call_args_list
+        if isinstance(call.args[1], StreamStartMessage)
+    ]
+    assert len(stream_start_calls) == 1
+
+
 def test_visualizer_role_resets_binary_timing_on_stream_start() -> None:
     """on_stream_start() resets binary timing for fresh grace window."""
     client = _make_client_stub()

--- a/tests/server/test_player_role_stream_messages.py
+++ b/tests/server/test_player_role_stream_messages.py
@@ -200,3 +200,109 @@ def test_player_role_on_audio_chunk_sends_binary() -> None:
 
     assert result is None
     client.send_binary.assert_called_once()
+
+
+def _stream_start_messages(client: MagicMock) -> list[StreamStartMessage]:
+    return [
+        call.args[1]
+        for call in client.send_role_message.call_args_list
+        if isinstance(call.args[1], StreamStartMessage)
+    ]
+
+
+def test_player_role_skips_redundant_stream_start_when_format_unchanged() -> None:
+    """Second on_stream_start with unchanged format must not re-emit stream/start.
+
+    Spec: stream/start during an active stream only updates configuration,
+    so re-sending an identical config is wasted traffic. Successor
+    PushStreams that preserve format should reach the client with no
+    intervening stream/start.
+    """
+    client = MagicMock()
+    client.send_role_message = MagicMock()
+    client.send_binary = MagicMock(return_value=True)
+
+    audio_req = AudioRequirements(
+        sample_rate=48000,
+        bit_depth=16,
+        channels=2,
+        transformer=PcmPassthrough(sample_rate=48000, bit_depth=16, channels=2),
+    )
+    role = PlayerV1Role(client=client, audio_requirements=audio_req)
+    role._client.connection = MagicMock()  # noqa: SLF001
+
+    # First cycle: initial stream/start.
+    role.on_stream_start()
+    chunk = AudioChunk(data=b"\x00" * 100, timestamp_us=0, duration_us=25000, byte_count=100)
+    role.on_audio_chunk(chunk)
+    assert len(_stream_start_messages(client)) == 1
+
+    # Simulate clear (per spec, leaves stream active) followed by a
+    # successor PushStream that re-triggers on_stream_start.
+    role.on_stream_clear()
+    role.on_stream_start()
+    role.on_audio_chunk(chunk)
+
+    # No second stream/start should have been emitted.
+    assert len(_stream_start_messages(client)) == 1
+
+
+def test_player_role_resends_stream_start_when_format_changes() -> None:
+    """Format change must emit a fresh stream/start carrying the new config."""
+    client = MagicMock()
+    client.send_role_message = MagicMock()
+    client.send_binary = MagicMock(return_value=True)
+
+    audio_req = AudioRequirements(
+        sample_rate=48000,
+        bit_depth=16,
+        channels=2,
+        transformer=PcmPassthrough(sample_rate=48000, bit_depth=16, channels=2),
+    )
+    role = PlayerV1Role(client=client, audio_requirements=audio_req)
+    role._client.connection = MagicMock()  # noqa: SLF001
+
+    role.on_stream_start()
+    chunk = AudioChunk(data=b"\x00" * 100, timestamp_us=0, duration_us=25000, byte_count=100)
+    role.on_audio_chunk(chunk)
+    assert len(_stream_start_messages(client)) == 1
+
+    # Swap to a different format (sample rate change).
+    role._audio_requirements = AudioRequirements(  # noqa: SLF001
+        sample_rate=44100,
+        bit_depth=16,
+        channels=2,
+        transformer=PcmPassthrough(sample_rate=44100, bit_depth=16, channels=2),
+    )
+    role.on_stream_start()
+    role.on_audio_chunk(chunk)
+
+    starts = _stream_start_messages(client)
+    assert len(starts) == 2
+    assert starts[1].payload.player.sample_rate == 44100
+
+
+def test_player_role_resends_stream_start_after_stream_end() -> None:
+    """stream/end clears last-sent format so the next stream/start fires again."""
+    client = MagicMock()
+    client.send_role_message = MagicMock()
+    client.send_binary = MagicMock(return_value=True)
+
+    audio_req = AudioRequirements(
+        sample_rate=48000,
+        bit_depth=16,
+        channels=2,
+        transformer=PcmPassthrough(sample_rate=48000, bit_depth=16, channels=2),
+    )
+    role = PlayerV1Role(client=client, audio_requirements=audio_req)
+    role._client.connection = MagicMock()  # noqa: SLF001
+
+    role.on_stream_start()
+    chunk = AudioChunk(data=b"\x00" * 100, timestamp_us=0, duration_us=25000, byte_count=100)
+    role.on_audio_chunk(chunk)
+    role.on_stream_end()
+
+    role.on_stream_start()
+    role.on_audio_chunk(chunk)
+
+    assert len(_stream_start_messages(client)) == 2

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -681,6 +681,65 @@ async def test_clear_does_not_send_stream_end(mock_loop: Any) -> None:
 
 
 @pytest.mark.asyncio
+async def test_clear_bumps_stream_generation(mock_loop: Any) -> None:
+    """clear() bumps stream_generation so in-flight commits bail out.
+
+    Without the bump, role state machines that preserve _stream_started
+    across stream/clear would deliver stale chunks from concurrent
+    commit_audio() coroutines after the clear takes effect.
+    """
+    group = _DummyGroup(clients=[])
+    _make_connected_player(mock_loop, group, "p1")
+
+    stream = PushStream(loop=mock_loop, clock=LoopClock(mock_loop), group=group)
+    before = stream._stream_generation  # noqa: SLF001
+    stream.clear()
+    assert stream._stream_generation == before + 1  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_clear_during_inflight_commit_suppresses_audio_delivery(mock_loop: Any) -> None:
+    """A clear() running during an in-flight commit must abort the delivery."""
+    group = _DummyGroup(clients=[])
+    _, conn = _make_connected_player(mock_loop, group, "p1")
+    stream = PushStream(loop=mock_loop, clock=LoopClock(mock_loop), group=group)
+
+    entered_delivery = asyncio.Event()
+    release_delivery = asyncio.Event()
+    original_deliver = stream._deliver_audio_to_roles  # noqa: SLF001
+
+    async def _gated_deliver(
+        prepared: dict[UUID, tuple[bytes, AudioFormat]],
+        channel_play_start: dict[UUID, int],
+        *,
+        commit_generation: int | None = None,
+    ) -> dict[object, list[CachedChunk]]:
+        entered_delivery.set()
+        await release_delivery.wait()
+        return await original_deliver(
+            prepared,
+            channel_play_start,
+            commit_generation=commit_generation,
+        )
+
+    stream._deliver_audio_to_roles = _gated_deliver  # type: ignore[method-assign]  # noqa: SLF001
+
+    stream.prepare_audio(
+        bytes(4800),
+        AudioFormat(sample_rate=48000, bit_depth=16, channels=2),
+    )
+    commit_task = asyncio.create_task(stream.commit_audio())
+    await asyncio.wait_for(entered_delivery.wait(), timeout=1.0)
+
+    stream.clear()
+    release_delivery.set()
+    await commit_task
+
+    assert any(isinstance(m, StreamClearMessage) for m in conn.sent_json)
+    assert not conn.sent_binary
+
+
+@pytest.mark.asyncio
 async def test_stop_with_keep_stream_suppresses_stream_end(mock_loop: Any) -> None:
     """stop(keep_stream=True) tears down transport without emitting stream/end."""
     group = _DummyGroup(clients=[])


### PR DESCRIPTION
Per the Sendspin spec, `stream/start` during an active stream is just a config update and `stream/clear` keeps the stream alive. Skip the redundant `stream/start` when the format hasn't changed across `clear()`.