### PR TITLE
Move `repeat` and `shuffle` to controller state

### DIFF
--- a/aiosendspin/models/controller.py
+++ b/aiosendspin/models/controller.py
@@ -76,3 +76,12 @@ class ControllerStatePayload(DataClassORJSONMixin):
         """Validate field values."""
         if not 0 <= self.volume <= 100:
             raise ValueError(f"Volume must be in range 0-100, got {self.volume}")
+
+    @classmethod
+    def __pre_deserialize__(cls, d: dict[str, object]) -> dict[str, object]:
+        """Backfill repeat/shuffle for pre-spec servers."""
+        # Deprecated: drop with metadata dual-emit.
+        data = dict(d)
+        data.setdefault("repeat", RepeatMode.OFF.value)
+        data.setdefault("shuffle", False)
+        return data

--- a/aiosendspin/models/controller.py
+++ b/aiosendspin/models/controller.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from mashumaro.config import BaseConfig
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-from .types import MediaCommand
+from .types import MediaCommand, RepeatMode
 
 
 # Client -> Server: client/command controller object
@@ -67,6 +67,10 @@ class ControllerStatePayload(DataClassORJSONMixin):
     """Volume of the whole group, range 0-100."""
     muted: bool
     """Mute state of the whole group."""
+    repeat: RepeatMode
+    """Repeat mode: 'off' = no repeat, 'one' = repeat current track, 'all' = repeat all."""
+    shuffle: bool
+    """Whether shuffle is enabled."""
 
     def __post_init__(self) -> None:
         """Validate field values."""

--- a/aiosendspin/server/roles/controller/group.py
+++ b/aiosendspin/server/roles/controller/group.py
@@ -46,9 +46,13 @@ class ControllerGroupRole(GroupRole):
         """Initialize ControllerGroupRole."""
         super().__init__(group)
         self._supported_commands: list[MediaCommand] = []
+        self._repeat: RepeatMode = RepeatMode.OFF
+        self._shuffle: bool = False
         self._last_sent_volume: int | None = None
         self._last_sent_muted: bool | None = None
         self._last_sent_supported_commands: list[MediaCommand] | None = None
+        self._last_sent_repeat: RepeatMode | None = None
+        self._last_sent_shuffle: bool | None = None
         # Track volume event subscriptions for player clients
         self._player_client_unsubs: dict[SendspinClient, Callable[[], None]] = {}
 
@@ -86,6 +90,26 @@ class ControllerGroupRole(GroupRole):
             player_group_role.set_group_muted(muted)
         self._push_state_to_members()
 
+    @property
+    def repeat(self) -> RepeatMode:
+        """Return current group repeat mode."""
+        return self._repeat
+
+    @property
+    def shuffle(self) -> bool:
+        """Return current group shuffle state."""
+        return self._shuffle
+
+    def set_repeat(self, mode: RepeatMode) -> None:
+        """Set group repeat mode and push state to members if changed."""
+        self._repeat = mode
+        self._push_state_to_members()
+
+    def set_shuffle(self, shuffle: bool) -> None:  # noqa: FBT001
+        """Set group shuffle state and push state to members if changed."""
+        self._shuffle = shuffle
+        self._push_state_to_members()
+
     def set_supported_commands(self, commands: list[MediaCommand]) -> None:
         """Set the commands supported by the application.
 
@@ -119,6 +143,8 @@ class ControllerGroupRole(GroupRole):
             supported_commands=supported_commands,
             volume=self.volume,
             muted=self.muted,
+            repeat=self._repeat,
+            shuffle=self._shuffle,
         )
         state_message = ServerStateMessage(ServerStatePayload(controller=controller_state))
         role.send_message(state_message)
@@ -128,22 +154,30 @@ class ControllerGroupRole(GroupRole):
         current_volume = self.volume
         current_muted = self.muted
         current_supported_commands = self._get_supported_commands()
+        current_repeat = self._repeat
+        current_shuffle = self._shuffle
 
         if (
             self._last_sent_volume == current_volume
             and self._last_sent_muted == current_muted
             and self._last_sent_supported_commands == current_supported_commands
+            and self._last_sent_repeat == current_repeat
+            and self._last_sent_shuffle == current_shuffle
         ):
             return
 
         self._last_sent_volume = current_volume
         self._last_sent_muted = current_muted
         self._last_sent_supported_commands = current_supported_commands
+        self._last_sent_repeat = current_repeat
+        self._last_sent_shuffle = current_shuffle
 
         controller_state = ControllerStatePayload(
             supported_commands=current_supported_commands,
             volume=current_volume,
             muted=current_muted,
+            repeat=current_repeat,
+            shuffle=current_shuffle,
         )
         state_message = ServerStateMessage(ServerStatePayload(controller=controller_state))
 

--- a/aiosendspin/server/roles/controller/group.py
+++ b/aiosendspin/server/roles/controller/group.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from dataclasses import replace
 from typing import TYPE_CHECKING
 
 from aiosendspin.models.controller import ControllerCommandPayload, ControllerStatePayload
@@ -24,6 +25,8 @@ from aiosendspin.server.roles.controller.events import (
     ControllerSwitchEvent,
     ControllerVolumeEvent,
 )
+from aiosendspin.server.roles.metadata.group import MetadataGroupRole
+from aiosendspin.server.roles.metadata.state import Metadata
 from aiosendspin.server.roles.player.events import VolumeChangedEvent
 
 if TYPE_CHECKING:
@@ -104,11 +107,22 @@ class ControllerGroupRole(GroupRole):
         """Set group repeat mode and push state to members if changed."""
         self._repeat = mode
         self._push_state_to_members()
+        self._mirror_to_metadata_back_compat()
 
     def set_shuffle(self, shuffle: bool) -> None:  # noqa: FBT001
         """Set group shuffle state and push state to members if changed."""
         self._shuffle = shuffle
         self._push_state_to_members()
+        self._mirror_to_metadata_back_compat()
+
+    def _mirror_to_metadata_back_compat(self) -> None:
+        """Mirror repeat/shuffle into metadata state for v1 clients."""
+        # Deprecated: drop with metadata dual-emit.
+        metadata_gr = self._group.group_role("metadata")
+        if not isinstance(metadata_gr, MetadataGroupRole):
+            return
+        current = metadata_gr.metadata or Metadata()
+        metadata_gr.set_metadata(replace(current, repeat=self._repeat, shuffle=self._shuffle))
 
     def set_supported_commands(self, commands: list[MediaCommand]) -> None:
         """Set the commands supported by the application.

