### PR TITLE
Implement the `color@v1` role

### DIFF
--- a/aiosendspin/client/client.py
+++ b/aiosendspin/client/client.py
@@ -115,6 +115,9 @@ GroupUpdateCallback = Callable[[GroupUpdateServerPayload], None]
 # Callback invoked when controller state updates are received.
 ControllerStateCallback = Callable[[ServerStatePayload], None]
 
+# Callback invoked when server state color updates are received.
+ColorCallback = Callable[[ServerStatePayload], None]
+
 # Callback invoked when audio streaming begins.
 StreamStartCallback = Callable[[StreamStartMessage], None]
 
@@ -230,6 +233,8 @@ class SendspinClient:
     """Callbacks invoked on group/update messages."""
     _controller_callbacks: list[ControllerStateCallback]
     """Callbacks invoked on server/state messages."""
+    _color_callbacks: list[ColorCallback]
+    """Callbacks invoked on server/state messages with color."""
     _stream_start_callbacks: list[StreamStartCallback]
     """Callbacks invoked when a stream starts."""
     _server_hello_callbacks: list[ServerHelloCallback]
@@ -352,6 +357,7 @@ class SendspinClient:
         self._metadata_callbacks = []
         self._group_callbacks = []
         self._controller_callbacks = []
+        self._color_callbacks = []
         self._stream_start_callbacks = []
         self._server_hello_callbacks = []
         self._stream_end_callbacks = []
@@ -566,6 +572,17 @@ class SendspinClient:
             self._controller_callbacks.remove(callback)
             if callback in self._controller_callbacks
             else None
+        )
+
+    def add_color_listener(self, callback: ColorCallback) -> Callable[[], None]:
+        """Add a listener for server/state messages with color.
+
+        Returns:
+            A function that removes this listener when called.
+        """
+        self._color_callbacks.append(callback)
+        return lambda: (
+            self._color_callbacks.remove(callback) if callback in self._color_callbacks else None
         )
 
     def add_stream_start_listener(self, callback: StreamStartCallback) -> Callable[[], None]:
@@ -946,6 +963,9 @@ class SendspinClient:
         # Notify metadata callback when metadata is present
         if payload.metadata is not None:
             self._notify_metadata_callback(payload)
+        # Notify color callback when color is present
+        if payload.color is not None:
+            self._notify_color_callback(payload)
 
     def _handle_server_command(self, payload: ServerCommandPayload) -> None:
         """Handle server/command message."""
@@ -1142,6 +1162,13 @@ class SendspinClient:
                 callback(payload)
             except Exception:
                 logger.exception("Error in controller callback %s", callback)
+
+    def _notify_color_callback(self, payload: ServerStatePayload) -> None:
+        for callback in list(self._color_callbacks):
+            try:
+                callback(payload)
+            except Exception:
+                logger.exception("Error in color callback %s", callback)
 
     def _notify_stream_start(self, message: StreamStartMessage) -> None:
         for callback in list(self._stream_start_callbacks):

