### PR TITLE
Enforce WCAG contrast in `Color` and use RGB tuples

### DIFF
--- a/aiosendspin/models/color.py
+++ b/aiosendspin/models/color.py
@@ -44,17 +44,17 @@ class SessionUpdateColor(DataClassORJSONMixin):
     timestamp: int
     """Server clock time in microseconds for when these colors are valid."""
     background_dark: _RGB | None | UndefinedField = field(default_factory=undefined_field)
-    """Background color for dark mode as [R, G, B]. Null clears the field."""
+    """Background color for dark mode as `(R, G, B)`. Null clears the field."""
     background_light: _RGB | None | UndefinedField = field(default_factory=undefined_field)
-    """Background color for light mode as [R, G, B]. Null clears the field."""
+    """Background color for light mode as `(R, G, B)`. Null clears the field."""
     primary: _RGB | None | UndefinedField = field(default_factory=undefined_field)
-    """Dominant color as [R, G, B]. Null clears the field."""
+    """Dominant color as `(R, G, B)`. Null clears the field."""
     accent: _RGB | None | UndefinedField = field(default_factory=undefined_field)
-    """Secondary or complementary color as [R, G, B]. Null clears the field."""
+    """Secondary or complementary color as `(R, G, B)`. Null clears the field."""
     on_dark: _RGB | None | UndefinedField = field(default_factory=undefined_field)
-    """Light color for use on dark backgrounds as [R, G, B]. Null clears the field."""
+    """Light color for use on dark backgrounds as `(R, G, B)`. Null clears the field."""
     on_light: _RGB | None | UndefinedField = field(default_factory=undefined_field)
-    """Dark color for use on light backgrounds as [R, G, B]. Null clears the field."""
+    """Dark color for use on light backgrounds as `(R, G, B)`. Null clears the field."""
 
     def __post_init__(self) -> None:
         """Validate RGB fields."""

--- a/aiosendspin/models/color.py
+++ b/aiosendspin/models/color.py
@@ -8,18 +8,20 @@ receive color palettes derived from the current audio.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import ClassVar
 
 from mashumaro.config import BaseConfig
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
 from .types import UndefinedField, undefined_field
 
+_RGB = tuple[int, int, int]
 _RGB_LEN = 3
 
 
-def _validate_rgb(name: str, value: list[int]) -> None:
+def _validate_rgb(name: str, value: _RGB) -> None:
     if len(value) != _RGB_LEN:
-        raise ValueError(f"{name} must be [R, G, B] (length 3), got length {len(value)}")
+        raise ValueError(f"{name} must be (R, G, B) (length 3), got length {len(value)}")
     for component in value:
         if not (0 <= component <= 255):
             raise ValueError(f"{name} values must be 0-255, got {component}")
@@ -30,34 +32,41 @@ def _validate_rgb(name: str, value: list[int]) -> None:
 class SessionUpdateColor(DataClassORJSONMixin):
     """Color object in server/state message."""
 
+    _RGB_FIELDS: ClassVar[tuple[str, ...]] = (
+        "background_dark",
+        "background_light",
+        "primary",
+        "accent",
+        "on_dark",
+        "on_light",
+    )
+
     timestamp: int
     """Server clock time in microseconds for when these colors are valid."""
-    background_dark: list[int] | None | UndefinedField = field(default_factory=undefined_field)
+    background_dark: _RGB | None | UndefinedField = field(default_factory=undefined_field)
     """Background color for dark mode as [R, G, B]. Null clears the field."""
-    background_light: list[int] | None | UndefinedField = field(default_factory=undefined_field)
+    background_light: _RGB | None | UndefinedField = field(default_factory=undefined_field)
     """Background color for light mode as [R, G, B]. Null clears the field."""
-    primary: list[int] | None | UndefinedField = field(default_factory=undefined_field)
+    primary: _RGB | None | UndefinedField = field(default_factory=undefined_field)
     """Dominant color as [R, G, B]. Null clears the field."""