--- a/aiosendspin/server/roles/metadata/group.py
+++ b/aiosendspin/server/roles/metadata/group.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 
 from aiosendspin.models.core import ServerStateMessage, ServerStatePayload
 from aiosendspin.models.metadata import Progress
-from aiosendspin.models.types import RepeatMode
 from aiosendspin.server.roles.base import GroupRole, Role
 from aiosendspin.server.roles.metadata.events import MetadataClearedEvent, MetadataUpdatedEvent
 from aiosendspin.server.roles.metadata.state import Metadata
@@ -152,7 +151,7 @@ class MetadataGroupRole(GroupRole):
             )
         )
 
-    def update(  # noqa: PLR0913
+    def update(
         self,
         *,
         title: str | None | object = _UNSET,
@@ -162,8 +161,6 @@ class MetadataGroupRole(GroupRole):
         artwork_url: str | None | object = _UNSET,
         year: int | None | object = _UNSET,
         track: int | None | object = _UNSET,
-        repeat: RepeatMode | None | object = _UNSET,
-        shuffle: bool | None | object = _UNSET,
         track_progress: int | None | object = _UNSET,
         track_duration: int | None | object = _UNSET,
         playback_speed: int | None | object = _UNSET,
@@ -188,10 +185,6 @@ class MetadataGroupRole(GroupRole):
             kwargs["year"] = year
         if track is not _UNSET:
             kwargs["track"] = track
-        if repeat is not _UNSET:
-            kwargs["repeat"] = repeat
-        if shuffle is not _UNSET:
-            kwargs["shuffle"] = shuffle
         if track_progress is not _UNSET:
             kwargs["track_progress"] = track_progress
         if track_duration is not _UNSET:

--- a/aiosendspin/server/roles/metadata/state.py
+++ b/aiosendspin/server/roles/metadata/state.py
@@ -26,8 +26,10 @@ class Metadata:
     """Release year of the current media."""
     track: int | None = None
     """Track number of the current media."""
+    # Deprecated: use ControllerGroupRole.set_repeat. Still emitted for backwards compatibility.
     repeat: RepeatMode | None = None
     """Current repeat mode."""
+    # Deprecated: use ControllerGroupRole.set_shuffle. Still emitted for backwards compatibility.
     shuffle: bool | None = None
     """Whether shuffle is enabled."""
 

--- a/tests/models/test_server_state_merge.py
+++ b/tests/models/test_server_state_merge.py
@@ -2,19 +2,20 @@
 
 from __future__ import annotations
 
+from aiosendspin.models.controller import ControllerStatePayload
 from aiosendspin.models.core import ServerStateMessage, ServerStatePayload
 from aiosendspin.models.metadata import Progress, SessionUpdateMetadata
-from aiosendspin.models.types import RepeatMode
+from aiosendspin.models.types import MediaCommand, RepeatMode
 
 
 def test_server_state_merge_preserves_metadata_fields_omitted_by_undefined() -> None:
-    """Keep repeat/shuffle when a later metadata delta omits them with UndefinedField."""
+    """Keep existing metadata fields when a later delta omits them with UndefinedField."""
     existing = ServerStateMessage(
         payload=ServerStatePayload(
             metadata=SessionUpdateMetadata(
                 timestamp=100,
-                repeat=RepeatMode.ALL,
-                shuffle=True,
+                title="Song Title",
+                album="Some Album",
             )
         )
     )
@@ -36,8 +37,8 @@ def test_server_state_merge_preserves_metadata_fields_omitted_by_undefined() -> 
     assert isinstance(merged, ServerStateMessage)
     assert merged.payload.metadata is not None
     assert merged.payload.metadata.timestamp == 200
-    assert merged.payload.metadata.repeat == RepeatMode.ALL
-    assert merged.payload.metadata.shuffle is True
+    assert merged.payload.metadata.title == "Song Title"
+    assert merged.payload.metadata.album == "Some Album"
     assert merged.payload.metadata.progress == Progress(
         track_progress=1_234,
         track_duration=5_678,
@@ -53,7 +54,7 @@ def test_server_state_merge_null_clears_existing_field() -> None:
                 timestamp=100,
                 title="Song Title",
                 artist="Artist Name",
-                repeat=RepeatMode.ALL,
+                album="Some Album",
             )
         )
     )
