### PR TITLE
Keep Sendspin stream alive when replacing the active `PushStream`

### DIFF
--- a/aiosendspin/server/group.py
+++ b/aiosendspin/server/group.py
@@ -130,7 +130,10 @@ class SendspinGroup:
         # Replace any existing active stream so stale handles cannot continue
         # committing audio after a new stream is started.
         if self._push_stream is not None and not self._push_stream.is_stopped:
-            self._push_stream.stop()
+            # Drop the previously buffered audio since that belonged to the old PushStream,
+            # but keep the Sendspin stream to avoid stopping and immediately restarting the stream
+            self._push_stream.clear()
+            self._push_stream.stop(keep_stream=True)
 
         self._push_stream = PushStream(
             loop=self._server.loop,

--- a/aiosendspin/server/group.py
+++ b/aiosendspin/server/group.py
@@ -130,10 +130,13 @@ class SendspinGroup:
         # Replace any existing active stream so stale handles cannot continue
         # committing audio after a new stream is started.
         if self._push_stream is not None and not self._push_stream.is_stopped:
-            # Drop the previously buffered audio since that belonged to the old PushStream,
-            # but keep the Sendspin stream to avoid stopping and immediately restarting the stream
-            self._push_stream.clear()
-            self._push_stream.stop(keep_stream=True)
+            if self._server.allow_noncompliant_clients:
+                self._push_stream.stop()
+            else:
+                # Clear buffered audio while preserving the protocol stream across replacement.
+                # Gate the spec-compliant path while legacy clients still mishandle stream/clear.
+                self._push_stream.clear()
+                self._push_stream.stop(keep_stream=True)
 
         self._push_stream = PushStream(
             loop=self._server.loop,

--- a/tests/server/test_group_push_stream.py
+++ b/tests/server/test_group_push_stream.py
@@ -34,6 +34,7 @@ class TestGroupStartStream:
         server = MagicMock()
         server.loop = mock_loop
         server.clock = LoopClock(mock_loop)
+        server.allow_noncompliant_clients = True
         return server
 
     @pytest.fixture
@@ -176,21 +177,46 @@ class TestGroupStartStream:
 
         assert stream1 is not stream2
 
-    def test_start_stream_replaces_and_stops_previous_stream(
+    def test_start_stream_ends_previous_stream_for_noncompliant_clients(
         self,
         mock_server: MagicMock,
         mock_client: MagicMock,
     ) -> None:
-        """Starting a new stream should stop the previous active stream."""
+        """Compatibility mode should end the previous active stream."""
         group = SendspinGroup(mock_server, mock_client)
         stream1 = group.start_stream()
 
         assert not stream1.is_stopped
 
-        stream2 = group.start_stream()
+        with (
+            patch.object(stream1, "clear", wraps=stream1.clear) as clear,
+            patch.object(stream1, "stop", wraps=stream1.stop) as stop,
+        ):
+            stream2 = group.start_stream()
 
         assert stream2 is not stream1
         assert stream1.is_stopped
+        clear.assert_not_called()
+        stop.assert_called_once_with()
+
+    def test_start_stream_keeps_protocol_stream_in_strict_mode(
+        self,
+        mock_server: MagicMock,
+        mock_client: MagicMock,
+    ) -> None:
+        """Strict mode should clear buffered audio without ending the protocol stream."""
+        mock_server.allow_noncompliant_clients = False
+        group = SendspinGroup(mock_server, mock_client)
+        stream1 = group.start_stream()
+
+        with (
+            patch.object(stream1, "clear", wraps=stream1.clear) as clear,
+            patch.object(stream1, "stop", wraps=stream1.stop) as stop,
+        ):
+            group.start_stream()
+
+        clear.assert_called_once_with()
+        stop.assert_called_once_with(keep_stream=True)
 
     @pytest.mark.asyncio
     async def test_replaced_stream_cannot_commit_audio(


### PR DESCRIPTION
`SendspinGroup.start_stream()` currently ends the active Sendspin stream whenever it replaces a `PushStream`, forcing clients through an unnecessary `stream/end` and subsequent `stream/start`.

When `allow_noncompliant_clients=False`, replace the transport using `stream/clear` and `stop(keep_stream=True)`, dropping buffered audio while keeping the protocol stream active. Compatibility mode retains `stream/end` for legacy clients that mishandle `stream/clear`.

Related:
- https://github.com/Sendspin/spec/pull/83
- https://github.com/Sendspin/sendspin-cpp/pull/54