-    accent: list[int] | None | UndefinedField = field(default_factory=undefined_field)
+    accent: _RGB | None | UndefinedField = field(default_factory=undefined_field)
     """Secondary or complementary color as [R, G, B]. Null clears the field."""
-    on_dark: list[int] | None | UndefinedField = field(default_factory=undefined_field)
+    on_dark: _RGB | None | UndefinedField = field(default_factory=undefined_field)
     """Light color for use on dark backgrounds as [R, G, B]. Null clears the field."""
-    on_light: list[int] | None | UndefinedField = field(default_factory=undefined_field)
+    on_light: _RGB | None | UndefinedField = field(default_factory=undefined_field)
     """Dark color for use on light backgrounds as [R, G, B]. Null clears the field."""
 
     def __post_init__(self) -> None:
         """Validate RGB fields."""
-        for name in (
-            "background_dark",
-            "background_light",
-            "primary",
-            "accent",
-            "on_dark",
-            "on_light",
-        ):
+        for name in self._RGB_FIELDS:
             value = getattr(self, name)
             if not isinstance(value, UndefinedField) and value is not None:
                 _validate_rgb(name, value)
+
+    @classmethod
+    def cleared(cls, timestamp: int) -> SessionUpdateColor:
+        """Build a SessionUpdateColor that explicitly clears all color fields."""
+        return cls(timestamp=timestamp, **dict.fromkeys(cls._RGB_FIELDS))
 
     class Config(BaseConfig):
         """Config for parsing json messages."""

--- a/aiosendspin/server/roles/color/group.py
+++ b/aiosendspin/server/roles/color/group.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from aiosendspin.models.color import SessionUpdateColor
 from aiosendspin.models.core import ServerStateMessage, ServerStatePayload
 from aiosendspin.server.roles.base import GroupRole, Role
 from aiosendspin.server.roles.color.events import ColorClearedEvent, ColorUpdatedEvent
 from aiosendspin.server.roles.color.state import Color
+from aiosendspin.server.roles.color.types import ColorRoleProtocol
 
 if TYPE_CHECKING:
     from aiosendspin.server.group import SendspinGroup
@@ -35,26 +37,24 @@ class ColorGroupRole(GroupRole):
         """Send current color to newly joined member."""
         self._send_state_to_role(role)
 
-    def _send_state_to_role(self, role: Role) -> None:
+    def _send_state_to_role(self, role: ColorRoleProtocol) -> None:
         """Send current color state to a single role."""
         timestamp = self._group._server.clock.now_us()  # noqa: SLF001
         if self._current_color is not None:
             color_update = self._current_color.snapshot_update(timestamp)
         else:
-            color_update = Color.cleared_update(timestamp)
-        state_message = ServerStateMessage(ServerStatePayload(color=color_update))
-        role.send_message(state_message)
+            color_update = SessionUpdateColor.cleared(timestamp)
+        role.send_message(ServerStateMessage(ServerStatePayload(color=color_update)))
 
     def set_color(self, color: Color | None) -> None:
         """Set color palette and push updates to all subscribed roles."""
-        timestamp = self._group._server.clock.now_us()  # noqa: SLF001
-
-        if color is not None and color.equals(self._current_color):
+        if color == self._current_color:
             return
 
+        timestamp = self._group._server.clock.now_us()  # noqa: SLF001
         last_color = self._current_color
         if color is None:
-            color_update = Color.cleared_update(timestamp)
+            color_update = SessionUpdateColor.cleared(timestamp)
         else:
             color_update = color.diff_update(last_color, timestamp)
 

--- a/aiosendspin/server/roles/color/state.py
+++ b/aiosendspin/server/roles/color/state.py
@@ -4,12 +4,20 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from aiosendspin.models.color import SessionUpdateColor
+from aiosendspin.models.color import SessionUpdateColor, _validate_rgb
 
 _RGB = tuple[int, int, int]
 _WHITE: _RGB = (255, 255, 255)
 _BLACK: _RGB = (0, 0, 0)
 _MIN_CONTRAST = 4.5