@@ -76,7 +77,40 @@ def test_server_state_merge_null_clears_existing_field() -> None:
     assert merged.payload.metadata.title is None
     assert merged.payload.metadata.artist is None
     # Not included in delta (UndefinedField) → should be preserved
-    assert merged.payload.metadata.repeat == RepeatMode.ALL
+    assert merged.payload.metadata.album == "Some Album"
+
+
+def test_server_state_merge_controller_overwrites_repeat_and_shuffle() -> None:
+    """Incoming controller state overwrites existing repeat/shuffle (required fields)."""
+    existing = ServerStateMessage(
+        payload=ServerStatePayload(
+            controller=ControllerStatePayload(
+                supported_commands=[MediaCommand.PLAY],
+                volume=50,
+                muted=False,
+                repeat=RepeatMode.OFF,
+                shuffle=False,
+            )
+        )
+    )
+    incoming = ServerStateMessage(
+        payload=ServerStatePayload(
+            controller=ControllerStatePayload(
+                supported_commands=[MediaCommand.PLAY],
+                volume=50,
+                muted=False,
+                repeat=RepeatMode.ALL,
+                shuffle=True,
+            )
+        )
+    )
+
+    merged = existing.merge(incoming)
+
+    assert isinstance(merged, ServerStateMessage)
+    assert merged.payload.controller is not None
+    assert merged.payload.controller.repeat == RepeatMode.ALL
+    assert merged.payload.controller.shuffle is True
 
 
 def test_server_state_merge_null_clears_nested_progress() -> None:

--- a/tests/server/roles/controller/test_group.py
+++ b/tests/server/roles/controller/test_group.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 from aiosendspin.models.controller import ControllerCommandPayload
 from aiosendspin.models.core import ServerStateMessage
