### PR TITLE
Fix duplicate `server/state` push when metadata client connects

### DIFF
--- a/aiosendspin/server/roles/metadata/v1.py
+++ b/aiosendspin/server/roles/metadata/v1.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from aiosendspin.server.roles.base import Role
-from aiosendspin.server.roles.metadata.group import MetadataGroupRole
 
 if TYPE_CHECKING:
     from aiosendspin.server.client import SendspinClient
@@ -48,8 +47,6 @@ class MetadataV1Role(Role):
     def on_connect(self) -> None:
         """Subscribe to MetadataGroupRole for state updates."""
         self._subscribe_to_group_role()
-        if isinstance(self._group_role, MetadataGroupRole):
-            self._group_role._send_state_to_role(self)  # noqa: SLF001
 
     def on_disconnect(self) -> None:
         """Unsubscribe from MetadataGroupRole."""


### PR DESCRIPTION
Metadata role's `on_connect` subscribed to the group role then explicitly called `_send_state_to_role`, but `subscribe()` already fires `on_member_join` which sends the same state. Result was two `server/state` messages per connect or reconnect for every metadata client.