--- a/aiosendspin/models/color.py
+++ b/aiosendspin/models/color.py
@@ -1,0 +1,65 @@
+"""
+Color messages for the Sendspin protocol.
+
+This module contains messages specific to clients with the color role, which
+receive color palettes derived from the current audio.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from mashumaro.config import BaseConfig
+from mashumaro.mixins.orjson import DataClassORJSONMixin
+
+from .types import UndefinedField, undefined_field
+
+_RGB_LEN = 3
+
+
+def _validate_rgb(name: str, value: list[int]) -> None:
+    if len(value) != _RGB_LEN:
+        raise ValueError(f"{name} must be [R, G, B] (length 3), got length {len(value)}")
+    for component in value:
+        if not (0 <= component <= 255):
+            raise ValueError(f"{name} values must be 0-255, got {component}")
+
+
+# Server -> Client: server/state color object
+@dataclass
+class SessionUpdateColor(DataClassORJSONMixin):
+    """Color object in server/state message."""
+
+    timestamp: int
+    """Server clock time in microseconds for when these colors are valid."""
+    background_dark: list[int] | None | UndefinedField = field(default_factory=undefined_field)
+    """Background color for dark mode as [R, G, B]. Null clears the field."""
+    background_light: list[int] | None | UndefinedField = field(default_factory=undefined_field)
+    """Background color for light mode as [R, G, B]. Null clears the field."""
+    primary: list[int] | None | UndefinedField = field(default_factory=undefined_field)
+    """Dominant color as [R, G, B]. Null clears the field."""
+    accent: list[int] | None | UndefinedField = field(default_factory=undefined_field)
+    """Secondary or complementary color as [R, G, B]. Null clears the field."""
+    on_dark: list[int] | None | UndefinedField = field(default_factory=undefined_field)
+    """Light color for use on dark backgrounds as [R, G, B]. Null clears the field."""
+    on_light: list[int] | None | UndefinedField = field(default_factory=undefined_field)
+    """Dark color for use on light backgrounds as [R, G, B]. Null clears the field."""
+
+    def __post_init__(self) -> None:
+        """Validate RGB fields."""
+        for name in (
+            "background_dark",
+            "background_light",
+            "primary",
+            "accent",
+            "on_dark",
+            "on_light",
+        ):
+            value = getattr(self, name)
+            if not isinstance(value, UndefinedField) and value is not None:
+                _validate_rgb(name, value)
+
+    class Config(BaseConfig):
+        """Config for parsing json messages."""
+
+        omit_default = True

--- a/aiosendspin/models/core.py
+++ b/aiosendspin/models/core.py
@@ -21,6 +21,7 @@ from .artwork import (
     StreamRequestFormatArtwork,
     StreamStartArtwork,
 )
+from .color import SessionUpdateColor
 from .controller import ControllerCommandPayload, ControllerStatePayload
 from .metadata import SessionUpdateMetadata
 from .player import (
@@ -340,6 +341,8 @@ class ServerStatePayload(DataClassORJSONMixin):
     """Metadata state - only sent to clients with metadata role."""
     controller: ControllerStatePayload | None = None
     """Controller state - only sent to clients with controller role."""
+    color: SessionUpdateColor | None = None
+    """Color state - only sent to clients with color role."""
 
     class Config(BaseConfig):
         """Config for parsing json messages."""

--- a/aiosendspin/models/types.py
+++ b/aiosendspin/models/types.py
@@ -73,6 +73,8 @@ class Roles(Enum):
 
     Has preferred format for audio features.
     """
+    COLOR = "color@v1"
+    """Receives colors derived from the current audio."""
 
 
 class BinaryMessageType(Enum):

