### PR TITLE
Add player timing capabilities (`required_lead_time_ms`, `min_buffer_ms`)

### DIFF
--- a/aiosendspin/client/client.py
+++ b/aiosendspin/client/client.py
@@ -204,6 +204,10 @@ class SendspinClient:
 
     _static_delay_us: int = 0
     """Static playback delay in microseconds."""
+    _required_lead_time_us: int = 250_000
+    """Reported startup lead time in microseconds."""
+    _min_buffer_us: int = 250_000
+    """Reported minimum ongoing buffer duration in microseconds."""
     _send_lock: asyncio.Lock
     """Lock for serializing WebSocket message sends."""
     _time_filter: SendspinTimeFilter
@@ -273,6 +277,8 @@ class SendspinClient:
         visualizer_support: ClientHelloVisualizerSupport | None = None,
         session: ClientSession | None = None,
         static_delay_ms: float = 0.0,
+        required_lead_time_ms: float = 250.0,
+        min_buffer_ms: float = 250.0,
         initial_volume: int = 100,
         initial_muted: bool = False,
         state_supported_commands: list[PlayerCommand] | None = None,
@@ -299,6 +305,12 @@ class SendspinClient:
                 and managed by this client.
             static_delay_ms: Static playback delay in milliseconds applied after
                 clock synchronization. Defaults to 0.0.
+            required_lead_time_ms: Startup lead time reported via client/state
+                (codec init, decode warmup, backend buffering, DAC latency).
+                Defaults to 250.0. Excludes static_delay_ms.
+            min_buffer_ms: Minimum ongoing buffer duration reported via client/state
+                to absorb network jitter and decode/playback variance. Defaults to
+                250.0. Excludes static_delay_ms.
             initial_volume: Initial volume level (0-100) for player role.
                 Defaults to 100. Sent automatically after handshake if PLAYER
                 role is supported.
@@ -351,6 +363,8 @@ class SendspinClient:
         self._initial_volume = initial_volume
         self._initial_muted = initial_muted
         self.set_static_delay_ms(static_delay_ms)
+        self.set_required_lead_time_ms(required_lead_time_ms)
+        self.set_min_buffer_ms(min_buffer_ms)
         self._state_supported_commands: list[PlayerCommand] = list(state_supported_commands or [])
 
         # Initialize callback lists
@@ -391,6 +405,40 @@ class SendspinClient:
             return
         self._static_delay_us = delay_us
         logger.info("Set static playback delay to %.1f ms", self.static_delay_ms)
+
+    @property
+    def required_lead_time_ms(self) -> float:
+        """Return the currently reported startup lead time in milliseconds."""
+        return self._required_lead_time_us / 1_000.0
+
+    def set_required_lead_time_ms(self, lead_ms: float) -> None:
+        """Update the startup lead time reported via client/state.
+
+        If changing frequently, the caller must debounce to only report sustained shifts.
+        """
+        lead_ms = max(0.0, min(30000.0, lead_ms))
+        lead_us = round(lead_ms * 1_000.0)
+        if lead_us == self._required_lead_time_us:
+            return
+        self._required_lead_time_us = lead_us
+        logger.info("Set required lead time to %.1f ms", self.required_lead_time_ms)
+
+    @property
+    def min_buffer_ms(self) -> float:
+        """Return the currently reported minimum ongoing buffer duration in milliseconds."""
+        return self._min_buffer_us / 1_000.0
+
+    def set_min_buffer_ms(self, buffer_ms: float) -> None:
+        """Update the minimum ongoing buffer duration reported via client/state.
+
+        If changing frequently, the caller must debounce to only report sustained shifts.
+        """
+        buffer_ms = max(0.0, min(30000.0, buffer_ms))
+        buffer_us = round(buffer_ms * 1_000.0)
+        if buffer_us == self._min_buffer_us:
+            return
+        self._min_buffer_us = buffer_us
+        logger.info("Set minimum ongoing buffer to %.1f ms", self.min_buffer_ms)
 
     async def connect(self, url: str) -> None:
         """Connect to a Sendspin server via WebSocket."""
@@ -514,6 +562,8 @@ class SendspinClient:
                     volume=volume,
                     muted=muted,
                     static_delay_ms=round(self._static_delay_us / 1_000),
+                    required_lead_time_ms=round(self._required_lead_time_us / 1_000),
+                    min_buffer_ms=round(self._min_buffer_us / 1_000),
                     supported_commands=self._state_supported_commands or None,
                 )
             )