+_RGB_FIELDS: tuple[str, ...] = (
+    "background_dark",
+    "background_light",
+    "primary",
+    "accent",
+    "on_dark",
+    "on_light",
+)
 
 
 def _relative_luminance(rgb: _RGB) -> float:
@@ -59,7 +67,11 @@ class Color:
     """Dark color for use on light backgrounds as (R, G, B)."""
 
     def __post_init__(self) -> None:
-        """Validate spec-mandated contrast pairs."""
+        """Validate RGB shape, range, and spec-mandated contrast pairs."""
+        for name in _RGB_FIELDS:
+            value = getattr(self, name)
+            if value is not None:
+                _validate_rgb(name, value)
         if self.background_dark is not None:
             _assert_contrast("background_dark vs white text", self.background_dark, _WHITE)
             if self.on_dark is not None:

--- a/aiosendspin/server/roles/color/state.py
+++ b/aiosendspin/server/roles/color/state.py
@@ -6,52 +6,74 @@ from dataclasses import dataclass
 
 from aiosendspin.models.color import SessionUpdateColor
 
+_RGB = tuple[int, int, int]
+_WHITE: _RGB = (255, 255, 255)
+_BLACK: _RGB = (0, 0, 0)
+_MIN_CONTRAST = 4.5
 
-@dataclass
+
+def _relative_luminance(rgb: _RGB) -> float:
+    """Compute WCAG relative luminance for an sRGB color."""
+
+    def channel(c: int) -> float:
+        s = c / 255.0
+        return s / 12.92 if s <= 0.03928 else ((s + 0.055) / 1.055) ** 2.4
+
+    r, g, b = rgb
+    return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+
+
+def _contrast_ratio(a: _RGB, b: _RGB) -> float:
+    """Compute WCAG contrast ratio between two RGB colors."""
+    la = _relative_luminance(a)
+    lb = _relative_luminance(b)
+    lighter, darker = (la, lb) if la >= lb else (lb, la)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def _assert_contrast(label: str, a: _RGB, b: _RGB) -> None:
+    ratio = _contrast_ratio(a, b)
+    if ratio < _MIN_CONTRAST:
+        raise ValueError(f"{label}: contrast {ratio:.2f} < {_MIN_CONTRAST}:1")
+
+
+@dataclass(frozen=True)
 class Color:
-    """Color palette for the current audio."""
+    """Color palette for the current audio.
 
-    background_dark: list[int] | None = None
-    """Background color for dark mode as [R, G, B].
-
-    Caller must ensure a WCAG contrast ratio of at least 4.5:1 with white text
-    and with `on_dark` (if also set).
-    """
-    background_light: list[int] | None = None
-    """Background color for light mode as [R, G, B].
-
-    Caller must ensure a WCAG contrast ratio of at least 4.5:1 with black text
-    and with `on_light` (if also set).
-    """
-    primary: list[int] | None = None
-    """Dominant color as [R, G, B]. Not adjusted for contrast."""
-    accent: list[int] | None = None
-    """Secondary or complementary color as [R, G, B]. Not adjusted for contrast."""
-    on_dark: list[int] | None = None
-    """Light color for use on dark backgrounds as [R, G, B].
-
-    Caller must ensure a WCAG contrast ratio of at least 4.5:1 with `background_dark`
-    (if also set).
-    """
-    on_light: list[int] | None = None
-    """Dark color for use on light backgrounds as [R, G, B].
-
-    Caller must ensure a WCAG contrast ratio of at least 4.5:1 with `background_light`
-    (if also set).
+    Enforces the WCAG ≥4.5:1 contrast invariants from the Sendspin color@v1
+    spec at construction time.
     """
 
-    def equals(self, other: Color | None) -> bool:
-        """Check if color palette is equal to another."""
-        if other is None:
-            return False
-        return (
-            self.background_dark == other.background_dark
-            and self.background_light == other.background_light
-            and self.primary == other.primary
-            and self.accent == other.accent
-            and self.on_dark == other.on_dark
-            and self.on_light == other.on_light
-        )
+    background_dark: _RGB | None = None
+    """Background color for dark mode as (R, G, B)."""
+    background_light: _RGB | None = None
+    """Background color for light mode as (R, G, B)."""
+    primary: _RGB | None = None
+    """Dominant color as (R, G, B). Not adjusted for contrast."""
+    accent: _RGB | None = None
+    """Secondary or complementary color as (R, G, B). Not adjusted for contrast."""
+    on_dark: _RGB | None = None
+    """Light color for use on dark backgrounds as (R, G, B)."""
+    on_light: _RGB | None = None
+    """Dark color for use on light backgrounds as (R, G, B)."""
+
+    def __post_init__(self) -> None:
+        """Validate spec-mandated contrast pairs."""
+        if self.background_dark is not None:
+            _assert_contrast("background_dark vs white text", self.background_dark, _WHITE)
+            if self.on_dark is not None:
+                _assert_contrast("background_dark vs on_dark", self.background_dark, self.on_dark)
+        if self.background_light is not None:
+            _assert_contrast("background_light vs black text", self.background_light, _BLACK)
+            if self.on_light is not None:
+                _assert_contrast(
+                    "background_light vs on_light", self.background_light, self.on_light
+                )
+        if self.on_dark is not None:
+            _assert_contrast("on_dark vs black text", self.on_dark, _BLACK)
+        if self.on_light is not None:
+            _assert_contrast("on_light vs white text", self.on_light, _WHITE)
 
     def diff_update(self, last: Color | None, timestamp: int) -> SessionUpdateColor:
         """Build a SessionUpdateColor containing only changed fields compared to last."""
@@ -72,23 +94,4 @@ class Color:
 
     def snapshot_update(self, timestamp: int) -> SessionUpdateColor:
         """Build a SessionUpdateColor snapshot with all current values."""
-        update = SessionUpdateColor(timestamp=timestamp)
-        update.background_dark = self.background_dark
-        update.background_light = self.background_light
-        update.primary = self.primary
-        update.accent = self.accent
-        update.on_dark = self.on_dark
-        update.on_light = self.on_light
-        return update
-
-    @staticmethod
-    def cleared_update(timestamp: int) -> SessionUpdateColor:
-        """Build a SessionUpdateColor that clears all color fields."""
-        update = SessionUpdateColor(timestamp=timestamp)
-        update.background_dark = None
-        update.background_light = None
-        update.primary = None
-        update.accent = None
-        update.on_dark = None
-        update.on_light = None
-        return update
+        return self.diff_update(None, timestamp)

--- a/tests/models/test_color.py
+++ b/tests/models/test_color.py
@@ -1,0 +1,54 @@
+"""Tests for SessionUpdateColor wire model."""
+
+from __future__ import annotations
+
+import pytest
+
+from aiosendspin.models.color import SessionUpdateColor
+from aiosendspin.models.types import UndefinedField
+
+
+def test_undefined_fields_omitted_from_json() -> None:
+    """Fields left as UndefinedField are omitted from serialized JSON."""
+    update = SessionUpdateColor(timestamp=42, primary=(10, 20, 30))
+    payload = update.to_dict()
+    assert payload == {"timestamp": 42, "primary": [10, 20, 30]}
+
+
+def test_explicit_none_serializes_as_null() -> None:
+    """Explicit None serializes (clears the field on the wire)."""
+    update = SessionUpdateColor.cleared(timestamp=7)
+    payload = update.to_dict()
+    assert payload["primary"] is None
+    assert payload["background_dark"] is None
+    assert payload["on_light"] is None
+
+
+def test_roundtrip_decodes_to_tuples() -> None:
+    """A wire dict with integer arrays decodes back to tuples."""
+    raw = {
+        "timestamp": 1,
+        "background_dark": [1, 2, 3],
+        "primary": [255, 0, 0],
+    }
+    update = SessionUpdateColor.from_dict(raw)
+    assert update.background_dark == (1, 2, 3)
+    assert update.primary == (255, 0, 0)
+
+
+def test_rgb_component_out_of_range_raises() -> None:
+    """Validation rejects component outside 0-255."""
+    with pytest.raises(ValueError, match="primary values must be 0-255"):
+        SessionUpdateColor(timestamp=0, primary=(300, 0, 0))  # type: ignore[arg-type]
+
+
+def test_undefined_field_passes_validation() -> None:
+    """UndefinedField sentinel does not trigger validation."""
+    update = SessionUpdateColor(timestamp=0)
+    assert isinstance(update.primary, UndefinedField)
+
+
+def test_rgb_wrong_length_raises() -> None:
+    """Validation rejects tuples that are not exactly 3 components."""
+    with pytest.raises(ValueError, match=r"primary must be \(R, G, B\)"):
+        SessionUpdateColor(timestamp=0, primary=(1, 2, 3, 4))  # type: ignore[arg-type]

--- a/tests/server/roles/color/test_group.py
+++ b/tests/server/roles/color/test_group.py
@@ -39,22 +39,22 @@ def test_set_color_stores_and_broadcasts() -> None:
     member = MagicMock()
     cgr._members = [member]  # noqa: SLF001
 
-    color = Color(primary=[255, 0, 0], accent=[0, 255, 0])
+    color = Color(primary=(255, 0, 0), accent=(0, 255, 0))
     cgr.set_color(color)
 
     assert cgr.color is not None
-    assert cgr.color.primary == [255, 0, 0]
+    assert cgr.color.primary == (255, 0, 0)
 
     member.send_message.assert_called_once()
     msg = member.send_message.call_args.args[0]
     assert isinstance(msg, ServerStateMessage)
     assert msg.payload.color is not None
-    assert msg.payload.color.primary == [255, 0, 0]
+    assert msg.payload.color.primary == (255, 0, 0)
 
     group._signal_event.assert_called_once()  # noqa: SLF001
     event = group._signal_event.call_args.args[0]  # noqa: SLF001
     assert isinstance(event, ColorUpdatedEvent)
-    assert event.color.primary == [255, 0, 0]
+    assert event.color.primary == (255, 0, 0)
     assert event.previous_color is None
 
 
@@ -63,11 +63,11 @@ def test_set_color_no_op_when_equal() -> None:
     group = _make_group_stub()
     cgr = ColorGroupRole(group)
 
-    color = Color(primary=[255, 0, 0])
+    color = Color(primary=(255, 0, 0))
     cgr.set_color(color)
     group._signal_event.reset_mock()  # noqa: SLF001
 
-    cgr.set_color(Color(primary=[255, 0, 0]))
+    cgr.set_color(Color(primary=(255, 0, 0)))
 
     group._signal_event.assert_not_called()  # noqa: SLF001
 
@@ -80,7 +80,7 @@ def test_clear_color() -> None:
     member = MagicMock()
     cgr._members = [member]  # noqa: SLF001
 
-    cgr.set_color(Color(primary=[255, 0, 0]))
+    cgr.set_color(Color(primary=(255, 0, 0)))
     member.send_message.reset_mock()
     group._signal_event.reset_mock()  # noqa: SLF001
 
@@ -101,7 +101,7 @@ def test_on_member_join_sends_current_color() -> None:
     """on_member_join sends a snapshot to the new member."""
     group = _make_group_stub()
     cgr = ColorGroupRole(group)
-    cgr._current_color = Color(primary=[100, 150, 200])  # noqa: SLF001
+    cgr._current_color = Color(primary=(100, 150, 200))  # noqa: SLF001
 
     member = MagicMock()
     cgr.on_member_join(member)
@@ -110,7 +110,7 @@ def test_on_member_join_sends_current_color() -> None:
     msg = member.send_message.call_args.args[0]
     assert isinstance(msg, ServerStateMessage)
     assert msg.payload.color is not None
-    assert msg.payload.color.primary == [100, 150, 200]
+    assert msg.payload.color.primary == (100, 150, 200)
 
 
 def test_on_member_join_sends_cleared_when_no_color() -> None:

--- a/tests/server/roles/color/test_state.py
+++ b/tests/server/roles/color/test_state.py
@@ -57,3 +57,15 @@ def test_valid_full_palette_passes() -> None:
         on_dark=(255, 255, 255),
         on_light=(0, 0, 0),
     )
+
+
+def test_rgb_wrong_length_raises() -> None:
+    """Color rejects tuples that are not exactly 3 components."""
+    with pytest.raises(ValueError, match=r"primary must be \(R, G, B\)"):
+        Color(primary=(1, 2, 3, 4))  # type: ignore[arg-type]
+
+
+def test_rgb_component_out_of_range_raises() -> None:
+    """Color rejects component values outside 0-255."""
+    with pytest.raises(ValueError, match="primary values must be 0-255"):
+        Color(primary=(300, 0, 0))

--- a/tests/server/roles/color/test_state.py
+++ b/tests/server/roles/color/test_state.py
@@ -1,0 +1,59 @@
+"""Tests for the Color domain dataclass and its WCAG invariants."""
+
+from __future__ import annotations
+
+import pytest
+
+from aiosendspin.server.roles.color.state import Color
+
+
+def test_empty_color_is_valid() -> None:
+    """All-None Color passes (no constraints triggered)."""
+    Color()
+
+
+def test_primary_and_accent_alone_are_not_contrast_checked() -> None:
+    """primary/accent have no spec contrast requirement."""
+    Color(primary=(255, 0, 0), accent=(0, 255, 0))
+
+
+def test_background_dark_fails_against_white_text() -> None:
+    """A near-white background_dark cannot clear 4.5:1 vs white text."""
+    with pytest.raises(ValueError, match="background_dark vs white text"):
+        Color(background_dark=(240, 240, 240))
+
+
+def test_background_light_fails_against_black_text() -> None:
+    """A near-black background_light cannot clear 4.5:1 vs black text."""
+    with pytest.raises(ValueError, match="background_light vs black text"):
+        Color(background_light=(20, 20, 20))
+
+
+def test_on_dark_fails_against_black_text() -> None:
+    """on_dark must also serve as a light bg (4.5:1 vs black)."""
+    with pytest.raises(ValueError, match="on_dark vs black text"):
+        Color(on_dark=(50, 50, 50))
+
+
+def test_on_light_fails_against_white_text() -> None:
+    """on_light must also serve as a dark bg (4.5:1 vs white)."""
+    with pytest.raises(ValueError, match="on_light vs white text"):
+        Color(on_light=(220, 220, 220))
+
+
+def test_background_dark_and_on_dark_pair_must_clear_min_contrast() -> None:
+    """background_dark vs on_dark must clear 4.5:1 when both set."""
+    with pytest.raises(ValueError, match="background_dark vs on_dark"):
+        Color(background_dark=(0, 0, 0), on_dark=(40, 40, 40))
+
+
+def test_valid_full_palette_passes() -> None:
+    """A palette satisfying all spec contrast rules constructs cleanly."""
+    Color(
+        background_dark=(0, 0, 0),
+        background_light=(255, 255, 255),
+        primary=(180, 30, 30),
+        accent=(30, 180, 30),
+        on_dark=(255, 255, 255),
+        on_light=(0, 0, 0),
+    )


### PR DESCRIPTION
Switch RGB fields to `tuple[int, int, int]` across the wire and domain models. `Color.__post_init__` now validates the WCAG 4.5:1 contrast pairs defined by the spec so the role no longer relies on upstream callers for the invariant. Drops the redundant `equals()` override and moves the clear-helper to a `SessionUpdateColor.cleared()` classmethod.