-from aiosendspin.models.types import MediaCommand
+from aiosendspin.models.types import MediaCommand, RepeatMode
 from aiosendspin.server.roles.controller.events import (
     ControllerMuteEvent,
     ControllerNextEvent,
@@ -274,8 +274,6 @@ def test_controller_group_role_handle_switch_command() -> None:
 
 def test_controller_group_role_handle_repeat_commands() -> None:
     """handle_command() emits RepeatEvent for repeat commands."""
-    from aiosendspin.models.types import RepeatMode  # noqa: PLC0415
-
     group = _make_group_stub()
     cgr = ControllerGroupRole(group)
     cgr.set_supported_commands(
@@ -317,6 +315,81 @@ def test_controller_group_role_handle_shuffle_commands() -> None:
         event = group._signal_event.call_args.args[0]  # noqa: SLF001
         assert isinstance(event, ControllerShuffleEvent)
         assert event.shuffle == expected_shuffle
+
+
+def test_controller_group_role_on_member_join_includes_repeat_and_shuffle_defaults() -> None:
+    """on_member_join() includes default repeat=OFF and shuffle=False in state."""
+    group = _make_group_stub()
+    cgr = ControllerGroupRole(group)
+
+    member = MagicMock()
+    cgr.on_member_join(member)
+
+    msg = member.send_message.call_args.args[0]
+    assert msg.payload.controller.repeat == RepeatMode.OFF
+    assert msg.payload.controller.shuffle is False
+
+
+def test_controller_group_role_set_repeat_pushes_state() -> None:
+    """set_repeat() pushes updated controller state to members."""
+    group = _make_group_stub()
+    cgr = ControllerGroupRole(group)
+
+    member = MagicMock()
+    cgr._members.append(member)  # noqa: SLF001
+    member.send_message.reset_mock()
+
+    cgr.set_repeat(RepeatMode.ALL)
+
+    member.send_message.assert_called_once()
+    msg = member.send_message.call_args.args[0]
+    assert msg.payload.controller.repeat == RepeatMode.ALL
+
+
+def test_controller_group_role_set_shuffle_pushes_state() -> None:
+    """set_shuffle() pushes updated controller state to members."""
+    group = _make_group_stub()
+    cgr = ControllerGroupRole(group)
+
+    member = MagicMock()
+    cgr._members.append(member)  # noqa: SLF001
+    member.send_message.reset_mock()
+
+    cgr.set_shuffle(shuffle=True)
+
+    member.send_message.assert_called_once()
+    msg = member.send_message.call_args.args[0]
+    assert msg.payload.controller.shuffle is True
+
+
+def test_controller_group_role_set_repeat_dedupes_unchanged_value() -> None:
+    """set_repeat() with same value does not re-push state."""
+    group = _make_group_stub()
+    cgr = ControllerGroupRole(group)
+
+    member = MagicMock()
+    cgr._members.append(member)  # noqa: SLF001
+
+    cgr.set_repeat(RepeatMode.ONE)
+    member.send_message.reset_mock()
+
+    cgr.set_repeat(RepeatMode.ONE)
+    member.send_message.assert_not_called()
+
+
+def test_controller_group_role_set_shuffle_dedupes_unchanged_value() -> None:
+    """set_shuffle() with same value does not re-push state."""
+    group = _make_group_stub()
+    cgr = ControllerGroupRole(group)
+
+    member = MagicMock()
+    cgr._members.append(member)  # noqa: SLF001
+
+    cgr.set_shuffle(shuffle=True)
+    member.send_message.reset_mock()
+
+    cgr.set_shuffle(shuffle=True)
+    member.send_message.assert_not_called()
 
 
 def test_controller_group_role_handle_unsupported_command() -> None:

--- a/tests/server/roles/metadata/test_group.py
+++ b/tests/server/roles/metadata/test_group.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from aiosendspin.models.core import ServerStateMessage
-from aiosendspin.models.types import RepeatMode
 from aiosendspin.server.roles.metadata import Metadata, MetadataClearedEvent, MetadataUpdatedEvent
 from aiosendspin.server.roles.metadata.group import MetadataGroupRole
 
@@ -122,28 +121,6 @@ def test_metadata_group_role_update_progress() -> None:
     assert mgr.metadata.track_progress == 30000
     assert mgr.metadata.track_duration == 180000
     assert mgr.metadata.playback_speed == 1000
-
-
-def test_metadata_group_role_update_repeat() -> None:
-    """update() updates repeat mode."""
-    group = _make_group_stub()
-    mgr = MetadataGroupRole(group)
-
-    mgr.update(repeat=RepeatMode.ALL)
-
-    assert mgr.metadata is not None
-    assert mgr.metadata.repeat == RepeatMode.ALL
-
-
-def test_metadata_group_role_update_shuffle() -> None:
-    """update() updates shuffle state."""
-    group = _make_group_stub()
-    mgr = MetadataGroupRole(group)
-
-    mgr.update(shuffle=True)
-
-    assert mgr.metadata is not None
-    assert mgr.metadata.shuffle is True
 
 
 def test_metadata_group_role_update_batch() -> None:


### PR DESCRIPTION
After [Sendspin/spec#81](https://github.com/Sendspin/spec/pull/81), `repeat` and `shuffle` now belong to the state object of the controller role instead of the metadata role.

For now the existing `metadata.repeat` / `metadata.shuffle` are kept for backwards compatibility with clients that haven't moved to the new format yet. This will be removed in a future PR.

# Breaking changes

* `MetadataGroupRole.update(repeat=...)` / `update(shuffle=...)` no longer exist. Use `ControllerGroupRole.set_repeat` / `set_shuffle` instead.
* `ControllerStatePayload` requires `repeat` and `shuffle` when constructed directly.