--- a/aiosendspin/models/player.py
+++ b/aiosendspin/models/player.py
@@ -88,6 +88,21 @@ class PlayerStatePayload(DataClassORJSONMixin):
     """Mute state, only included if 'mute' in supported_commands."""
     static_delay_ms: int = 0
     """Static delay in milliseconds (0-5000), always present for players."""
+    # TODO: drop default once all clients report this field per spec.
+    required_lead_time_ms: int = 250
+    """Minimum startup lead time in milliseconds (0-30000), always present for players.
+
+    Measured from the server transmit time of the start/restart trigger (stream/start
+    or stream/clear) to the timestamp of the first subsequent audio chunk. Covers codec
+    init, decode warmup, audio backend buffering, and DAC latency. Excludes static_delay_ms.
+    """
+    # TODO: drop default once all clients report this field per spec.
+    min_buffer_ms: int = 250
+    """Requested minimum ongoing buffer duration in milliseconds (0-30000).
+
+    Maintained during playback (primarily for live streams) to absorb network jitter and
+    decode/playback timing variance. Excludes static_delay_ms.
+    """
     supported_commands: list[PlayerCommand] | None = None
     """Subset of: 'set_static_delay'. Commands this player supports via client/state."""
 
@@ -97,6 +112,12 @@ class PlayerStatePayload(DataClassORJSONMixin):
             raise ValueError(f"Volume must be in range 0-100, got {self.volume}")
         if not 0 <= self.static_delay_ms <= 5000:
             raise ValueError(f"static_delay_ms must be in range 0-5000, got {self.static_delay_ms}")
+        if not 0 <= self.required_lead_time_ms <= 30000:
+            raise ValueError(
+                f"required_lead_time_ms must be in range 0-30000, got {self.required_lead_time_ms}"
+            )
+        if not 0 <= self.min_buffer_ms <= 30000:
+            raise ValueError(f"min_buffer_ms must be in range 0-30000, got {self.min_buffer_ms}")
         VALID_STATE_COMMANDS = {PlayerCommand.SET_STATIC_DELAY}  # noqa: N806
         if self.supported_commands:
             invalid = [c for c in self.supported_commands if c not in VALID_STATE_COMMANDS]