--- a/aiosendspin/server/roles/__init__.py
+++ b/aiosendspin/server/roles/__init__.py
@@ -10,6 +10,7 @@ Roles encapsulate per-connection behavior for different client capabilities.
 # Import submodules to trigger auto-registration of roles
 from aiosendspin.server.roles import (
     artwork,  # noqa: F401
+    color,  # noqa: F401
     controller,  # noqa: F401
     metadata,  # noqa: F401
     player,  # noqa: F401
@@ -30,6 +31,13 @@ from aiosendspin.server.roles.base import (
     GroupRole,
     Role,
     StreamRequirements,
+)
+from aiosendspin.server.roles.color import (
+    ColorClearedEvent,
+    ColorEvent,
+    ColorGroupRole,
+    ColorUpdatedEvent,
+    ColorV1Role,
 )
 from aiosendspin.server.roles.controller import (
     ControllerEvent,
@@ -74,6 +82,11 @@ __all__ = [
     "ArtworkV1Role",
     "AudioChunk",
     "AudioRequirements",
+    "ColorClearedEvent",
+    "ColorEvent",
+    "ColorGroupRole",
+    "ColorUpdatedEvent",
+    "ColorV1Role",
     "ControllerEvent",
     "ControllerGroupRole",
     "ControllerMuteEvent",

--- a/aiosendspin/server/roles/color/__init__.py
+++ b/aiosendspin/server/roles/color/__init__.py
@@ -1,0 +1,25 @@
+"""Color role - client and group level."""
+
+from aiosendspin.server.roles.color.events import (
+    ColorClearedEvent,
+    ColorEvent,
+    ColorUpdatedEvent,
+)
+from aiosendspin.server.roles.color.group import ColorGroupRole
+from aiosendspin.server.roles.color.state import Color
+from aiosendspin.server.roles.color.types import ColorRoleProtocol
+from aiosendspin.server.roles.color.v1 import ColorV1Role
+from aiosendspin.server.roles.registry import register_group_role, register_role
+
+register_group_role("color", ColorGroupRole)
+register_role("color@v1", lambda client: ColorV1Role(client=client))
+
+__all__ = [
+    "Color",
+    "ColorClearedEvent",
+    "ColorEvent",
+    "ColorGroupRole",
+    "ColorRoleProtocol",
+    "ColorUpdatedEvent",
+    "ColorV1Role",
+]

--- a/aiosendspin/server/roles/color/events.py
+++ b/aiosendspin/server/roles/color/events.py
@@ -1,0 +1,29 @@
+"""Color group role events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aiosendspin.server.events import GroupRoleEvent
+from aiosendspin.server.roles.color.state import Color
+
+
+class ColorEvent(GroupRoleEvent):
+    """Base event type for color group role changes."""
+
+
+@dataclass
+class ColorUpdatedEvent(ColorEvent):
+    """Color palette was set or updated for the group."""
+
+    color: Color
+    previous_color: Color | None
+    timestamp_us: int
+
+
+@dataclass
+class ColorClearedEvent(ColorEvent):
+    """Color palette was cleared for the group."""
+
+    previous_color: Color | None
+    timestamp_us: int

--- a/aiosendspin/server/roles/color/group.py
+++ b/aiosendspin/server/roles/color/group.py
@@ -1,0 +1,82 @@
+"""ColorGroupRole - group-level color coordination."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from aiosendspin.models.core import ServerStateMessage, ServerStatePayload
+from aiosendspin.server.roles.base import GroupRole, Role
+from aiosendspin.server.roles.color.events import ColorClearedEvent, ColorUpdatedEvent
+from aiosendspin.server.roles.color.state import Color
+
+if TYPE_CHECKING:
+    from aiosendspin.server.group import SendspinGroup
+
+
+class ColorGroupRole(GroupRole):
+    """Coordinate color palette across a group.
+
+    Stores current color state and pushes updates to subscribed ColorV1Roles.
+    """
+
+    role_family = "color"
+
+    def __init__(self, group: SendspinGroup) -> None:
+        """Initialize ColorGroupRole."""
+        super().__init__(group)
+        self._current_color: Color | None = None
+
+    @property
+    def color(self) -> Color | None:
+        """Return current color palette."""
+        return self._current_color
+
+    def on_member_join(self, role: Role) -> None:
+        """Send current color to newly joined member."""
+        self._send_state_to_role(role)
+
+    def _send_state_to_role(self, role: Role) -> None:
+        """Send current color state to a single role."""
+        timestamp = self._group._server.clock.now_us()  # noqa: SLF001
+        if self._current_color is not None:
+            color_update = self._current_color.snapshot_update(timestamp)
+        else:
+            color_update = Color.cleared_update(timestamp)
+        state_message = ServerStateMessage(ServerStatePayload(color=color_update))
+        role.send_message(state_message)
+
+    def set_color(self, color: Color | None) -> None:
+        """Set color palette and push updates to all subscribed roles."""
+        timestamp = self._group._server.clock.now_us()  # noqa: SLF001
+
+        if color is not None and color.equals(self._current_color):
+            return
+
+        last_color = self._current_color
+        if color is None:
+            color_update = Color.cleared_update(timestamp)
+        else:
+            color_update = color.diff_update(last_color, timestamp)
+
+        self._current_color = color
+
+        for role in self._members:
+            state_message = ServerStateMessage(ServerStatePayload(color=color_update))
+            role.send_message(state_message)
+
+        if color is None:
+            self.emit_group_event(
+                ColorClearedEvent(previous_color=last_color, timestamp_us=timestamp)
+            )
+            return
+        self.emit_group_event(
+            ColorUpdatedEvent(
+                color=color,
+                previous_color=last_color,
+                timestamp_us=timestamp,
+            )
+        )
+
+    def clear(self) -> None:
+        """Clear the color palette."""
+        self.set_color(None)

--- a/aiosendspin/server/roles/color/state.py
+++ b/aiosendspin/server/roles/color/state.py
@@ -1,0 +1,94 @@
+"""Color state for the Sendspin protocol."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aiosendspin.models.color import SessionUpdateColor
+
+
+@dataclass
+class Color:
+    """Color palette for the current audio."""
+
+    background_dark: list[int] | None = None
+    """Background color for dark mode as [R, G, B].
+
+    Caller must ensure a WCAG contrast ratio of at least 4.5:1 with white text
+    and with `on_dark` (if also set).
+    """
+    background_light: list[int] | None = None
+    """Background color for light mode as [R, G, B].
+
+    Caller must ensure a WCAG contrast ratio of at least 4.5:1 with black text
+    and with `on_light` (if also set).
+    """
+    primary: list[int] | None = None
+    """Dominant color as [R, G, B]. Not adjusted for contrast."""
+    accent: list[int] | None = None
+    """Secondary or complementary color as [R, G, B]. Not adjusted for contrast."""
+    on_dark: list[int] | None = None
+    """Light color for use on dark backgrounds as [R, G, B].
+
+    Caller must ensure a WCAG contrast ratio of at least 4.5:1 with `background_dark`
+    (if also set).
+    """
+    on_light: list[int] | None = None
+    """Dark color for use on light backgrounds as [R, G, B].
+
+    Caller must ensure a WCAG contrast ratio of at least 4.5:1 with `background_light`
+    (if also set).
+    """
+
+    def equals(self, other: Color | None) -> bool:
+        """Check if color palette is equal to another."""
+        if other is None:
+            return False
+        return (
+            self.background_dark == other.background_dark
+            and self.background_light == other.background_light
+            and self.primary == other.primary
+            and self.accent == other.accent
+            and self.on_dark == other.on_dark
+            and self.on_light == other.on_light
+        )
+
+    def diff_update(self, last: Color | None, timestamp: int) -> SessionUpdateColor:
+        """Build a SessionUpdateColor containing only changed fields compared to last."""
+        update = SessionUpdateColor(timestamp=timestamp)
+        if last is None or last.background_dark != self.background_dark:
+            update.background_dark = self.background_dark
+        if last is None or last.background_light != self.background_light:
+            update.background_light = self.background_light
+        if last is None or last.primary != self.primary:
+            update.primary = self.primary
+        if last is None or last.accent != self.accent:
+            update.accent = self.accent
+        if last is None or last.on_dark != self.on_dark:
+            update.on_dark = self.on_dark
+        if last is None or last.on_light != self.on_light:
+            update.on_light = self.on_light
+        return update
+
+    def snapshot_update(self, timestamp: int) -> SessionUpdateColor:
+        """Build a SessionUpdateColor snapshot with all current values."""
+        update = SessionUpdateColor(timestamp=timestamp)
+        update.background_dark = self.background_dark
+        update.background_light = self.background_light
+        update.primary = self.primary
+        update.accent = self.accent
+        update.on_dark = self.on_dark
+        update.on_light = self.on_light
+        return update
+
+    @staticmethod
+    def cleared_update(timestamp: int) -> SessionUpdateColor:
+        """Build a SessionUpdateColor that clears all color fields."""
+        update = SessionUpdateColor(timestamp=timestamp)
+        update.background_dark = None
+        update.background_light = None
+        update.primary = None
+        update.accent = None
+        update.on_dark = None
+        update.on_light = None
+        return update

--- a/aiosendspin/server/roles/color/types.py
+++ b/aiosendspin/server/roles/color/types.py
@@ -1,0 +1,21 @@
+"""Shared color role protocols."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from aiosendspin.models.types import ServerMessage
+
+
+@runtime_checkable
+class ColorRoleProtocol(Protocol):
+    """Protocol for color role implementations."""
+
+    @property
+    def role_id(self) -> str:
+        """Return the versioned role identifier."""
+        ...
+
+    def send_message(self, message: ServerMessage) -> None:
+        """Send a JSON message to the client."""
+        ...

--- a/aiosendspin/server/roles/color/v1.py
+++ b/aiosendspin/server/roles/color/v1.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from aiosendspin.server.roles.base import Role
-from aiosendspin.server.roles.color.group import ColorGroupRole
 
 if TYPE_CHECKING:
     from aiosendspin.server.client import SendspinClient
@@ -44,8 +43,6 @@ class ColorV1Role(Role):
     def on_connect(self) -> None:
         """Subscribe to ColorGroupRole for state updates."""
         self._subscribe_to_group_role()
-        if isinstance(self._group_role, ColorGroupRole):
-            self._group_role._send_state_to_role(self)  # noqa: SLF001
 
     def on_disconnect(self) -> None:
         """Unsubscribe from ColorGroupRole."""

--- a/aiosendspin/server/roles/color/v1.py
+++ b/aiosendspin/server/roles/color/v1.py
@@ -1,0 +1,52 @@
+"""ColorV1Role implementation (v1).
+
+This role handles outbound server/state messages with color palettes for display clients.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from aiosendspin.server.roles.base import Role
+from aiosendspin.server.roles.color.group import ColorGroupRole
+
+if TYPE_CHECKING:
+    from aiosendspin.server.client import SendspinClient
+
+
+class ColorV1Role(Role):
+    """Role implementation for color palette display.
+
+    Receives color updates from ColorGroupRole and sends server/state
+    messages to the client. This role is outbound-only.
+    """
+
+    def __init__(self, client: SendspinClient | None = None) -> None:
+        """Initialize ColorV1Role."""
+        if client is None:
+            msg = "ColorV1Role requires a client"
+            raise ValueError(msg)
+        self._client = client
+        self._stream_started = False
+        self._buffer_tracker = None
+        self._group_role = None
+
+    @property
+    def role_id(self) -> str:
+        """Versioned role identifier."""
+        return "color@v1"
+
+    @property
+    def role_family(self) -> str:
+        """Role family name for protocol messages."""
+        return "color"
+
+    def on_connect(self) -> None:
+        """Subscribe to ColorGroupRole for state updates."""
+        self._subscribe_to_group_role()
+        if isinstance(self._group_role, ColorGroupRole):
+            self._group_role._send_state_to_role(self)  # noqa: SLF001
+
+    def on_disconnect(self) -> None:
+        """Unsubscribe from ColorGroupRole."""
+        self._unsubscribe_from_group_role()

--- a/tests/server/roles/color/__init__.py
+++ b/tests/server/roles/color/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for color role."""

--- a/tests/server/roles/color/test_group.py
+++ b/tests/server/roles/color/test_group.py
@@ -1,0 +1,128 @@
+"""Tests for ColorGroupRole."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from aiosendspin.models.core import ServerStateMessage
+from aiosendspin.server.roles.color import ColorClearedEvent, ColorUpdatedEvent
+from aiosendspin.server.roles.color.group import ColorGroupRole
+from aiosendspin.server.roles.color.state import Color
+
+
+def _make_group_stub() -> MagicMock:
+    group = MagicMock()
+    group._server = MagicMock()  # noqa: SLF001
+    group._server.clock.now_us.return_value = 1_000_000  # noqa: SLF001
+    return group
+
+
+def test_color_group_role_family() -> None:
+    """ColorGroupRole has role_family of 'color'."""
+    group = _make_group_stub()
+    cgr = ColorGroupRole(group)
+    assert cgr.role_family == "color"
+
+
+def test_color_group_role_initial_color_is_none() -> None:
+    """Initial color is None."""
+    group = _make_group_stub()
+    cgr = ColorGroupRole(group)
+    assert cgr.color is None
+
+
+def test_set_color_stores_and_broadcasts() -> None:
+    """set_color() stores the color and sends update to members."""
+    group = _make_group_stub()
+    cgr = ColorGroupRole(group)
+
+    member = MagicMock()
+    cgr._members = [member]  # noqa: SLF001
+
+    color = Color(primary=[255, 0, 0], accent=[0, 255, 0])
+    cgr.set_color(color)
+
+    assert cgr.color is not None
+    assert cgr.color.primary == [255, 0, 0]
+
+    member.send_message.assert_called_once()
+    msg = member.send_message.call_args.args[0]
+    assert isinstance(msg, ServerStateMessage)
+    assert msg.payload.color is not None
+    assert msg.payload.color.primary == [255, 0, 0]
+
+    group._signal_event.assert_called_once()  # noqa: SLF001
+    event = group._signal_event.call_args.args[0]  # noqa: SLF001
+    assert isinstance(event, ColorUpdatedEvent)
+    assert event.color.primary == [255, 0, 0]
+    assert event.previous_color is None
+
+
+def test_set_color_no_op_when_equal() -> None:
+    """set_color() with the same color does nothing."""
+    group = _make_group_stub()
+    cgr = ColorGroupRole(group)
+
+    color = Color(primary=[255, 0, 0])
+    cgr.set_color(color)
+    group._signal_event.reset_mock()  # noqa: SLF001
+
+    cgr.set_color(Color(primary=[255, 0, 0]))
+
+    group._signal_event.assert_not_called()  # noqa: SLF001
+
+
+def test_clear_color() -> None:
+    """clear() sets color to None and sends cleared update."""
+    group = _make_group_stub()
+    cgr = ColorGroupRole(group)
+
+    member = MagicMock()
+    cgr._members = [member]  # noqa: SLF001
+
+    cgr.set_color(Color(primary=[255, 0, 0]))
+    member.send_message.reset_mock()
+    group._signal_event.reset_mock()  # noqa: SLF001
+
+    cgr.clear()
+
+    assert cgr.color is None
+    member.send_message.assert_called_once()
+    msg = member.send_message.call_args.args[0]
+    assert isinstance(msg, ServerStateMessage)
+    assert msg.payload.color is not None
+    assert msg.payload.color.primary is None
+
+    event = group._signal_event.call_args.args[0]  # noqa: SLF001
+    assert isinstance(event, ColorClearedEvent)
+
+
+def test_on_member_join_sends_current_color() -> None:
+    """on_member_join sends a snapshot to the new member."""
+    group = _make_group_stub()
+    cgr = ColorGroupRole(group)
+    cgr._current_color = Color(primary=[100, 150, 200])  # noqa: SLF001
+
+    member = MagicMock()
+    cgr.on_member_join(member)
+
+    member.send_message.assert_called_once()
+    msg = member.send_message.call_args.args[0]
+    assert isinstance(msg, ServerStateMessage)
+    assert msg.payload.color is not None
+    assert msg.payload.color.primary == [100, 150, 200]
+
+
+def test_on_member_join_sends_cleared_when_no_color() -> None:
+    """on_member_join sends a cleared update when no color is set."""
+    group = _make_group_stub()
+    cgr = ColorGroupRole(group)
+
+    member = MagicMock()
+    cgr.on_member_join(member)
+
+    member.send_message.assert_called_once()
+    msg = member.send_message.call_args.args[0]
+    assert isinstance(msg, ServerStateMessage)
+    assert msg.payload.color is not None
+    assert msg.payload.color.primary is None

--- a/tests/server/roles/color/test_v1.py
+++ b/tests/server/roles/color/test_v1.py
@@ -1,0 +1,76 @@
+"""Tests for ColorV1Role (v1) implementation."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from aiosendspin.server.roles.color.v1 import ColorV1Role
+
+
+def _make_client_stub() -> MagicMock:
+    client = MagicMock()
+    client.group = MagicMock()
+    client.group.group_role.return_value = None
+    return client
+
+
+def test_color_v1_role_id() -> None:
+    """ColorV1Role has role_id of 'color@v1'."""
+    client = _make_client_stub()
+    role = ColorV1Role(client=client)
+    assert role.role_id == "color@v1"
+
+
+def test_color_v1_role_family() -> None:
+    """ColorV1Role has role_family of 'color'."""
+    client = _make_client_stub()
+    role = ColorV1Role(client=client)
+    assert role.role_family == "color"
+
+
+def test_color_v1_role_requires_client() -> None:
+    """ColorV1Role raises ValueError if no client provided."""
+    with pytest.raises(ValueError, match="requires a client"):
+        ColorV1Role(client=None)
+
+
+def test_color_v1_on_connect_subscribes_to_group_role() -> None:
+    """on_connect() subscribes to ColorGroupRole."""
+    client = _make_client_stub()
+    group_role = MagicMock()
+    client.group.group_role.return_value = group_role
+
+    role = ColorV1Role(client=client)
+    role.on_connect()
+
+    client.group.group_role.assert_called_with("color")
+    group_role.subscribe.assert_called_once_with(role)
+
+
+def test_color_v1_on_disconnect_unsubscribes_from_group_role() -> None:
+    """on_disconnect() unsubscribes from ColorGroupRole."""
+    client = _make_client_stub()
+    group_role = MagicMock()
+    client.group.group_role.return_value = group_role
+
+    role = ColorV1Role(client=client)
+    role.on_connect()
+    role.on_disconnect()
+
+    group_role.unsubscribe.assert_called_once_with(role)
+
+
+def test_color_v1_has_no_stream_requirements() -> None:
+    """ColorV1Role does not send binary streams."""
+    client = _make_client_stub()
+    role = ColorV1Role(client=client)
+    assert role.get_stream_requirements() is None
+
+
+def test_color_v1_has_no_audio_requirements() -> None:
+    """ColorV1Role does not receive audio."""
+    client = _make_client_stub()
+    role = ColorV1Role(client=client)
+    assert role.get_audio_requirements() is None


### PR DESCRIPTION
Implements the new color role from the Sendspin Specification:
- https://github.com/Sendspin/spec/pull/70

Setting/extracting the colors is handled by the server, as well as ensuring the minimum contrast. `aiosendspin` only passes the colors set through `ColorGroupRole.set_color()` to compatible clients.