--- a/aiosendspin/server/__init__.py
+++ b/aiosendspin/server/__init__.py
@@ -24,6 +24,8 @@ __all__ = [
     "GroupMemberRemovedEvent",
     "GroupRoleEvent",
     "GroupStateChangedEvent",
+    "MinBufferChangedEvent",
+    "RequiredLeadTimeChangedEvent",
     "SendspinClient",
     "SendspinEvent",
     "SendspinGroup",
@@ -50,7 +52,12 @@ from .events import (
 from .group import (
     SendspinGroup,
 )
-from .roles.player.events import StaticDelayChangedEvent, VolumeChangedEvent
+from .roles.player.events import (
+    MinBufferChangedEvent,
+    RequiredLeadTimeChangedEvent,
+    StaticDelayChangedEvent,
+    VolumeChangedEvent,
+)
 from .server import (
     ClientAddedEvent,
     ClientRemovedEvent,

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -773,7 +773,7 @@ class PushStream:
         """Return a stable timestamp for commits interrupted by stop()."""
         if self._channel_timing:
             return min(self._channel_timing.values())
-        return self._clock.now_us() + DEFAULT_INITIAL_DELAY_US + self._max_active_static_delay_us()
+        return self._clock.now_us() + self._min_send_ahead_us()
 
     @staticmethod
     def _client_in_audio_pipeline(client: SendspinClient) -> bool:
@@ -814,6 +814,26 @@ class PushStream:
         if not roles:
             return 0
         return max(role.get_static_delay_us() for _, role in roles)
+
+    @staticmethod
+    def _role_send_ahead_us(role: Role) -> int:
+        """Per-role send-ahead floor: max(required_lead, min_buffer) + static_delay.
+
+        Satisfies both spec constraints at once: the first chunk lands at least
+        required_lead_time_ms ahead (startup) and the ongoing timeline never sits
+        below min_buffer_ms ahead, with the player's static delay added on top.
+        """
+        return (
+            max(role.get_required_lead_time_us(), role.get_min_buffer_us())
+            + role.get_static_delay_us()
+        )
+
+    def _min_send_ahead_us(self) -> int:
+        """Return the common send-ahead floor across active audio roles."""
+        roles = self._get_audio_roles()
+        if not roles:
+            return DEFAULT_INITIAL_DELAY_US
+        return max(self._role_send_ahead_us(role) for _, role in roles)
 
     def _get_cached_resampler(self, key: _ResamplerKey) -> _ResamplerState | None:
         """Get existing resampler from cache, or None if not cached."""
@@ -961,7 +981,9 @@ class PushStream:
             # drifted far ahead (e.g., reconnect with large server-side buffering),
             # use the standard near-now target to avoid long audible startup delays.
             channel_tail_us = max(now_us, self._channel_timing[channel_id])
-            align_ceiling_us = now_us + DEFAULT_INITIAL_DELAY_US + delay_us
+            align_ceiling_us = now_us + (
+                self._role_send_ahead_us(role) if role is not None else DEFAULT_INITIAL_DELAY_US
+            )
             if channel_tail_us <= align_ceiling_us:
                 return max(channel_tail_us, target_us)
         return target_us
@@ -1007,9 +1029,7 @@ class PushStream:
             if not self._channel_buffers and not historical:
                 now_us = self._clock.now_us()
                 if not self._channel_timing:
-                    self._channel_timing[MAIN_CHANNEL] = (
-                        now_us + DEFAULT_INITIAL_DELAY_US + self._max_active_static_delay_us()
-                    )
+                    self._channel_timing[MAIN_CHANNEL] = now_us + self._min_send_ahead_us()
                     self._channel_timing_residue[MAIN_CHANNEL] = 0
                 return min(self._channel_timing.values())
 
@@ -1143,7 +1163,7 @@ class PushStream:
 
         # Auto-calculate mode (existing behavior).
         now_us = self._clock.now_us()
-        target_min_us = now_us + DEFAULT_INITIAL_DELAY_US + self._max_active_static_delay_us()
+        target_min_us = now_us + self._min_send_ahead_us()
         # Limit timeline sharing/rebase inputs to channels participating in this commit
         # (active subscribers + prepared payloads). This excludes stale timing entries
         # from inactive channels.
@@ -1205,9 +1225,7 @@ class PushStream:
         :param historical: Channel ID -> list of (pcm, format) chunks (oldest first).
         """
         now_us = self._clock.now_us()
-        min_delivery_timestamp_us = (
-            now_us + DEFAULT_INITIAL_DELAY_US + self._max_active_static_delay_us()
-        )
+        min_delivery_timestamp_us = now_us + self._min_send_ahead_us()
 
         for channel_id, chunks in historical.items():
             if not self._is_generation_active(commit_generation):
@@ -1258,9 +1276,7 @@ class PushStream:
                 self._channel_timing[channel_id] = max(0, anchor_timing_us - total_duration_us)
                 self._channel_timing_residue[channel_id] = 0
             else:
-                self._channel_timing[channel_id] = (
-                    now_us + DEFAULT_INITIAL_DELAY_US + self._max_active_static_delay_us()
-                )
+                self._channel_timing[channel_id] = now_us + self._min_send_ahead_us()
                 self._channel_timing_residue[channel_id] = 0
 
             for pcm_bytes, fmt in chunks:
@@ -2068,7 +2084,7 @@ class PushStream:
             # will de-sync it from other clients.
             return
         now_us = self._clock.now_us()
-        max_resume_start_us = now_us + DEFAULT_INITIAL_DELAY_US + joining_role.get_static_delay_us()
+        max_resume_start_us = now_us + self._role_send_ahead_us(joining_role)
         self._channel_timing[channel_id] = min(
             self._channel_timing[channel_id], max_resume_start_us
         )

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -1214,7 +1214,7 @@ class PushStream:
 
         # If audio production stalls (e.g., the upstream source blocks), the scheduled
         # play timeline can drift into the past. Rebase the timeline so new audio is
-        # always scheduled with at least the default initial delay from "now".
+        # always scheduled at least `_min_send_ahead_us()` from "now".
         rebase_candidates = [
             self._channel_timing[cid]
             for cid in active_or_prepared_channels

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -703,6 +703,11 @@ class PushStream:
         self._clock = clock
         self._group = group
         self._is_stopped = False
+        # Whether the audio source is realtime (live) vs buffered. Live sources
+        # honor min_buffer_ms at startup since the queue cannot grow after
+        # playback begins. Buffered sources skip the min_buffer startup wait.
+        # Default to buffered; callers opt into live via set_live_source(True).
+        self._is_live: bool = False
         # Monotonic lifecycle token used to invalidate in-flight commit work on stop().
         self._stream_generation = 0
         # Pending audio per channel: channel_id -> (pcm_bytes, audio_format)
@@ -815,18 +820,22 @@ class PushStream:
             return 0
         return max(role.get_static_delay_us() for _, role in roles)
 
-    @staticmethod
-    def _role_send_ahead_us(role: Role) -> int:
-        """Per-role send-ahead floor: max(required_lead, min_buffer) + static_delay.
+    def _role_send_ahead_us(self, role: Role) -> int:
+        """Per-role send-ahead floor.
 
-        Satisfies both spec constraints at once: the first chunk lands at least
-        required_lead_time_ms ahead (startup) and the ongoing timeline never sits
-        below min_buffer_ms ahead, with the player's static delay added on top.
+        Live: max(required_lead, min_buffer) + static. The first chunk lands at
+        least required_lead ahead and the timeline never sits below min_buffer
+        ahead, since a realtime queue cannot grow after playback begins.
+
+        Buffered: required_lead + static. The queue grows naturally past
+        min_buffer once playback starts, so paying min_buffer upfront would only
+        add startup latency without buying jitter resilience.
         """
-        return (
-            max(role.get_required_lead_time_us(), role.get_min_buffer_us())
-            + role.get_static_delay_us()
-        )
+        lead_us = role.get_required_lead_time_us()
+        static_us = role.get_static_delay_us()
+        if self._is_live:
+            return max(lead_us, role.get_min_buffer_us()) + static_us
+        return lead_us + static_us
 
     def _min_send_ahead_us(self) -> int:
         """Return the common send-ahead floor across active audio roles."""
@@ -834,6 +843,24 @@ class PushStream:
         if not roles:
             return DEFAULT_INITIAL_DELAY_US
         return max(self._role_send_ahead_us(role) for _, role in roles)
+
+    @property
+    def is_live(self) -> bool:
+        """Whether the audio source is treated as realtime/live."""
+        return self._is_live
+
+    def set_live_source(self, is_live: bool) -> None:  # noqa: FBT001
+        """Configure whether subsequent stream startups treat audio as live or buffered.
+
+        Buffered (default): startup uses only required_lead_time_ms since the
+        queue can grow naturally after playback begins. Live: startup waits for
+        min_buffer_ms so the jitter buffer is filled before playback, since a
+        realtime source cannot grow the queue after start.
+
+        Call before the first commit_audio of a new stream session so the startup
+        anchor uses the right floor.
+        """
+        self._is_live = is_live
 
     def _get_cached_resampler(self, key: _ResamplerKey) -> _ResamplerState | None:
         """Get existing resampler from cache, or None if not cached."""

--- a/aiosendspin/server/roles/base.py
+++ b/aiosendspin/server/roles/base.py
@@ -32,6 +32,11 @@ if TYPE_CHECKING:
     from aiosendspin.server.group import SendspinGroup
 
 
+# Default startup lead time used when a role does not report its own. Matches the
+# push stream's no-roles fallback so default behavior is unchanged.
+DEFAULT_REQUIRED_LEAD_TIME_US = 250_000
+
+
 @dataclass(frozen=True)
 class BinaryHandling:
     """Policy for how binary messages should be handled by connection.
@@ -266,6 +271,14 @@ class Role(ABC):
 
     def get_static_delay_us(self) -> int:
         """Return transport delay in microseconds applied by this role (default: 0)."""
+        return 0
+
+    def get_required_lead_time_us(self) -> int:
+        """Return the startup lead time this role needs before the first audio chunk."""
+        return DEFAULT_REQUIRED_LEAD_TIME_US
+
+    def get_min_buffer_us(self) -> int:
+        """Return the minimum ongoing buffer duration this role wants during playback."""
         return 0
 
     def get_join_delay_s(self) -> float:

--- a/aiosendspin/server/roles/player/__init__.py
+++ b/aiosendspin/server/roles/player/__init__.py
@@ -3,9 +3,11 @@
 from aiosendspin.models.player import ClientHelloPlayerSupport
 from aiosendspin.server.roles.player.audio_transformers import FlacEncoder, PcmPassthrough
 from aiosendspin.server.roles.player.events import (
+    MinBufferChangedEvent,
     PlayerGroupEvent,
     PlayerGroupMuteChangedEvent,
     PlayerGroupVolumeChangedEvent,
+    RequiredLeadTimeChangedEvent,
     StaticDelayChangedEvent,
     VolumeChangedEvent,
 )
@@ -30,6 +32,7 @@ register_role_support_spec(
 
 __all__ = [
     "FlacEncoder",
+    "MinBufferChangedEvent",
     "PcmPassthrough",
     "PlayerGroupEvent",
     "PlayerGroupMuteChangedEvent",
@@ -37,6 +40,7 @@ __all__ = [
     "PlayerGroupVolumeChangedEvent",
     "PlayerRoleProtocol",
     "PlayerV1Role",
+    "RequiredLeadTimeChangedEvent",
     "StaticDelayChangedEvent",
     "VolumeChangedEvent",
 ]

--- a/aiosendspin/server/roles/player/events.py
+++ b/aiosendspin/server/roles/player/events.py
@@ -22,6 +22,20 @@ class StaticDelayChangedEvent(ClientRoleEvent):
     static_delay_ms: int
 
 
+@dataclass
+class RequiredLeadTimeChangedEvent(ClientRoleEvent):
+    """The player's reported startup lead time was changed."""
+
+    required_lead_time_ms: int
+
+
+@dataclass
+class MinBufferChangedEvent(ClientRoleEvent):
+    """The player's reported minimum ongoing buffer duration was changed."""
+
+    min_buffer_ms: int
+
+
 class PlayerGroupEvent(GroupRoleEvent):
     """Base event type for player group role changes."""
 

--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -43,7 +43,12 @@ from aiosendspin.server.roles.player.audio_transformers import (
     PcmPassthrough,
 )
 from aiosendspin.server.roles.player.capabilities import can_encode_format, filter_encodable_formats
-from aiosendspin.server.roles.player.events import StaticDelayChangedEvent, VolumeChangedEvent
+from aiosendspin.server.roles.player.events import (
+    MinBufferChangedEvent,
+    RequiredLeadTimeChangedEvent,
+    StaticDelayChangedEvent,
+    VolumeChangedEvent,
+)
 from aiosendspin.util import create_task
 
 if TYPE_CHECKING:
@@ -62,6 +67,8 @@ class PlayerPersistentState:
     disconnect_time_us: int | None = None
     buffer_reset_handle: asyncio.TimerHandle | None = None
     static_delay_ms: int = 0
+    required_lead_time_ms: int = 250
+    min_buffer_ms: int = 250
     state_supported_commands: list[PlayerCommand] = field(default_factory=list)
 
 
@@ -420,6 +427,24 @@ class PlayerV1Role(Role):
         self._state().static_delay_ms = value
 
     @property
+    def required_lead_time_ms(self) -> int:
+        """Startup lead time reported by this player in milliseconds."""
+        return self._state().required_lead_time_ms
+
+    @required_lead_time_ms.setter
+    def required_lead_time_ms(self, value: int) -> None:
+        self._state().required_lead_time_ms = value
+
+    @property
+    def min_buffer_ms(self) -> int:
+        """Minimum ongoing buffer duration reported by this player in milliseconds."""
+        return self._state().min_buffer_ms
+
+    @min_buffer_ms.setter
+    def min_buffer_ms(self, value: int) -> None:
+        self._state().min_buffer_ms = value
+
+    @property
     def state_supported_commands(self) -> list[PlayerCommand]:
         """Commands supported via client/state (e.g., set_static_delay)."""
         return self._state().state_supported_commands
@@ -447,6 +472,14 @@ class PlayerV1Role(Role):
     def get_static_delay_us(self) -> int:
         """Return transport delay in microseconds for timestamp offsetting."""
         return max(self.static_delay_ms, 0) * 1_000
+
+    def get_required_lead_time_us(self) -> int:
+        """Return reported startup lead time in microseconds."""
+        return max(self.required_lead_time_ms, 0) * 1_000
+
+    def get_min_buffer_us(self) -> int:
+        """Return reported minimum ongoing buffer duration in microseconds."""
+        return max(self.min_buffer_ms, 0) * 1_000
 
     def get_static_delay_ms(self) -> int:
         """Return static delay for protocol API."""
@@ -641,6 +674,18 @@ class PlayerV1Role(Role):
             self.static_delay_ms = state.static_delay_ms
             self._client._signal_event(  # noqa: SLF001
                 StaticDelayChangedEvent(static_delay_ms=state.static_delay_ms)
+            )
+
+        if self.required_lead_time_ms != state.required_lead_time_ms:
+            self.required_lead_time_ms = state.required_lead_time_ms
+            self._client._signal_event(  # noqa: SLF001
+                RequiredLeadTimeChangedEvent(required_lead_time_ms=state.required_lead_time_ms)
+            )
+
+        if self.min_buffer_ms != state.min_buffer_ms:
+            self.min_buffer_ms = state.min_buffer_ms
+            self._client._signal_event(  # noqa: SLF001
+                MinBufferChangedEvent(min_buffer_ms=state.min_buffer_ms)
             )
 
     def on_stream_request_format(self, payload: StreamRequestFormatPayload) -> None:

--- a/tests/models/test_player.py
+++ b/tests/models/test_player.py
@@ -48,6 +48,32 @@ def test_player_state_backward_compat_no_delay() -> None:
     assert payload.static_delay_ms == 0
 
 
+def test_player_state_timing_defaults() -> None:
+    """Clients that omit timing fields get the 250 ms defaults."""
+    payload = PlayerStatePayload.from_json('{"volume": 50}')
+    assert payload.required_lead_time_ms == 250
+    assert payload.min_buffer_ms == 250
+
+
+def test_player_state_timing_serializes() -> None:
+    """Timing fields are always serialized (not omitted)."""
+    data = PlayerStatePayload(required_lead_time_ms=80, min_buffer_ms=1200).to_dict()
+    assert data["required_lead_time_ms"] == 80
+    assert data["min_buffer_ms"] == 1200
+
+
+def test_player_state_required_lead_time_out_of_range() -> None:
+    """required_lead_time_ms above 30000 is rejected."""
+    with pytest.raises(ValueError, match="required_lead_time_ms"):
+        PlayerStatePayload(required_lead_time_ms=30001)
+
+
+def test_player_state_min_buffer_negative_invalid() -> None:
+    """Negative min_buffer_ms is rejected."""
+    with pytest.raises(ValueError, match="min_buffer_ms"):
+        PlayerStatePayload(min_buffer_ms=-1)
+
+
 def test_player_command_set_static_delay_valid() -> None:
     """SET_STATIC_DELAY command accepts valid delay value."""
     cmd = PlayerCommandPayload(command=PlayerCommand.SET_STATIC_DELAY, static_delay_ms=300)

--- a/tests/server/roles/test_player_v1.py
+++ b/tests/server/roles/test_player_v1.py
@@ -22,6 +22,10 @@ from aiosendspin.server.audio import AudioFormat
 from aiosendspin.server.roles import PlayerV1Role
 from aiosendspin.server.roles.base import AudioChunk, AudioRequirements, StreamRequirements
 from aiosendspin.server.roles.player.audio_transformers import FlacEncoder, PcmPassthrough
+from aiosendspin.server.roles.player.events import (
+    MinBufferChangedEvent,
+    RequiredLeadTimeChangedEvent,
+)
 
 # --- Basic properties ---
 
@@ -851,6 +855,42 @@ def test_on_client_state_no_event_if_unchanged() -> None:
     payload = ClientStatePayload(player=PlayerStatePayload(static_delay_ms=0))
     role.on_client_state(payload)
     client._signal_event.assert_not_called()  # noqa: SLF001
+
+
+def test_timing_defaults() -> None:
+    """Lead time and min buffer default to 250 ms."""
+    client = _make_client_stub()
+    role = PlayerV1Role(client=client)
+    assert role.required_lead_time_ms == 250
+    assert role.min_buffer_ms == 250
+    assert role.get_required_lead_time_us() == 250_000
+    assert role.get_min_buffer_us() == 250_000
+
+
+def test_on_client_state_updates_required_lead_time() -> None:
+    """on_client_state() updates required_lead_time_ms and fires its event."""
+    client = _make_client_stub()
+    role = PlayerV1Role(client=client)
+    payload = ClientStatePayload(player=PlayerStatePayload(required_lead_time_ms=80))
+    role.on_client_state(payload)
+    assert role.required_lead_time_ms == 80
+    assert role.get_required_lead_time_us() == 80_000
+    event = client._signal_event.call_args[0][0]  # noqa: SLF001
+    assert isinstance(event, RequiredLeadTimeChangedEvent)
+    assert event.required_lead_time_ms == 80
+
+
+def test_on_client_state_updates_min_buffer() -> None:
+    """on_client_state() updates min_buffer_ms and fires its event."""
+    client = _make_client_stub()
+    role = PlayerV1Role(client=client)
+    payload = ClientStatePayload(player=PlayerStatePayload(min_buffer_ms=1500))
+    role.on_client_state(payload)
+    assert role.min_buffer_ms == 1500
+    assert role.get_min_buffer_us() == 1_500_000
+    event = client._signal_event.call_args[0][0]  # noqa: SLF001
+    assert isinstance(event, MinBufferChangedEvent)
+    assert event.min_buffer_ms == 1500
 
 
 def test_on_client_state_updates_supported_commands() -> None:

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -2767,7 +2767,7 @@ async def test_commit_audio_uses_reported_lead_time() -> None:
 
 @pytest.mark.asyncio
 async def test_commit_audio_min_buffer_floors_send_ahead() -> None:
-    """When min_buffer exceeds lead time, the send-ahead floor follows min_buffer."""
+    """Live streams: when min_buffer exceeds lead time, the floor follows min_buffer."""
     loop = asyncio.get_running_loop()
     clock = ManualClock(now_us_value=1_000_000)
     group = _DummyGroup(clients=[])
@@ -2775,6 +2775,7 @@ async def test_commit_audio_min_buffer_floors_send_ahead() -> None:
     group.clients.append(_DummyClient([role]))
 
     stream = PushStream(loop=loop, clock=clock, group=group)
+    stream.set_live_source(is_live=True)
     fmt = AudioFormat(sample_rate=48000, bit_depth=16, channels=2)
     stream.prepare_audio(bytes(4800), fmt)
     play_start = await stream.commit_audio()
@@ -2783,8 +2784,27 @@ async def test_commit_audio_min_buffer_floors_send_ahead() -> None:
 
 
 @pytest.mark.asyncio
+async def test_buffered_source_skips_min_buffer_at_startup() -> None:
+    """Buffered streams anchor startup at required_lead + static, ignoring min_buffer."""
+    loop = asyncio.get_running_loop()
+    clock = ManualClock(now_us_value=1_000_000)
+    group = _DummyGroup(clients=[])
+    role = _make_role(required_lead_time_us=0, min_buffer_us=15_000_000, static_delay_us=0)
+    group.clients.append(_DummyClient([role]))
+
+    stream = PushStream(loop=loop, clock=clock, group=group)
+    stream.set_live_source(is_live=False)
+    fmt = AudioFormat(sample_rate=48000, bit_depth=16, channels=2)
+    stream.prepare_audio(bytes(4800), fmt)
+    play_start = await stream.commit_audio()
+
+    # Buffered: startup = lead(0) + static(0) = 0; min_buffer ignored upfront.
+    assert play_start == clock.now_us()
+
+
+@pytest.mark.asyncio
 async def test_send_ahead_uses_largest_member_budget() -> None:
-    """Grouped players use a common floor: max(lead, min_buffer) + static across members."""
+    """Live grouped players use a common floor: max(lead, min_buffer) + static across members."""
     loop = asyncio.get_running_loop()
     clock = ManualClock(now_us_value=1_000_000)
     group = _DummyGroup(clients=[])
@@ -2795,6 +2815,7 @@ async def test_send_ahead_uses_largest_member_budget() -> None:
     group.clients.extend([_DummyClient([role_low]), _DummyClient([role_high])])
 
     stream = PushStream(loop=loop, clock=clock, group=group)
+    stream.set_live_source(is_live=True)
     fmt = AudioFormat(sample_rate=48000, bit_depth=16, channels=2)
     stream.prepare_audio(bytes(4800), fmt)
     play_start = await stream.commit_audio()

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -113,9 +113,18 @@ class _FakeConnection:
 
 
 class _DummyRole:
-    def __init__(self, requirements: AudioRequirements, *, static_delay_us: int = 0) -> None:
+    def __init__(
+        self,
+        requirements: AudioRequirements,
+        *,
+        static_delay_us: int = 0,
+        required_lead_time_us: int = DEFAULT_INITIAL_DELAY_US,
+        min_buffer_us: int = 0,
+    ) -> None:
         self._requirements = requirements
         self._static_delay_us = static_delay_us
+        self._required_lead_time_us = required_lead_time_us
+        self._min_buffer_us = min_buffer_us
         self.received: list[AudioChunk] = []
         self.started = 0
 
@@ -124,6 +133,12 @@ class _DummyRole:
 
     def get_static_delay_us(self) -> int:
         return self._static_delay_us
+
+    def get_required_lead_time_us(self) -> int:
+        return self._required_lead_time_us
+
+    def get_min_buffer_us(self) -> int:
+        return self._min_buffer_us
 
     def get_join_delay_s(self) -> float:
         return 0.0
@@ -2679,6 +2694,8 @@ _STATIC_DELAY_US = 5_000_000  # 5 s
 def _make_role(
     *,
     static_delay_us: int = 0,
+    required_lead_time_us: int = DEFAULT_INITIAL_DELAY_US,
+    min_buffer_us: int = 0,
     channel_id: UUID = MAIN_CHANNEL,
 ) -> _DummyRole:
     return _DummyRole(
@@ -2691,6 +2708,8 @@ def _make_role(
             frame_duration_us=25_000,
         ),
         static_delay_us=static_delay_us,
+        required_lead_time_us=required_lead_time_us,
+        min_buffer_us=min_buffer_us,
     )
 
 
@@ -2727,6 +2746,61 @@ async def test_mixed_delay_timeline_uses_largest_static_delay() -> None:
     play_start = await stream.commit_audio()
 
     assert play_start >= clock.now_us() + DEFAULT_INITIAL_DELAY_US + _STATIC_DELAY_US
+
+
+@pytest.mark.asyncio
+async def test_commit_audio_uses_reported_lead_time() -> None:
+    """A player reporting a low lead time starts ahead by exactly that lead."""
+    loop = asyncio.get_running_loop()
+    clock = ManualClock(now_us_value=1_000_000)
+    group = _DummyGroup(clients=[])
+    role = _make_role(required_lead_time_us=50_000, min_buffer_us=0, static_delay_us=0)
+    group.clients.append(_DummyClient([role]))
+
+    stream = PushStream(loop=loop, clock=clock, group=group)
+    fmt = AudioFormat(sample_rate=48000, bit_depth=16, channels=2)
+    stream.prepare_audio(bytes(4800), fmt)
+    play_start = await stream.commit_audio()
+
+    assert play_start == clock.now_us() + 50_000
+
+
+@pytest.mark.asyncio
+async def test_commit_audio_min_buffer_floors_send_ahead() -> None:
+    """When min_buffer exceeds lead time, the send-ahead floor follows min_buffer."""
+    loop = asyncio.get_running_loop()
+    clock = ManualClock(now_us_value=1_000_000)
+    group = _DummyGroup(clients=[])
+    role = _make_role(required_lead_time_us=50_000, min_buffer_us=2_000_000, static_delay_us=0)
+    group.clients.append(_DummyClient([role]))
+
+    stream = PushStream(loop=loop, clock=clock, group=group)
+    fmt = AudioFormat(sample_rate=48000, bit_depth=16, channels=2)
+    stream.prepare_audio(bytes(4800), fmt)
+    play_start = await stream.commit_audio()
+
+    assert play_start == clock.now_us() + 2_000_000
+
+
+@pytest.mark.asyncio
+async def test_send_ahead_uses_largest_member_budget() -> None:
+    """Grouped players use a common floor: max(lead, min_buffer) + static across members."""
+    loop = asyncio.get_running_loop()
+    clock = ManualClock(now_us_value=1_000_000)
+    group = _DummyGroup(clients=[])
+    role_low = _make_role(required_lead_time_us=100_000, min_buffer_us=0, static_delay_us=0)
+    role_high = _make_role(
+        required_lead_time_us=0, min_buffer_us=1_500_000, static_delay_us=200_000
+    )
+    group.clients.extend([_DummyClient([role_low]), _DummyClient([role_high])])
+
+    stream = PushStream(loop=loop, clock=clock, group=group)
+    fmt = AudioFormat(sample_rate=48000, bit_depth=16, channels=2)
+    stream.prepare_audio(bytes(4800), fmt)
+    play_start = await stream.commit_audio()
+
+    # role_high dominates: max(0, 1_500_000) + 200_000 = 1_700_000.
+    assert play_start == clock.now_us() + 1_700_000
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Adds player-reported `required_lead_time_ms` and `min_buffer_ms` in `client/state` so the server can size send-ahead per the player's startup warmup and ongoing jitter needs, dynamic across `client/state` updates and grouped via the max across members.

`PushStream` uses `max(required_lead, min_buffer) + static_delay` for live sources and `required_lead + static_delay` for buffered (`PushStream.set_live_source(...)`, default buffered) since a buffered queue grows past `min_buffer` naturally after playback begins.

Implements:
- Sendspin/spec#69.