### PR TITLE
Implement the `visualizer@v1` role

### DIFF
--- a/aiosendspin/client/client.py
+++ b/aiosendspin/client/client.py
@@ -141,7 +141,9 @@ DisconnectCallback = Callable[[], None]
 # Callback invoked when server sends player commands (volume, mute).
 ServerCommandCallback = Callable[[ServerCommandPayload], None]
 
-# Callback invoked when visualizer frames are received.
+# Callback invoked when visualizer frames are received. Beat events are
+# delivered through the same callback as a `VisualizerFrame` carrying
+# only `timestamp_us` + `is_downbeat`.
 VisualizerCallback = Callable[[list[VisualizerFrame]], None]
 
 # Callback invoked when artwork binary frames are received.
@@ -250,7 +252,7 @@ class SendspinClient:
     _server_command_callbacks: list[ServerCommandCallback]
     """Callbacks invoked when server sends player commands."""
     _visualizer_callbacks: list[VisualizerCallback]
-    """Callbacks invoked when visualizer frames are received."""
+    """Callbacks invoked when visualizer frames are received (beats included)."""
     _artwork_callbacks: list[ArtworkCallback]
     """Callbacks invoked when artwork frames are received."""
 
@@ -834,10 +836,16 @@ class SendspinClient:
                 logger.exception("Failed to unpack binary header")
                 return
             self._handle_artwork_chunk(message_type, payload[BINARY_HEADER_SIZE:])
-        elif message_type is BinaryMessageType.VISUALIZATION_DATA:
-            # Spec format: [type:1][frame_count:1][frames...]
-            # Pass payload[1:] so _parse_visualization_frames sees frame_count at data[0]
-            self._handle_visualization_data(payload[1:])
+        elif message_type in {
+            BinaryMessageType.VISUALIZATION_LOUDNESS,
+            BinaryMessageType.VISUALIZATION_F_PEAK,
+            BinaryMessageType.VISUALIZATION_SPECTRUM,
+            BinaryMessageType.VISUALIZATION_PEAK,
+            BinaryMessageType.VISUALIZATION_PITCH,
+        }:
+            self._handle_visualization_frame(message_type, payload[1:])
+        elif message_type is BinaryMessageType.VISUALIZATION_BEAT:
+            self._handle_visualization_beat(payload[1:])
         else:
             logger.debug("Ignoring unsupported binary message type: %s", message_type)
 
@@ -871,8 +879,9 @@ class SendspinClient:
         self._time_filter.update(round(offset), round(delay), now_us)
 
     async def _handle_stream_start(self, message: StreamStartMessage) -> None:
-        # Handle visualizer stream start
-        if message.payload.visualizer is not None:
+        # Handle visualizer stream start (client SDK is v1-only; older
+        # draft_r1 schema is ignored — those servers expect the legacy SDK).
+        if isinstance(message.payload.visualizer, StreamStartVisualizer):
             self._current_visualizer_config = message.payload.visualizer
             self._visualizer_stream_active = True
         if message.payload.artwork is not None:
@@ -1007,95 +1016,64 @@ class SendspinClient:
             except Exception:
                 logger.exception("Error in artwork callback %s", callback)
 
-    def _handle_visualization_data(self, payload: bytes) -> None:
-        """Handle incoming visualization data binary message."""
+    def _handle_visualization_frame(self, message_type: BinaryMessageType, payload: bytes) -> None:
+        """Parse a single-type visualization binary and notify callbacks."""
         if not self._visualizer_callbacks:
             return
         if self._current_visualizer_config is None:
             return
-
-        config = self._current_visualizer_config
-        types_order = list(config.types)
-        n_disp_bins = 0
-        if config.spectrum is not None:
-            n_disp_bins = config.spectrum.n_disp_bins
-
         try:
-            frames = self._parse_visualization_frames(payload, types_order, n_disp_bins)
+            frame = self._parse_visualization_frame(
+                message_type, payload, self._current_visualizer_config
+            )
         except Exception:
-            logger.exception("Failed to parse visualization data")
+            logger.exception("Failed to parse visualization frame")
             return
-
-        if frames:
-            self._notify_visualizer_callbacks(frames)
+        if frame is not None:
+            self._notify_visualizer_callbacks([frame])
 
     @staticmethod
-    def _parse_visualization_frames(
-        data: bytes, types_order: Sequence[str], n_disp_bins: int
-    ) -> list[VisualizerFrame]:
-        """Parse visualization frames from binary data."""
-        if len(data) < 1:
-            return []
+    def _parse_visualization_frame(
+        message_type: BinaryMessageType,
+        data: bytes,
+        config: StreamStartVisualizer,
+    ) -> VisualizerFrame | None:
+        """Parse `[ts:8][data]` payload for one of the v1 visualizer types."""
+        if len(data) < 8:
+            return None
+        (timestamp_us,) = struct.unpack_from(">q", data, 0)
+        rest = data[8:]
 
-        # Determine bytes consumed per frame for the negotiated type order.
-        bytes_per_frame = 8  # timestamp_us
-        for data_type in types_order:
-            if data_type in {"loudness", "f_peak"}:
-                bytes_per_frame += 2
-            elif data_type == "spectrum":
-                bytes_per_frame += n_disp_bins * 2
-
-        frame_count = data[0]
-        expected_len = 1 + (frame_count * bytes_per_frame)
-        if len(data) != expected_len:
-            return []
-        offset = 1
-        frames: list[VisualizerFrame] = []
-
-        for _ in range(frame_count):
-            if offset + 8 > len(data):
-                break
-            timestamp_us = struct.unpack_from(">q", data, offset)[0]
-            offset += 8
-
-            loudness: int | None = None
-            f_peak: int | None = None
-            spectrum: list[int] | None = None
-            complete_frame = True
-
-            for data_type in types_order:
-                if data_type == "loudness":
-                    if offset + 2 > len(data):
-                        complete_frame = False
-                        break
-                    loudness = struct.unpack_from(">H", data, offset)[0]
-                    offset += 2
-                elif data_type == "f_peak":
-                    if offset + 2 > len(data):
-                        complete_frame = False
-                        break
-                    f_peak = struct.unpack_from(">H", data, offset)[0]
-                    offset += 2
-                elif data_type == "spectrum":
-                    nbytes = n_disp_bins * 2
-                    if offset + nbytes > len(data):
-                        complete_frame = False
-                        break
-                    spectrum = list(struct.unpack_from(f">{n_disp_bins}H", data, offset))
-                    offset += nbytes
-
-            if not complete_frame:
-                break
-            frames.append(
-                VisualizerFrame(
-                    timestamp_us=timestamp_us,
-                    loudness=loudness,
-                    f_peak=f_peak,
-                    spectrum=spectrum,
-                )
+        if message_type is BinaryMessageType.VISUALIZATION_LOUDNESS:
+            if len(rest) != 2:
+                return None
+            (value,) = struct.unpack(">H", rest)
+            return VisualizerFrame(timestamp_us=timestamp_us, loudness=value)
+        if message_type is BinaryMessageType.VISUALIZATION_F_PEAK:
+            if len(rest) != 4:
+                return None
+            freq, amp = struct.unpack(">HH", rest)
+            return VisualizerFrame(timestamp_us=timestamp_us, f_peak_freq=freq, f_peak_amp=amp)
+        if message_type is BinaryMessageType.VISUALIZATION_SPECTRUM:
+            n_disp_bins = config.spectrum.n_disp_bins if config.spectrum is not None else 0
+            if n_disp_bins <= 0 or len(rest) != n_disp_bins * 2:
+                return None
+            bins = list(struct.unpack(f">{n_disp_bins}H", rest))
+            return VisualizerFrame(timestamp_us=timestamp_us, spectrum=bins)
+        if message_type is BinaryMessageType.VISUALIZATION_PEAK:
+            if len(rest) != 1:
+                return None
+            return VisualizerFrame(timestamp_us=timestamp_us, peak_strength=rest[0])
+        if message_type is BinaryMessageType.VISUALIZATION_PITCH:
+            if len(rest) != 3:
+                return None
+            (midi_q88,) = struct.unpack(">H", rest[:2])
+            return VisualizerFrame(
+                timestamp_us=timestamp_us,
+                pitch_midi_q88=midi_q88,
+                pitch_confidence=rest[2],
             )
-
-        return frames
+        return None
 
     def _notify_visualizer_callbacks(self, frames: list[VisualizerFrame]) -> None:
         for callback in list(self._visualizer_callbacks):
@@ -1103,6 +1081,27 @@ class SendspinClient:
                 callback(frames)
             except Exception:
                 logger.exception("Error in visualizer callback %s", callback)
+
+    def _handle_visualization_beat(self, payload: bytes) -> None:
+        """Handle a `beat` binary message (type 17). 9 bytes of payload.
+
+        Routed through the same `VisualizerCallback` as the periodic
+        frames; the dispatched `VisualizerFrame` carries only
+        `timestamp_us` + `is_downbeat`.
+        """
+        if not self._visualizer_callbacks:
+            return
+        if len(payload) != 9:
+            return
+        try:
+            (ts,) = struct.unpack_from(">q", payload, 0)
+        except Exception:
+            logger.exception("Failed to parse beat data")
+            return
+        is_downbeat = bool(payload[8] & 0b0000_0001)
+        self._notify_visualizer_callbacks(
+            [VisualizerFrame(timestamp_us=ts, is_downbeat=is_downbeat)]
+        )
 
     def compute_play_time(self, server_timestamp_us: int) -> int:
         """

--- a/aiosendspin/models/core.py
+++ b/aiosendspin/models/core.py
@@ -442,10 +442,21 @@ class ServerCommandMessage(ServerMessage):
     type: Literal["server/command"] = "server/command"
 
 
-def _serialize_stream_start_visualizer(
-    value: StreamStartVisualizer | StreamStartVisualizerDraftR1 | None,
-) -> dict[str, Any] | None:
-    return value.to_dict() if value is not None else None
+# Shape carried by `StreamStartPayload.visualizer`. The field is typed `Any`
+# so mashumaro defers to the dispatch hooks below, but callers should annotate
+# against this alias for static checking.
+StreamStartVisualizerLike = StreamStartVisualizer | StreamStartVisualizerDraftR1 | None
+
+
+def _serialize_stream_start_visualizer(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if not isinstance(value, (StreamStartVisualizer, StreamStartVisualizerDraftR1)):
+        raise TypeError(
+            "StreamStartPayload.visualizer must be a StreamStartVisualizer, "
+            f"StreamStartVisualizerDraftR1, or None; got {type(value).__name__}"
+        )
+    return value.to_dict()
 
 
 def _deserialize_stream_start_visualizer(
@@ -476,10 +487,10 @@ class StreamStartPayload(DataClassORJSONMixin):
     """Information about the player."""
     artwork: StreamStartArtwork | None = None
     """Artwork information (sent to clients with artwork role)."""
-    # Typed `Any` (rather than the v1|draft union) so mashumaro defers to the
-    # explicit serialize/deserialize hooks; the bare union cannot disambiguate
-    # the two same-named schemas. Holds StreamStartVisualizer (v1),
-    # StreamStartVisualizerDraftR1, or None.
+    # Typed `Any` (rather than `StreamStartVisualizerLike`) so mashumaro defers
+    # to the explicit serialize/deserialize hooks; the bare union cannot
+    # disambiguate the two same-named schemas. The serialize hook rejects
+    # anything other than the alias's members at runtime.
     visualizer: Any = field(
         default=None,
         metadata={

--- a/aiosendspin/models/core.py
+++ b/aiosendspin/models/core.py
@@ -46,6 +46,12 @@ from .visualizer import (
     StreamRequestFormatVisualizer,
     StreamStartVisualizer,
 )
+from .visualizer_draft_r1 import (
+    ClientHelloVisualizerSupport as ClientHelloVisualizerSupportDraftR1,
+)
+from .visualizer_draft_r1 import (
+    StreamStartVisualizer as StreamStartVisualizerDraftR1,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -118,15 +124,20 @@ class ClientHelloPayload(DataClassORJSONMixin):
     artwork_support: Annotated[ClientHelloArtworkSupport | None, Alias("artwork@v1_support")] = None
     """Artwork support configuration - only if artwork role is in supported_roles."""
     visualizer_support: Annotated[
-        ClientHelloVisualizerSupport | None, Alias("visualizer@_draft_r1_support")
+        ClientHelloVisualizerSupport | None, Alias("visualizer@v1_support")
     ] = None
-    """Visualizer support configuration - only if visualizer role is in supported_roles."""
+    """Visualizer support configuration - only if visualizer@v1 role is in supported_roles."""
+    visualizer_draft_r1_support: Annotated[
+        ClientHelloVisualizerSupportDraftR1 | None, Alias("visualizer@_draft_r1_support")
+    ] = None
+    """Visualizer support for clients on the legacy `visualizer@_draft_r1` wire."""
 
     # Static mapping: unversioned support key -> actual alias key.
     _SUPPORT_KEY_ALIASES: ClassVar[dict[str, str]] = {
         "player_support": "player@v1_support",
         "artwork_support": "artwork@v1_support",
-        "visualizer_support": "visualizer@_draft_r1_support",
+        "visualizer_support": "visualizer@v1_support",
+        "visualizer_draft_r1_support": "visualizer@_draft_r1_support",
     }
 
     @classmethod
@@ -174,15 +185,25 @@ class ClientHelloPayload(DataClassORJSONMixin):
         if not artwork_role_supported:
             self.artwork_support = None
 
-        # Validate visualizer role and support configuration
+        # Validate visualizer role and support configuration.
         visualizer_role_supported = Roles.VISUALIZER.value in self.supported_roles
         if visualizer_role_supported and self.visualizer_support is None:
             raise ValueError(
-                "visualizer@_draft_r1_support (visualizer_support alias) must be "
-                "provided when 'visualizer@_draft_r1' is in supported_roles"
+                "visualizer@v1_support (visualizer_support alias) must be "
+                "provided when 'visualizer@v1' is in supported_roles"
             )
         if not visualizer_role_supported:
             self.visualizer_support = None
+
+        # Validate legacy `visualizer@_draft_r1` support configuration.
+        visualizer_draft_supported = "visualizer@_draft_r1" in self.supported_roles
+        if visualizer_draft_supported and self.visualizer_draft_r1_support is None:
+            raise ValueError(
+                "visualizer@_draft_r1_support must be provided when "
+                "'visualizer@_draft_r1' is in supported_roles"
+            )
+        if not visualizer_draft_supported:
+            self.visualizer_draft_r1_support = None
 
     class Config(BaseConfig):
         """Config for parsing json messages."""
@@ -430,8 +451,12 @@ class StreamStartPayload(DataClassORJSONMixin):
     """Information about the player."""
     artwork: StreamStartArtwork | None = None
     """Artwork information (sent to clients with artwork role)."""
-    visualizer: StreamStartVisualizer | None = None
-    """Visualizer information (sent to clients with visualizer role)."""
+    visualizer: StreamStartVisualizer | StreamStartVisualizerDraftR1 | None = None
+    """Visualizer information (sent to clients with visualizer role).
+
+    Carries the v1 schema by default; legacy clients on `visualizer@_draft_r1`
+    get the draft schema. Roles emit whichever matches their negotiated wire.
+    """
 
     class Config(BaseConfig):
         """Config for parsing json messages."""

--- a/aiosendspin/models/core.py
+++ b/aiosendspin/models/core.py
@@ -9,7 +9,7 @@ synchronization, stream lifecycle management, and role-based state updates and c
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import dataclass, field, fields, is_dataclass
 from typing import Annotated, Any, ClassVar, Literal
 
 from mashumaro.config import BaseConfig
@@ -442,6 +442,31 @@ class ServerCommandMessage(ServerMessage):
     type: Literal["server/command"] = "server/command"
 
 
+def _serialize_stream_start_visualizer(
+    value: StreamStartVisualizer | StreamStartVisualizerDraftR1 | None,
+) -> dict[str, Any] | None:
+    return value.to_dict() if value is not None else None
+
+
+def _deserialize_stream_start_visualizer(
+    value: Any,
+) -> StreamStartVisualizer | StreamStartVisualizerDraftR1 | None:
+    """Pick the visualizer wire schema by its discriminating field.
+
+    The v1 and draft schemas overlap on `types`/`spectrum` and share the
+    class name `StreamStartVisualizer`, so mashumaro's bare-union resolution
+    cannot tell them apart (it yields None / raises for a draft payload).
+    They are distinguished by the required `rate_max` (v1) vs `batch_max`
+    (draft); dispatch explicitly. The field is annotated `Any` so mashumaro
+    defers to these hooks instead of generating union codec.
+    """
+    if not isinstance(value, dict):
+        return None
+    if "batch_max" in value and "rate_max" not in value:
+        return StreamStartVisualizerDraftR1.from_dict(value)
+    return StreamStartVisualizer.from_dict(value)
+
+
 # Server -> Client: stream/start
 @dataclass
 class StreamStartPayload(DataClassORJSONMixin):
@@ -451,7 +476,17 @@ class StreamStartPayload(DataClassORJSONMixin):
     """Information about the player."""
     artwork: StreamStartArtwork | None = None
     """Artwork information (sent to clients with artwork role)."""
-    visualizer: StreamStartVisualizer | StreamStartVisualizerDraftR1 | None = None
+    # Typed `Any` (rather than the v1|draft union) so mashumaro defers to the
+    # explicit serialize/deserialize hooks; the bare union cannot disambiguate
+    # the two same-named schemas. Holds StreamStartVisualizer (v1),
+    # StreamStartVisualizerDraftR1, or None.
+    visualizer: Any = field(
+        default=None,
+        metadata={
+            "serialize": _serialize_stream_start_visualizer,
+            "deserialize": _deserialize_stream_start_visualizer,
+        },
+    )
     """Visualizer information (sent to clients with visualizer role).
 
     Carries the v1 schema by default; legacy clients on `visualizer@_draft_r1`

--- a/aiosendspin/models/types.py
+++ b/aiosendspin/models/types.py
@@ -67,11 +67,10 @@ class Roles(Enum):
     """Displays text metadata describing the currently playing audio."""
     ARTWORK = "artwork@v1"
     """Displays artwork images. Has preferred format for images."""
-    VISUALIZER = "visualizer@_draft_r1"
+    VISUALIZER = "visualizer@v1"
     """
-    Visualizes music.
-
-    Has preferred format for audio features.
+    Visualizes music. Has preferred format for audio features (FFT spectrum,
+    loudness, beats, peaks, pitch).
     """
     COLOR = "color@v1"
     """Receives colors derived from the current audio."""
@@ -95,10 +94,22 @@ class BinaryMessageType(Enum):
     """Artwork channel 3 (Artwork role, slot 3)."""
 
     # Visualizer role (bits 00010xxx, IDs 16-23):
-    VISUALIZATION_DATA = 16
-    """Visualization data (Visualizer role, slot 0)."""
+    VISUALIZATION_LOUDNESS = 16
+    """Loudness frame (Visualizer role, slot 0). Also reused for the legacy
+    `visualizer@_draft_r1` `VISUALIZATION_DATA` blob — same wire byte, the
+    negotiated role's `get_binary_handling` selects the framing."""
+    VISUALIZATION_DATA = 16  # noqa: PIE796
+    """Alias of `VISUALIZATION_LOUDNESS` for the legacy draft_r1 wire."""
     VISUALIZATION_BEAT = 17
-    """Visualization beat data (Visualizer role, slot 1)."""
+    """Musical beat event (Visualizer role, slot 1)."""
+    VISUALIZATION_F_PEAK = 18
+    """Dominant frequency + amplitude (Visualizer role, slot 2)."""
+    VISUALIZATION_SPECTRUM = 19
+    """Display-binned spectrum (Visualizer role, slot 3)."""
+    VISUALIZATION_PEAK = 20
+    """Energy onset event with strength (Visualizer role, slot 4)."""
+    VISUALIZATION_PITCH = 21
+    """Perceived pitch (MIDI 8.8 + confidence) (Visualizer role, slot 5)."""
 
 
 class RepeatMode(Enum):

--- a/aiosendspin/models/visualizer.py
+++ b/aiosendspin/models/visualizer.py
@@ -135,10 +135,10 @@ class StreamStartVisualizer(DataClassORJSONMixin):
         )
         if not stream_types:
             raise ValueError("visualizer stream must contain at least one supported type")
-        # tracks_downbeats only meaningful when beat is in types.
-        effective_tracks_downbeats: bool | None = None
-        if "beat" in stream_types:
-            effective_tracks_downbeats = bool(tracks_downbeats)
+        # tracks_downbeats is only meaningful when beat is in types. Preserve
+        # the caller's tri-state (None = not declared) instead of coercing to
+        # False so an "unknown" stays omitted on the wire.
+        effective_tracks_downbeats = tracks_downbeats if "beat" in stream_types else None
         return cls(
             types=stream_types,
             rate_max=support.rate_max,

--- a/aiosendspin/models/visualizer.py
+++ b/aiosendspin/models/visualizer.py
@@ -27,9 +27,9 @@ class BeatAvailability(Enum):
     """Server-side declaration of whether beats will arrive for the source.
 
     `PENDING` (default): beats may arrive via `append_beat_schedule()`. `beat`
-    is included in `stream/start.types` up front (when the client requested
-    it), so no mid-stream `stream/start` re-emit is needed once a schedule
-    lands.
+    is deferred from `stream/start.types` until the first schedule lands (when
+    the client requested it), at which point the role re-emits `stream/start`
+    with `beat` added.
 
     `UNAVAILABLE`: no beats will arrive for this source. `beat` is excluded
     from the negotiated types, and any `append_beat_schedule()` call is a

--- a/aiosendspin/models/visualizer_draft_r1.py
+++ b/aiosendspin/models/visualizer_draft_r1.py
@@ -3,41 +3,17 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
 from typing import Any, Literal, cast
 
 from mashumaro.config import BaseConfig
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
-VisualizerType = Literal["loudness", "f_peak", "spectrum", "beat", "peak", "pitch"]
-SupportedVisualizerType = Literal["loudness", "f_peak", "spectrum", "beat", "peak", "pitch"]
+VisualizerType = Literal["loudness", "f_peak", "spectrum", "beat"]
+SupportedVisualizerType = Literal["loudness", "f_peak", "spectrum"]
 SpectrumScale = Literal["lin", "log", "mel"]
 
-_SUPPORTED_TYPES: tuple[SupportedVisualizerType, ...] = (
-    "loudness",
-    "f_peak",
-    "spectrum",
-    "beat",
-    "peak",
-    "pitch",
-)
-
-
-class BeatAvailability(Enum):
-    """Server-side declaration of whether beats will arrive for the source.
-
-    `PENDING` (default): beats may arrive via `append_beat_schedule()`. `beat`
-    is included in `stream/start.types` up front (when the client requested
-    it), so no mid-stream `stream/start` re-emit is needed once a schedule
-    lands.
-
-    `UNAVAILABLE`: no beats will arrive for this source. `beat` is excluded
-    from the negotiated types, and any `append_beat_schedule()` call is a
-    no-op until availability changes back.
-    """
-
-    PENDING = "pending"
-    UNAVAILABLE = "unavailable"
+# TODO: Add "beat" once wire format + extraction support is implemented.
+_SUPPORTED_TYPES: tuple[SupportedVisualizerType, ...] = ("loudness", "f_peak", "spectrum")
 
 
 # Client -> Server: client/hello visualizer support object
@@ -49,6 +25,7 @@ class ClientHelloVisualizerSpectrum(DataClassORJSONMixin):
     scale: SpectrumScale
     f_min: int
     f_max: int
+    rate_max: int
 
     def __post_init__(self) -> None:
         """Validate spectrum config bounds."""
@@ -58,6 +35,8 @@ class ClientHelloVisualizerSpectrum(DataClassORJSONMixin):
             raise ValueError(f"f_min must be >= 0, got {self.f_min}")
         if self.f_max <= self.f_min:
             raise ValueError(f"f_max must be > f_min, got f_min={self.f_min}, f_max={self.f_max}")
+        if self.rate_max <= 0:
+            raise ValueError(f"rate_max must be > 0, got {self.rate_max}")
 
     def to_wire_dict(self) -> dict[str, Any]:
         """Serialize to stream/start visualizer.spectrum payload."""
@@ -71,11 +50,11 @@ class ClientHelloVisualizerSpectrum(DataClassORJSONMixin):
 
 @dataclass
 class ClientHelloVisualizerSupport(DataClassORJSONMixin):
-    """Visualizer support payload for client/hello visualizer negotiation."""
+    """Visualizer support payload for client/hello draft-r1 negotiation."""
 
     buffer_capacity: int
-    rate_max: int
-    types: list[str]
+    types: list[str] | None = None
+    batch_max: int | None = None
     spectrum: ClientHelloVisualizerSpectrum | None = None
 
     @classmethod
@@ -93,16 +72,16 @@ class ClientHelloVisualizerSupport(DataClassORJSONMixin):
 
     def __post_init__(self) -> None:
         """Validate support object constraints."""
-        if not self.types:
+        if self.types == []:
             raise ValueError(
-                "visualizer support 'types' must contain at least one supported type "
+                "visualizer support 'types' did not contain any supported type "
                 f"(supported: {list(_SUPPORTED_TYPES)})"
             )
         if self.buffer_capacity <= 0:
             raise ValueError(f"buffer_capacity must be > 0, got {self.buffer_capacity}")
-        if self.rate_max <= 0:
-            raise ValueError(f"rate_max must be > 0, got {self.rate_max}")
-        if "spectrum" in self.types and self.spectrum is None:
+        if self.batch_max is not None and self.batch_max <= 0:
+            raise ValueError(f"batch_max must be > 0, got {self.batch_max}")
+        if self.types is not None and "spectrum" in self.types and self.spectrum is None:
             raise ValueError("visualizer support must include 'spectrum' object")
 
     class Config(BaseConfig):
@@ -114,36 +93,29 @@ class ClientHelloVisualizerSupport(DataClassORJSONMixin):
 # Server -> Client: stream/start visualizer object
 @dataclass(frozen=True)
 class StreamStartVisualizer(DataClassORJSONMixin):
-    """Negotiated visualizer stream config returned in stream/start."""
+    """Negotiated draft visualizer stream config returned in stream/start."""
 
     types: tuple[SupportedVisualizerType, ...]
-    rate_max: int
-    tracks_downbeats: bool | None = None
+    batch_max: int
     spectrum: ClientHelloVisualizerSpectrum | None = None
 
     @classmethod
-    def from_support(
-        cls,
-        support: ClientHelloVisualizerSupport,
-        *,
-        tracks_downbeats: bool | None = None,
-    ) -> StreamStartVisualizer:
+    def from_support(cls, support: ClientHelloVisualizerSupport) -> StreamStartVisualizer:
         """Create server stream config from validated client support data."""
+        if support.types is None:
+            raise ValueError("visualizer support must include 'types'")
+        if support.batch_max is None:
+            raise ValueError("visualizer support must include 'batch_max'")
         stream_types = cast(
             "tuple[SupportedVisualizerType, ...]",
             tuple(typed for typed in support.types if typed in _SUPPORTED_TYPES),
         )
         if not stream_types:
             raise ValueError("visualizer stream must contain at least one supported type")
-        # tracks_downbeats only meaningful when beat is in types.
-        effective_tracks_downbeats: bool | None = None
-        if "beat" in stream_types:
-            effective_tracks_downbeats = bool(tracks_downbeats)
         return cls(
             types=stream_types,
-            rate_max=support.rate_max,
+            batch_max=support.batch_max,
             spectrum=support.spectrum,
-            tracks_downbeats=effective_tracks_downbeats,
         )
 
     def to_wire_dict(self) -> dict[str, Any]:
@@ -159,14 +131,10 @@ class StreamStartVisualizer(DataClassORJSONMixin):
 # Client -> Server: stream/request-format visualizer object
 @dataclass
 class StreamRequestFormatVisualizer(DataClassORJSONMixin):
-    """Visualizer stream format renegotiation payload.
-
-    All fields optional; omitted fields keep the prior value.
-    """
+    """Draft visualizer format request payload."""
 
     types: list[VisualizerType] | None = None
-    rate_max: int | None = None
-    buffer_capacity: int | None = None
+    batch_max: int | None = None
     spectrum: ClientHelloVisualizerSpectrum | None = None
 
     class Config(BaseConfig):
@@ -177,27 +145,9 @@ class StreamRequestFormatVisualizer(DataClassORJSONMixin):
 
 @dataclass(slots=True)
 class VisualizerFrame:
-    """Single visualizer frame parsed by clients from binary payloads.
-
-    On the v1 wire each binary message carries one type's data, so any given
-    `VisualizerFrame` has exactly one of the optional fields populated.
-    """
+    """Single visualizer frame parsed by clients from binary payloads."""
 
     timestamp_us: int
     loudness: int | None = None
-    f_peak_freq: int | None = None
-    f_peak_amp: int | None = None
+    f_peak: int | None = None
     spectrum: list[int] | None = None
-    peak_strength: int | None = None
-    pitch_midi_q88: int | None = None
-    pitch_confidence: int | None = None
-    # Set for beat frames (msg 17). True at bar boundaries on the v1 wire.
-    is_downbeat: bool | None = None
-
-
-@dataclass(frozen=True, slots=True)
-class BeatTiming:
-    """A single beat in a visualizer beat schedule."""
-
-    timestamp_us: int
-    is_downbeat: bool = False

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -467,22 +467,30 @@ class SendspinConnection:
                 continue
 
             custom_support_key = f"{selected_role}_support"
+            # If the role's support key has a mashumaro-aliased field on
+            # ClientHelloPayload (e.g. legacy `visualizer@_draft_r1` running
+            # alongside the primary `visualizer@v1`), let mashumaro parse it
+            # via the alias and skip the custom-role path so the schema is
+            # picked correctly for the role version.
+            if custom_support_key in ClientHelloPayload._SUPPORT_KEY_ALIASES.values():  # noqa: SLF001
+                continue
             custom_support = payload.get(custom_support_key)
             primary_support_key = (
                 f"{primary_role_id}_support" if primary_role_id is not None else None
             )
             legacy_support_key = f"{family}_support"
-            if custom_support is None and (
-                (primary_support_key is not None and payload.get(primary_support_key) is not None)
-                or payload.get(legacy_support_key) is not None
+            # Fall back to the legacy (unversioned) <family>_support key when
+            # the client didn't include a per-version key. Versioned keys for
+            # OTHER versions (e.g. primary_support_key) stay rejected because
+            # their schema may differ from the selected role's.
+            if custom_support is None and payload.get(legacy_support_key) is not None:
+                custom_support = payload.get(legacy_support_key)
+            elif custom_support is None and (
+                primary_support_key is not None and payload.get(primary_support_key) is not None
             ):
-                # If built-in/legacy support keys are present for custom role IDs, keep
-                # legacy behavior but make it explicit that custom roles must use their
-                # versioned support key.
                 logger.warning(
-                    "Ignoring %s/%s for custom role %s; expected %s",
+                    "Ignoring %s for custom role %s; expected %s",
                     primary_support_key,
-                    legacy_support_key,
                     selected_role,
                     custom_support_key,
                 )
@@ -714,7 +722,11 @@ class SendspinConnection:
             return
 
     def _check_late_binary(
-        self, handling: BinaryHandling | None, role: Role | None, timestamp_us: int
+        self,
+        handling: BinaryHandling | None,
+        role: Role | None,
+        timestamp_us: int,
+        message_type: int = 0,
     ) -> bool:
         """Check if a binary message's playback time has passed and should be dropped.
 
@@ -736,7 +748,9 @@ class SendspinConnection:
         if late_by_us > 0 and not in_grace_period:
             role._late_skips_since_log += 1  # noqa: SLF001
             self._logger.debug(
-                "Discarding late chunk: late_by=%.1fms, plays_in=%.1fms",
+                "Discarding late chunk type=%s role=%s: late_by=%.1fms, plays_in=%.1fms",
+                message_type,
+                role.role_family,
                 late_by_us / 1000,
                 -late_by_us / 1000,
             )
@@ -744,8 +758,10 @@ class SendspinConnection:
             if now_s - role._last_late_log_s >= 1.0:  # noqa: SLF001
                 qsize, qmax = self.queue_status()
                 self._logger.warning(
-                    "Late binary: skipping %s chunk(s); "
+                    "Late binary type=%s role=%s: skipping %s chunk(s); "
                     "late_by_us=%s ts_us=%s now_us=%s queue=%s/%s",
+                    message_type,
+                    role.role_family,
                     role._late_skips_since_log,  # noqa: SLF001
                     late_by_us,
                     timestamp_us,
@@ -1001,7 +1017,9 @@ class SendspinConnection:
         if (
             handling is not None
             and handling_role is not None
-            and self._check_late_binary(handling, handling_role, entry.timestamp_us)
+            and self._check_late_binary(
+                handling, handling_role, entry.timestamp_us, entry.binary.message_type
+            )
         ):
             self._discard_role_head(role)
             self._schedule_role_head(role)

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -1919,9 +1919,15 @@ class PushStream:
                             self._ensure_role_started(role)
                         return
 
-                if self._has_established_resampler_for(req, channel_id):
+                if not role.replay_from_pcm_cache() and self._has_established_resampler_for(
+                    req, channel_id
+                ):
                     # Sharing a resampler key with a live role would shift this
                     # role's audio across the hand-off; skip historical replay.
+                    # Analysis-only roles opt out: their catch-up uses isolated
+                    # resampler state and an inaudible seam, so replaying the
+                    # buffered PCM now beats waiting for a live commit that may
+                    # sit far ahead behind the producer buffer.
                     self._rebase_far_ahead_join_tail(channel_id, role)
                     if self._channel_timing:
                         self._ensure_role_started(role)

--- a/aiosendspin/server/roles/__init__.py
+++ b/aiosendspin/server/roles/__init__.py
@@ -73,6 +73,7 @@ from aiosendspin.server.roles.visualizer import (
     VisualizerGroupRole,
     VisualizerV1Role,
 )
+from aiosendspin.server.roles.visualizer_draft_r1 import VisualizerDraftR1Role
 
 __all__ = [
     "ArtworkClearedEvent",
@@ -113,6 +114,7 @@ __all__ = [
     "PlayerV1Role",
     "Role",
     "StreamRequirements",
+    "VisualizerDraftR1Role",
     "VisualizerGroupRole",
     "VisualizerV1Role",
     "register_role",

--- a/aiosendspin/server/roles/base.py
+++ b/aiosendspin/server/roles/base.py
@@ -250,6 +250,20 @@ class Role(ABC):
         """
         return False
 
+    def replay_from_pcm_cache(self) -> bool:
+        """Whether late-join should replay cached PCM even when a live resampler exists.
+
+        Audio-playback roles skip historical replay when another live role
+        already drives a resampler at their target PCM shape, because
+        re-running that resampler would shift the live role's samples across
+        the hand-off. Analysis-only roles (e.g. visualizer) do not feed a
+        synchronized output, so the seam is inaudible; they override this to
+        True so a mid-stream join is fed the buffered PCM immediately instead
+        of waiting for the next live commit (which may sit far ahead of the
+        playhead behind a producer buffer).
+        """
+        return False
+
     def get_binary_handling(self, message_type: int) -> BinaryHandling | None:  # noqa: ARG002
         """Return handling policy for a binary message type, or None if not handled.
 

--- a/aiosendspin/server/roles/metadata/v1.py
+++ b/aiosendspin/server/roles/metadata/v1.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from aiosendspin.server.roles.base import Role
+from aiosendspin.server.roles.metadata.group import MetadataGroupRole
 
 if TYPE_CHECKING:
     from aiosendspin.server.client import SendspinClient
@@ -47,6 +48,8 @@ class MetadataV1Role(Role):
     def on_connect(self) -> None:
         """Subscribe to MetadataGroupRole for state updates."""
         self._subscribe_to_group_role()
+        if isinstance(self._group_role, MetadataGroupRole):
+            self._group_role._send_state_to_role(self)  # noqa: SLF001
 
     def on_disconnect(self) -> None:
         """Unsubscribe from MetadataGroupRole."""

--- a/aiosendspin/server/roles/visualizer/__init__.py
+++ b/aiosendspin/server/roles/visualizer/__init__.py
@@ -8,10 +8,11 @@ from aiosendspin.server.roles.registry import (
     register_role_support_spec,
 )
 from aiosendspin.server.roles.visualizer.group import VisualizerGroupRole
+from aiosendspin.server.roles.visualizer.types import VisualizerRoleProtocol
 from aiosendspin.server.roles.visualizer.v1 import VisualizerV1Role
 
 register_group_role("visualizer", VisualizerGroupRole)
-register_role("visualizer@_draft_r1", lambda client: VisualizerV1Role(client=client))
+register_role("visualizer@v1", lambda client: VisualizerV1Role(client=client))
 register_role_support_spec(
     "visualizer",
     RoleSupportSpec(
@@ -19,4 +20,8 @@ register_role_support_spec(
     ),
 )
 
-__all__ = ["VisualizerGroupRole", "VisualizerV1Role"]
+__all__ = [
+    "VisualizerGroupRole",
+    "VisualizerRoleProtocol",
+    "VisualizerV1Role",
+]

--- a/aiosendspin/server/roles/visualizer/features.py
+++ b/aiosendspin/server/roles/visualizer/features.py
@@ -9,15 +9,62 @@ import numpy as np
 
 from aiosendspin.models.visualizer import StreamStartVisualizer
 
+# Default FFT window at 48 kHz: 2048 samples ≈ 42 ms → ~23 Hz bin
+# resolution, stable on constant tones. Decoupled from chunk cadence by
+# the rolling buffer. At other rates the window scales so the time span
+# (and therefore the achievable pitch F_MIN) stays roughly constant —
+# see `_window_samples_for_rate`.
+_DEFAULT_WINDOW_SAMPLES = 2048
+_REFERENCE_SAMPLE_RATE = 48_000
+# Below this many samples the FFT result is too coarse to be worth emitting.
+_MIN_WINDOW_SAMPLES = 256
+# Temporal smoothing factors (new sample weight). 0 = no smoothing, 1 = no memory.
+_SPECTRUM_EMA_ALPHA = 0.4
+_LOUDNESS_EMA_ALPHA = 0.5
+# f_peak hysteresis: only switch reported peak bin when its magnitude exceeds
+# the held peak's magnitude by this ratio. Suppresses bin-hop jitter between
+# near-equal neighbours on steady tones.
+_F_PEAK_SWITCH_RATIO = 1.10
+# Pitch (YINFFT) search bounds and gating. The floor is set to the melody
+# register (not the bass) so octave-down errors fall below it and are rejected.
+_PITCH_F_MIN = 130.0
+_PITCH_F_MAX = 1200.0
+# Pitch ACF is computed via `rfft → |X|² → irfft`, which is the *circular*
+# autocorrelation of the windowed signal — not the linear one YIN
+# assumes. For `tau_max / n ≈ 0.36` (130 Hz at 48 kHz with a 2048-sample
+# window) wrap-around contamination is bounded by the Hanning taper.
+# Dropping F_MIN below ~100 Hz requires zero-padding the time-domain
+# signal to `2n` before the rfft to recover a proper linear ACF.
+# Below this windowed RMS (dBFS) the frame is treated as unvoiced.
+_PITCH_RMS_FLOOR_DB = -45.0
+# YIN absolute threshold: first CMNDF dip below this is taken as the period.
+_PITCH_YIN_THRESHOLD = 0.12
+# Voicing gate: above this normalized-difference at the chosen period the frame
+# is aperiodic (percussion, noise, unpitched) and no pitch is emitted.
+_PITCH_UNVOICED_DPRIME = 0.35
+# Octave stabilization: EMA weight of the running pitch register, max semitone
+# distance at which a raw note is snapped to the register's octave, and the gap
+# after which the register is considered stale.
+_PITCH_REGISTER_ALPHA = 0.25
+_PITCH_SNAP_MAX_SEMITONES = 7.0
+_PITCH_REGISTER_GAP_US = 400_000
+
 
 @dataclass(frozen=True)
 class ExtractedFrame:
-    """Computed visualizer features for one audio chunk."""
+    """Computed visualizer features for one emit timestamp."""
 
     timestamp_us: int
     loudness: int | None = None
-    f_peak: int | None = None
+    # f_peak fields are paired — both populated together.
+    f_peak_freq: int | None = None
+    f_peak_amp: int | None = None
     spectrum: np.ndarray | None = None
+    # Onset detector output; None when no transient fired this frame.
+    peak: int | None = None
+    # Pitch fields are paired — both None when no confident pitch was detected.
+    pitch_midi_q88: int | None = None
+    pitch_confidence: int | None = None
 
 
 def _hz_to_mel(hz: np.ndarray) -> np.ndarray:
@@ -28,8 +75,21 @@ def _mel_to_hz(mel: np.ndarray) -> np.ndarray:
     return 700.0 * (10.0 ** (mel / 2595.0) - 1.0)
 
 
+def _db_norm(value: float, ref: float) -> float:
+    """Map a linear A-weighted magnitude to the spec's [0, 1] dB scale.
+
+    -60 dB maps to 0, 0 dB to 1, linear in dB across that window. `ref` is the
+    full-scale reference in the caller's domain. Shared by `loudness` and the
+    `f_peak` amplitude so both use the single dB mapping the spec pins for
+    visualizer amplitudes.
+    """
+    ratio = max(value / ref, 1e-10)
+    db = 20.0 * np.log10(ratio)
+    return float(np.clip((db + 60.0) / 60.0, 0.0, 1.0))
+
+
 class VisualizerFeatureExtractor:
-    """Compute visualizer features from PCM chunks."""
+    """Compute visualizer features from PCM chunks at a configurable hop rate."""
 
     def __init__(
         self,
@@ -42,73 +102,429 @@ class VisualizerFeatureExtractor:
         self._sample_rate = sample_rate
         self._channels = channels
         self._config = config
-        self._last_spectrum_ts_us: int | None = None
-        self._last_spectrum: np.ndarray | None = None
+
+        # Hop is derived from rate_max. Zero/negative means "one frame per chunk":
+        # cursor is reset to chunk_end after every chunk.
+        self._hop_us: int = 1_000_000 // config.rate_max if config.rate_max > 0 else 0
+        self._window_samples: int = min(self._window_samples_for_rate(sample_rate), sample_rate)
+
+        # Rolling mono buffer + ts of its first sample.
+        self._buffer: np.ndarray = np.zeros(0, dtype=np.float32)
+        self._buffer_start_ts_us: int | None = None
+        # Cursor: ts of the NEXT frame to emit. Set on first chunk.
+        self._next_emit_ts_us: int | None = None
+
+        # Smoothing / hysteresis state.
+        self._spectrum_ema: np.ndarray | None = None
+        self._loudness_ema: float | None = None
         self._a_weight_cache: np.ndarray | None = None
+        self._f_peak_last_idx: int | None = None
+        # Onset detector state: EMA of A-weighted energy. A new frame fires a
+        # `peak` when current energy exceeds the EMA by a threshold ratio.
+        self._energy_ema: float | None = None
+        self._last_peak_ts_us: int | None = None
+        # Pitch octave-stabilization state: EMA of recent raw MIDI and the ts of
+        # the last voiced frame. Reset by any unvoiced frame.
+        self._pitch_register: float | None = None
+        self._pitch_last_ts_us: int | None = None
+
+    @staticmethod
+    def _window_samples_for_rate(sample_rate: int) -> int:
+        """Scale the FFT window with sample rate, rounded to the next power of two.
+
+        Keeps the time-domain span (and therefore the pitch F_MIN) roughly
+        constant across input rates. At the reference rate the default
+        2048 samples are used unchanged.
+        """
+        target = _DEFAULT_WINDOW_SAMPLES * sample_rate / _REFERENCE_SAMPLE_RATE
+        size = 1
+        while size < target:
+            size <<= 1
+        return size
 
     def reset(self) -> None:
         """Reset extractor state at stream boundaries."""
-        self._last_spectrum_ts_us = None
-        self._last_spectrum = None
+        self._buffer = np.zeros(0, dtype=np.float32)
+        self._buffer_start_ts_us = None
+        self._next_emit_ts_us = None
+        self._spectrum_ema = None
+        self._loudness_ema = None
+        self._f_peak_last_idx = None
+        self._energy_ema = None
+        self._last_peak_ts_us = None
+        self._pitch_register = None
+        self._pitch_last_ts_us = None
 
-    def process_chunk(self, pcm: bytes, timestamp_us: int) -> ExtractedFrame:
-        """Compute a single frame from a PCM chunk."""
+    def process_chunk(self, pcm: bytes, timestamp_us: int) -> list[ExtractedFrame]:
+        """Append PCM and emit one frame per hop boundary that fits.
+
+        Returns frames in non-decreasing timestamp order. May be empty if the
+        chunk is too short to advance past the next hop boundary.
+        """
         mono = self._decode_pcm_to_mono_float32(pcm)
+        if mono.size == 0:
+            return []
 
-        needs_fft = any(t in self._config.types for t in ("loudness", "f_peak", "spectrum"))
+        chunk_duration_us = round(mono.size * 1_000_000 / self._sample_rate)
+        chunk_end_ts_us = timestamp_us + chunk_duration_us
+
+        if self._buffer_start_ts_us is not None:
+            expected_ts = self._buffer_start_ts_us + round(
+                self._buffer.size * 1_000_000 / self._sample_rate
+            )
+            # Discontinuity in chunk timestamps (seek, codec restart, sparse
+            # feeding) invalidates the rolling buffer's contiguous-sample
+            # assumption. Reset and treat this chunk as a fresh start.
+            if abs(timestamp_us - expected_ts) > 1_000:
+                self._buffer = np.zeros(0, dtype=np.float32)
+                self._buffer_start_ts_us = None
+                self._next_emit_ts_us = None
+
+        if self._buffer_start_ts_us is None:
+            self._buffer = mono.copy()
+            self._buffer_start_ts_us = timestamp_us
+            # Anchor first emit at chunk end so the first frame's window
+            # covers the whole chunk.
+            self._next_emit_ts_us = chunk_end_ts_us
+        else:
+            self._buffer = np.concatenate([self._buffer, mono])
+
+        # `rate_max <= 0` falls back to one frame per chunk at chunk end.
+        if self._hop_us <= 0:
+            self._next_emit_ts_us = chunk_end_ts_us
+
+        frames: list[ExtractedFrame] = []
+        assert self._next_emit_ts_us is not None
+        while self._next_emit_ts_us <= chunk_end_ts_us:
+            emit_ts = self._next_emit_ts_us
+            window = self._extract_window(emit_ts)
+            if window is None:
+                if self._hop_us <= 0:
+                    break
+                self._next_emit_ts_us += self._hop_us
+                continue
+            frames.append(self._compute_frame(window, emit_ts))
+            if self._hop_us <= 0:
+                self._next_emit_ts_us = chunk_end_ts_us + 1
+                break
+            self._next_emit_ts_us += self._hop_us
+
+        self._trim_buffer()
+        return frames
+
+    def _extract_window(self, emit_ts: int) -> np.ndarray | None:
+        """Return up to `_window_samples` PCM samples ending at `emit_ts`.
+
+        Returns None when fewer than `_MIN_WINDOW_SAMPLES` are available.
+        """
+        assert self._buffer_start_ts_us is not None
+        emit_idx = round((emit_ts - self._buffer_start_ts_us) * self._sample_rate / 1_000_000)
+        emit_idx = min(emit_idx, self._buffer.size)
+        if emit_idx < _MIN_WINDOW_SAMPLES:
+            return None
+        n = min(self._window_samples, emit_idx)
+        return self._buffer[emit_idx - n : emit_idx]
+
+    def _trim_buffer(self) -> None:
+        """Bound buffer growth — keep the last `_window_samples` only."""
+        keep = self._window_samples
+        if self._buffer.size > keep * 2:
+            drop = self._buffer.size - keep
+            self._buffer = self._buffer[-keep:]
+            assert self._buffer_start_ts_us is not None
+            self._buffer_start_ts_us += round(drop * 1_000_000 / self._sample_rate)
+
+    def _compute_frame(self, mono: np.ndarray, emit_ts: int) -> ExtractedFrame:
+        """Compute a single frame from a windowed mono PCM slice."""
+        needs_fft = any(
+            t in self._config.types for t in ("loudness", "f_peak", "spectrum", "peak", "pitch")
+        )
 
         loudness: int | None = None
-        f_peak: int | None = None
+        f_peak_freq: int | None = None
+        f_peak_amp: int | None = None
         spectrum: np.ndarray | None = None
+        peak: int | None = None
+        pitch_midi_q88: int | None = None
+        pitch_confidence: int | None = None
 
         if needs_fft:
             freqs, magnitude = self._fft_magnitude(mono)
             compensated = self._apply_psychoacoustic_compensation(freqs, magnitude)
 
             if "loudness" in self._config.types:
-                # A-weighted RMS via Parseval's theorem for one-sided rfft:
-                # RMS ≈ sqrt(2 * sum(|X|^2)) / N
-                if compensated.size == 0:
-                    loudness = 0
-                else:
-                    n = mono.size
-                    weighted_power = float(np.sum(np.square(compensated, dtype=np.float64)))
-                    rms = np.sqrt(2.0 * weighted_power) / max(n, 1)
-                    # A full-scale sine through Hanning has RMS ≈ sqrt(3/16) ≈ 0.43
-                    # (amplitude 1.0, mean(sin^2)=0.5, mean(hann^2)=3/8).
-                    # A-weight gain ~1.0 at 1-4 kHz.
-                    ref = np.sqrt(3.0 / 16.0)
-                    normalized = float(np.clip(rms / ref, 0.0, 1.0))
-                    loudness = int(normalized * 65535.0)
+                loudness = self._compute_loudness_db(compensated, mono.size)
 
             if "f_peak" in self._config.types:
-                if compensated.size == 0:
-                    f_peak = 0
-                else:
-                    idx = int(np.argmax(compensated))
-                    peak_hz = int(freqs[idx]) if idx < freqs.size else 0
-                    f_peak = int(np.clip(peak_hz, 0, 65535))
+                f_peak_freq, f_peak_amp = self._compute_f_peak(freqs, compensated, mono.size)
 
             if "spectrum" in self._config.types:
-                spectrum = self._maybe_compute_spectrum(freqs, compensated, timestamp_us)
+                spectrum = self._compute_spectrum(freqs, compensated)
+
+            if "peak" in self._config.types:
+                peak = self._detect_onset(compensated, emit_ts)
+
+            if "pitch" in self._config.types:
+                pitch_midi_q88, pitch_confidence = self._compute_pitch_yinfft(mono, magnitude)
+                if pitch_midi_q88 is None:
+                    self._pitch_register = None
+                    self._pitch_last_ts_us = None
+                else:
+                    pitch_midi_q88 = self._stabilize_pitch_octave(pitch_midi_q88, emit_ts)
 
         return ExtractedFrame(
-            timestamp_us=timestamp_us,
+            timestamp_us=emit_ts,
             loudness=loudness,
-            f_peak=f_peak,
+            f_peak_freq=f_peak_freq,
+            f_peak_amp=f_peak_amp,
             spectrum=spectrum,
+            peak=peak,
+            pitch_midi_q88=pitch_midi_q88,
+            pitch_confidence=pitch_confidence,
         )
+
+    def _compute_loudness_db(self, compensated: np.ndarray, n_samples: int) -> int:
+        """A-weighted, dB-scaled loudness in `[0, 65535]`, lightly smoothed.
+
+        Mirrors the spectrum encoding: -60 dB → 0, 0 dB → 65535, linear in dB
+        across that window.
+        """
+        if compensated.size == 0:
+            return 0
+        weighted_power = float(np.sum(np.square(compensated, dtype=np.float64)))
+        rms = np.sqrt(2.0 * weighted_power) / max(n_samples, 1)
+        # Full-scale sine through Hanning has RMS ≈ sqrt(3/16) ≈ 0.43.
+        ref = float(np.sqrt(3.0 / 16.0))
+        normalized = _db_norm(float(rms), ref)
+        if self._loudness_ema is None:
+            self._loudness_ema = normalized
+        else:
+            self._loudness_ema = (
+                _LOUDNESS_EMA_ALPHA * normalized + (1.0 - _LOUDNESS_EMA_ALPHA) * self._loudness_ema
+            )
+        return int(self._loudness_ema * 65535.0)
+
+    def _compute_f_peak(
+        self, freqs: np.ndarray, compensated: np.ndarray, n_samples: int
+    ) -> tuple[int, int]:
+        """Return (freq_hz, amp_db_q16) for the dominant FFT bin with sub-bin interpolation."""
+        if compensated.size == 0:
+            return 0, 0
+        candidate_idx = int(np.argmax(compensated))
+        last_idx = self._f_peak_last_idx
+        # Hysteresis: stay on the previously held bin unless the new candidate's
+        # magnitude exceeds it by the switch ratio.
+        if (
+            last_idx is not None
+            and 0 <= last_idx < compensated.size
+            and candidate_idx != last_idx
+            and compensated[candidate_idx] < _F_PEAK_SWITCH_RATIO * compensated[last_idx]
+        ):
+            idx = last_idx
+        else:
+            idx = candidate_idx
+        self._f_peak_last_idx = idx
+        if idx >= freqs.size or compensated[idx] <= 0.0:
+            return 0, 0
+        # Parabolic interpolation across the bin's neighbours for sub-bin freq.
+        peak_mag = float(compensated[idx])
+        peak_hz_float = float(freqs[idx])
+        if 0 < idx < compensated.size - 1:
+            a = float(compensated[idx - 1])
+            b = float(compensated[idx])
+            c = float(compensated[idx + 1])
+            denom = a - 2.0 * b + c
+            if abs(denom) > 1e-12:
+                delta = 0.5 * (a - c) / denom
+                # Clamp to ±1 bin so a bad neighbour can't fling the peak.
+                delta = float(np.clip(delta, -1.0, 1.0))
+                bin_hz = float(freqs[idx + 1] - freqs[idx]) if idx + 1 < freqs.size else 0.0
+                peak_hz_float = float(freqs[idx]) + delta * bin_hz
+                peak_mag = b - 0.25 * (a - c) * delta
+        peak_hz = int(np.clip(round(peak_hz_float), 0, 65535))
+        # Convert peak magnitude to the shared dB encoding so the amp value
+        # matches `loudness`/`spectrum` scaling. Full-scale sine through Hanning
+        # has rfft peak N/2, reduced to N/4 by the window.
+        ref = max(float(n_samples) / 4.0, 1.0)
+        amp = int(_db_norm(peak_mag, ref) * 65535.0)
+        if peak_hz == 0:
+            amp = 0
+        return peak_hz, amp
+
+    def _compute_pitch_yinfft(
+        self, mono: np.ndarray, magnitude: np.ndarray
+    ) -> tuple[int | None, int | None]:
+        """Return (midi_q88, confidence_uint8) via FFT-accelerated YIN.
+
+        Derives the YIN difference function from the autocorrelation of
+        the (Hanning-windowed, unweighted) magnitude spectrum via
+        `irfft`. The first cumulative-mean-normalized-difference dip
+        below `_PITCH_YIN_THRESHOLD` is the period, refined sub-sample
+        by parabolic interpolation.
+
+        Uses the unweighted magnitude (NOT A-weighted) on purpose: A-
+        weighting attenuates the fundamental of any note below ~500 Hz
+        by 3-10 dB while boosting the 1-4 kHz band, which biases the
+        ACF toward harmonics and produces octave-up errors on
+        mid-vocal-range pitches.
+
+        Returns `(None, None)` below the voicing floor or when no
+        confident period is found. `midi_q88` is a uint16 8.8 fixed-
+        point MIDI note; `confidence_uint8` is 0-255.
+        """
+        n = mono.size
+        # `irfft` requires `magnitude.size == n // 2 + 1` for a length-`n`
+        # result; otherwise its zero-pad/truncate behaviour gives nonsense.
+        if n < 64 or magnitude.size != n // 2 + 1:
+            return None, None
+
+        # DC-remove before the RMS voicing check: a small DC bias (e.g.
+        # 0.01 amplitude → -40 dBFS) would otherwise pass the floor and,
+        # combined with `_fft_magnitude` zeroing bin 0, produce a
+        # confident ghost pitch from a constant signal.
+        mono_dc_removed = mono - np.mean(mono, dtype=np.float64)
+        rms = float(np.sqrt(np.mean(np.square(mono_dc_removed, dtype=np.float64))))
+        if rms <= 0.0 or 20.0 * np.log10(rms) < _PITCH_RMS_FLOOR_DB:
+            return None, None
+
+        sr = float(self._sample_rate)
+        tau_min = max(2, int(sr / _PITCH_F_MAX))
+        tau_max = min(n // 2, int(sr / _PITCH_F_MIN))
+        if tau_max <= tau_min + 1:
+            return None, None
+
+        # YIN difference via the windowed signal's autocorrelation
+        # (Wiener-Khinchin on |X|²).
+        power = np.square(magnitude.astype(np.float64))
+        acf = np.fft.irfft(power, n=n)
+        # Second silence gate: if the windowed signal has near-zero
+        # energy (`acf[0]` ≈ 0), every `d_prime` collapses and the
+        # search would otherwise pick `tau_min` with confidence 1.
+        if acf[0] <= 1e-12:
+            return None, None
+        diff = 2.0 * (acf[0] - acf[: tau_max + 1])
+        np.maximum(diff, 0.0, out=diff)
+
+        d_prime = np.ones(tau_max + 1, dtype=np.float64)
+        csum = np.cumsum(diff[1:])
+        d_prime[1:] = diff[1:] * np.arange(1, tau_max + 1) / np.maximum(csum, 1e-12)
+
+        selected = -1
+        for tau in range(tau_min, tau_max):
+            if d_prime[tau] < _PITCH_YIN_THRESHOLD and d_prime[tau] <= d_prime[tau + 1]:
+                selected = tau
+                break
+        if selected == -1:
+            selected = tau_min + int(np.argmin(d_prime[tau_min : tau_max + 1]))
+        if d_prime[selected] > _PITCH_UNVOICED_DPRIME:
+            return None, None
+
+        # Parabolic interpolation around the chosen tau for sub-sample
+        # precision. Clip the vertex offset to ±0.5 — a near-zero denom
+        # can otherwise fling tau outside `[selected-1, selected+1]`.
+        tau_refined = float(selected)
+        if 0 < selected < tau_max:
+            a = d_prime[selected - 1]
+            b = d_prime[selected]
+            c = d_prime[selected + 1]
+            denom = 2.0 * (a - 2.0 * b + c)
+            if abs(denom) > 1e-12:
+                offset = float(np.clip((a - c) / denom, -0.5, 0.5))
+                tau_refined = selected + offset
+        if tau_refined <= 0.0:
+            return None, None
+
+        freq = sr / tau_refined
+        midi = 69.0 + 12.0 * float(np.log2(freq / 440.0))
+        if midi < 0.0 or midi >= 128.0:
+            return None, None
+        midi_q88 = int(np.clip(midi * 256.0, 0, 65535))
+        # Spread `d_prime ∈ [0, _PITCH_UNVOICED_DPRIME]` across the full
+        # 0-255 confidence range — the gate caps `d_prime[selected]`, so
+        # `(1 - d_prime)` alone would crowd output into a narrow upper
+        # band (~166-255 with the default 0.35 gate).
+        confidence_value = 1.0 - d_prime[selected] / _PITCH_UNVOICED_DPRIME
+        confidence_uint8 = int(np.clip(confidence_value * 255.0, 0, 255))
+        return midi_q88, confidence_uint8
+
+    def _stabilize_pitch_octave(self, midi_q88: int, emit_ts: int) -> int:
+        """Snap a raw pitch to the octave nearest the running register.
+
+        Tracks an EMA of recent *raw* (pre-snap) notes. When a raw note sits
+        closer to the register an octave (or two) away, it is shifted there —
+        suppressing the octave flips that frame-independent estimation produces
+        on steady notes. Following the raw note (not the snapped one) lets the
+        register climb to a sustained octave leap within a few frames, so real
+        melodic leaps survive while one-frame flips are absorbed. The register
+        is reset by any unvoiced frame (handled by the caller) or a long gap.
+        """
+        midi = midi_q88 / 256.0
+        register = self._pitch_register
+        last_ts = self._pitch_last_ts_us
+        stale = last_ts is not None and emit_ts - last_ts > _PITCH_REGISTER_GAP_US
+        if register is None or stale:
+            emit = midi
+        else:
+            emit = midi
+            best_distance = abs(midi - register)
+            for shift in (-24.0, -12.0, 12.0, 24.0):
+                candidate = midi + shift
+                if 0.0 <= candidate < 128.0 and abs(candidate - register) < best_distance:
+                    emit, best_distance = candidate, abs(candidate - register)
+            if best_distance > _PITCH_SNAP_MAX_SEMITONES:
+                emit = midi
+
+        if register is None or stale:
+            self._pitch_register = midi
+        else:
+            a = _PITCH_REGISTER_ALPHA
+            self._pitch_register = a * midi + (1.0 - a) * register
+        self._pitch_last_ts_us = emit_ts
+        return int(np.clip(emit * 256.0, 0, 65535))
+
+    def _detect_onset(self, compensated: np.ndarray, timestamp_us: int) -> int | None:
+        """Energy-based onset detector.
+
+        Maintains an EMA of A-weighted broadband energy. When the current frame
+        exceeds that average by a fixed multiplier, fires a peak whose strength
+        (0-255) scales with the excess. Returns None when no onset is detected.
+        """
+        if compensated.size == 0:
+            return None
+        energy = float(np.sum(np.square(compensated.astype(np.float64))))
+        # Bootstrap EMA on first frame.
+        if self._energy_ema is None or self._energy_ema <= 0.0:
+            self._energy_ema = max(energy, 1e-12)
+            return None
+        ema = self._energy_ema
+        # Minimum 80 ms gap between successive onsets.
+        if self._last_peak_ts_us is not None and timestamp_us - self._last_peak_ts_us < 80_000:
+            # Still update EMA so the running average tracks loud passages.
+            self._energy_ema = 0.9 * ema + 0.1 * energy
+            return None
+        threshold_multiplier = 1.6
+        if energy > threshold_multiplier * ema:
+            # Strength scales the excess into 0-255 over a ~6x range.
+            excess = (energy / ema) - threshold_multiplier
+            strength = int(np.clip(excess / 6.0, 0.0, 1.0) * 255.0)
+            # Fast attack on EMA so we don't keep firing on a sustained rise.
+            self._energy_ema = 0.6 * ema + 0.4 * energy
+            self._last_peak_ts_us = timestamp_us
+            return max(1, strength)
+        # Standard EMA update outside onset events.
+        self._energy_ema = 0.9 * ema + 0.1 * energy
+        return None
 
     def _decode_pcm_to_mono_float32(self, pcm: bytes) -> np.ndarray:
         """Decode little-endian signed PCM16 to mono float32 in [-1, 1]."""
         raw = np.frombuffer(pcm, dtype="<i2")
         if raw.size == 0:
-            return np.zeros(1, dtype=np.float32)
+            return np.zeros(0, dtype=np.float32)
 
         if self._channels > 1:
             frame_count = raw.size // self._channels
             if frame_count <= 0:
-                return np.zeros(1, dtype=np.float32)
+                return np.zeros(0, dtype=np.float32)
             reshaped = raw[: frame_count * self._channels].reshape(frame_count, self._channels)
             mono = np.mean(reshaped.astype(np.float32), axis=1, dtype=np.float32)
         else:
@@ -152,20 +568,11 @@ class VisualizerFeatureExtractor:
         result: np.ndarray = magnitude * self._a_weight_cache
         return result
 
-    def _maybe_compute_spectrum(
-        self, freqs: np.ndarray, magnitude: np.ndarray, timestamp_us: int
-    ) -> np.ndarray:
+    def _compute_spectrum(self, freqs: np.ndarray, magnitude: np.ndarray) -> np.ndarray:
+        """Compute binned spectrum with per-bin EMA smoothing."""
         spectrum_cfg = self._config.spectrum
         if spectrum_cfg is None:
             raise ValueError("spectrum in config.types but config.spectrum is None")
-
-        if self._last_spectrum_ts_us is not None:
-            min_delta_us = int(1_000_000 / spectrum_cfg.rate_max)
-            if (
-                timestamp_us - self._last_spectrum_ts_us < min_delta_us
-                and self._last_spectrum is not None
-            ):
-                return self._last_spectrum
 
         computed = self._compute_binned_spectrum(
             freqs=freqs,
@@ -175,9 +582,15 @@ class VisualizerFeatureExtractor:
             f_max=spectrum_cfg.f_max,
             scale=spectrum_cfg.scale,
         )
-        self._last_spectrum_ts_us = timestamp_us
-        self._last_spectrum = computed
-        return computed
+        # Per-bin EMA in normalized space, then quantize to uint16.
+        new_norm = computed.astype(np.float32) / 65535.0
+        if self._spectrum_ema is None or self._spectrum_ema.size != new_norm.size:
+            self._spectrum_ema = new_norm.copy()
+        else:
+            self._spectrum_ema = (
+                _SPECTRUM_EMA_ALPHA * new_norm + (1.0 - _SPECTRUM_EMA_ALPHA) * self._spectrum_ema
+            )
+        return (np.clip(self._spectrum_ema, 0.0, 1.0) * 65535.0).astype(np.uint16)
 
     def _compute_binned_spectrum(
         self,
@@ -211,13 +624,19 @@ class VisualizerFeatureExtractor:
 
         # dB scale: map [-60 dB, 0 dB] relative to full-scale sine → [0, 65535].
         # Full-scale sine has rfft peak N/2, reduced to N/4 by Hanning window.
-        n = freqs.size * 2 - 1  # original time-domain sample count
+        n = freqs.size * 2 - 1
         ref = max(float(n) / 4.0, 1.0)
         ratio = np.maximum(binned / ref, 1e-10)
         db = 20.0 * np.log10(ratio)
         db_floor = -60.0
-        normalized = np.clip((db - db_floor) / -db_floor, 0.0, 1.0)
-        return (normalized * 65535.0).astype(np.uint16)
+        t = (db - db_floor) / -db_floor
+        t = np.maximum(t, 0.0)
+        # Soft floor: bottom 10% (≈6 dB) folds into a quadratic fade so bins
+        # crossing the floor don't snap between 0 and a positive value.
+        soft = 10.0 * t * t
+        t = np.where(t < 0.1, soft, t)
+        t = np.minimum(t, 1.0)
+        return (t * 65535.0).astype(np.uint16)
 
     def _frequency_bin_edges(
         self, *, n_bins: int, f_min: int, f_max: int, scale: Literal["lin", "log", "mel"]

--- a/aiosendspin/server/roles/visualizer/features.py
+++ b/aiosendspin/server/roles/visualizer/features.py
@@ -114,6 +114,15 @@ class VisualizerFeatureExtractor:
         # Cursor: ts of the NEXT frame to emit. Set on first chunk.
         self._next_emit_ts_us: int | None = None
 
+        # Per-FFT-size caches for values that are constant once the window
+        # size settles (recomputing them every frame is pure overhead on
+        # constrained hardware). Keyed by window length so the brief warmup
+        # ramp, where the window grows, refreshes them and then they stick.
+        self._hann_window: np.ndarray | None = None
+        self._rfftfreq: np.ndarray | None = None
+        # (freqs.size, valid mask, bin-index array) for the spectrum binning.
+        self._spectrum_bin_cache: tuple[int, np.ndarray, np.ndarray] | None = None
+
         # Smoothing / hysteresis state.
         self._spectrum_ema: np.ndarray | None = None
         self._loudness_ema: float | None = None
@@ -537,10 +546,15 @@ class VisualizerFeatureExtractor:
         if mono.size <= 1:
             return np.zeros(0, dtype=np.float32), np.zeros(0, dtype=np.float32)
 
-        windowed = mono * np.hanning(mono.size).astype(np.float32)
+        n = mono.size
+        if self._hann_window is None or self._hann_window.size != n:
+            self._hann_window = np.hanning(n).astype(np.float32)
+            self._rfftfreq = np.fft.rfftfreq(n, d=1.0 / float(self._sample_rate)).astype(np.float32)
+        assert self._rfftfreq is not None
+        windowed = mono * self._hann_window
         spectrum = np.fft.rfft(windowed)
         magnitude = np.abs(spectrum).astype(np.float32)
-        freqs = np.fft.rfftfreq(mono.size, d=1.0 / float(self._sample_rate)).astype(np.float32)
+        freqs = self._rfftfreq
 
         # Drop DC for peak/spectrum display.
         if magnitude.size > 0:
@@ -610,12 +624,19 @@ class VisualizerFeatureExtractor:
         if hi <= lo:
             return np.zeros(n_bins, dtype=np.uint16)
 
-        edges = self._frequency_bin_edges(n_bins=n_bins, f_min=lo, f_max=hi, scale=scale)
-
-        # Vectorized binning via np.digitize.
-        bin_indices = np.digitize(freqs, edges) - 1
-        valid = (bin_indices >= 0) & (bin_indices < n_bins)
-        idx = bin_indices[valid]
+        # Bin assignment is constant for a fixed freq grid + config; compute it
+        # once per window size and reuse (digitize over ~1k bins per frame is
+        # otherwise a steady cost). f_min/f_max/scale are fixed for the
+        # extractor's lifetime, so freqs.size alone keys the cache.
+        cache = self._spectrum_bin_cache
+        if cache is not None and cache[0] == freqs.size:
+            _, valid, idx = cache
+        else:
+            edges = self._frequency_bin_edges(n_bins=n_bins, f_min=lo, f_max=hi, scale=scale)
+            bin_indices = np.digitize(freqs, edges) - 1
+            valid = (bin_indices >= 0) & (bin_indices < n_bins)
+            idx = bin_indices[valid]
+            self._spectrum_bin_cache = (freqs.size, valid, idx)
         mag = magnitude[valid]
 
         sq = mag.astype(np.float64) ** 2

--- a/aiosendspin/server/roles/visualizer/group.py
+++ b/aiosendspin/server/roles/visualizer/group.py
@@ -1,25 +1,30 @@
-"""VisualizerGroupRole - group-level visualizer coordination.
-
-This is a placeholder implementation. Real visualization would involve:
-- Audio analysis (FFT, beat detection)
-- Timestamped binary visualization data
-- Synchronization with audio playback
-"""
+"""VisualizerGroupRole - group-level visualizer coordination."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from aiosendspin.server.roles.base import GroupRole
+from aiosendspin.models.visualizer import BeatAvailability, BeatTiming
+from aiosendspin.server.roles.base import GroupRole, Role
+from aiosendspin.server.roles.visualizer.types import VisualizerRoleProtocol
 
 if TYPE_CHECKING:
     from aiosendspin.server.group import SendspinGroup
 
 
 class VisualizerGroupRole(GroupRole):
-    """Coordinate visualizer roles across a group.
+    """VisualizerGroupRole - group-level visualizer coordination.
 
-    Placeholder implementation with only subscribe/unsubscribe functionality.
+    Reliable beat extraction is too computationally intensive to run on
+    the fly, so the schedule is not calculated inside aiosendspin. The
+    embedding server is responsible for computing beats offline and
+    feeding them in via `append_beat_schedule()`.
+
+    The group role is shared across all visualizer wire versions
+    (`visualizer@v1`, `visualizer@_draft_r1`, …). Only members that
+    satisfy `VisualizerRoleProtocol` are treated as beat-capable; older
+    wire versions that lack the protocol attributes are silently
+    skipped.
     """
 
     role_family = "visualizer"
@@ -27,3 +32,141 @@ class VisualizerGroupRole(GroupRole):
     def __init__(self, group: SendspinGroup) -> None:
         """Initialize VisualizerGroupRole."""
         super().__init__(group)
+        self._current_beats: list[BeatTiming] = []
+        self._beat_availability: BeatAvailability = BeatAvailability.PENDING
+
+    @property
+    def current_beats(self) -> list[BeatTiming]:
+        """Snapshot of beats in the current schedule."""
+        return list(self._current_beats)
+
+    @property
+    def beat_availability(self) -> BeatAvailability:
+        """Current beat availability for this source."""
+        return self._beat_availability
+
+    @property
+    def beats_wanted(self) -> bool:
+        """True if any subscribed visualizer client wants beats.
+
+        The server should gate beat computation on this: skip the
+        (expensive) beat analysis while it is False. It reflects
+        membership live, so a client joining mid-stream flips it True
+        on the next read. Re-check it on the client/group membership
+        events the server already receives.
+        """
+        return any(
+            member.wants_beats
+            for member in self._members
+            if isinstance(member, VisualizerRoleProtocol)
+        )
+
+    def set_beat_availability(self, availability: BeatAvailability) -> None:
+        """Declare whether beats will arrive for the current source.
+
+        Default is `PENDING`: beats may still arrive via
+        `append_beat_schedule()`; roles defer `beat` in
+        `stream/start.types` until the first schedule lands.
+
+        `UNAVAILABLE` tells subscribers no beats will arrive for this
+        source — `beat` stays out of the negotiated types and any
+        currently stored schedule is dropped (a late joiner must not
+        receive stale beats for a source that has been declared
+        UNAVAILABLE).
+        """
+        self._beat_availability = availability
+        if availability is BeatAvailability.UNAVAILABLE:
+            self._current_beats = []
+        # Snapshot members: callbacks may synchronously re-enter the
+        # group (e.g. send_binary → backpressure → role disconnect →
+        # unsubscribe → _members.remove).
+        for role in list(self._members):
+            if isinstance(role, VisualizerRoleProtocol):
+                role.set_beat_availability(availability)
+
+    def on_member_join(self, role: Role) -> None:
+        """Replay availability + current schedule to a fresh beat-capable role.
+
+        Roles that don't want beats are skipped (avoids replaying a
+        whole-track schedule onto a wire that can't carry it). The
+        schedule is filtered to future-only beats relative to the
+        current playhead so the joining role's wire-ts guard doesn't
+        burn cycles dropping every past beat one by one.
+        """
+        if not isinstance(role, VisualizerRoleProtocol):
+            return
+        role.set_beat_availability(self._beat_availability)
+        if not role.wants_beats:
+            return
+        role.clear_beats()
+        if not self._current_beats:
+            return
+        now_us = self._group._server.clock.now_us()  # noqa: SLF001
+        future_beats = [b for b in self._current_beats if b.timestamp_us >= now_us]
+        if future_beats:
+            role.append_beats(future_beats)
+
+    def on_member_leave(self, role: Role) -> None:  # noqa: ARG002
+        """No-op override.
+
+        Per-member state (timers, pending queues) is cleaned by the
+        role's own `on_disconnect`. The base `GroupRole.unsubscribe`
+        removes the member from `self._members` for us. Documented
+        here so future maintainers don't add a cleanup that duplicates
+        the role-side teardown.
+        """
+        return
+
+    def append_beat_schedule(self, beats: list[BeatTiming]) -> None:
+        """Append upcoming beats and broadcast to subscribers.
+
+        Each BeatTiming carries its server-clock timestamp and a
+        downbeat flag. Timestamps within a single call must be strictly
+        increasing. Adjacent calls may share a boundary ts (server feeds
+        `[..100]` then `[100..200]`); the duplicate head is dropped so
+        producers don't have to shift timestamps by 1 µs.
+
+        No-op when availability is `UNAVAILABLE`.
+        """
+        if self._beat_availability is BeatAvailability.UNAVAILABLE:
+            return
+        # Snapshot the caller's list so post-call mutations can't change
+        # what subscribers see, and so validation runs against a stable
+        # iteration order.
+        snapshot = list(beats)
+        if not snapshot:
+            return
+        last_ts = self._current_beats[-1].timestamp_us if self._current_beats else None
+        # Allow a shared-boundary duplicate at the head (segment seam),
+        # then require strictly-increasing inside the segment.
+        if last_ts is not None and snapshot and snapshot[0].timestamp_us == last_ts:
+            snapshot = snapshot[1:]
+        for beat in snapshot:
+            if last_ts is not None and beat.timestamp_us <= last_ts:
+                raise ValueError(
+                    f"beat timestamps must be strictly increasing; "
+                    f"got {beat.timestamp_us} after {last_ts}"
+                )
+            last_ts = beat.timestamp_us
+        if not snapshot:
+            return
+        self._current_beats.extend(snapshot)
+        new_segment = list(snapshot)
+        for role in list(self._members):
+            if isinstance(role, VisualizerRoleProtocol):
+                role.append_beats(new_segment)
+
+    def clear_beat_schedule(self) -> None:
+        """Drop the stored schedule and broadcast a clear marker.
+
+        Also resets availability to `PENDING` — each track starts fresh,
+        so a previous `UNAVAILABLE` declaration does not silently
+        block the next track's schedule. Server can redeclare
+        `UNAVAILABLE` after the next `append_beat_schedule` if needed.
+        """
+        self._current_beats = []
+        self._beat_availability = BeatAvailability.PENDING
+        for role in list(self._members):
+            if isinstance(role, VisualizerRoleProtocol):
+                role.clear_beats()
+                role.set_beat_availability(BeatAvailability.PENDING)

--- a/aiosendspin/server/roles/visualizer/packing.py
+++ b/aiosendspin/server/roles/visualizer/packing.py
@@ -1,53 +1,22 @@
-"""Binary packing helpers for draft visualizer role."""
+"""Binary packing helper for the visualizer@v1 wire.
+
+Each visualizer binary message carries exactly one frame of data and
+follows the shared layout `[type:1][ts:8][data]`. The single helper
+emits the `[type][ts]` header plus the caller-supplied data bytes.
+Per-type value clipping and invariants live at the call site in
+`v1.py`.
+"""
 
 from __future__ import annotations
 
 import struct
 
-import numpy as np
-
 from aiosendspin.models.types import BinaryMessageType
-from aiosendspin.models.visualizer import StreamStartVisualizer
-from aiosendspin.server.roles.visualizer.features import ExtractedFrame
+
+# Bit 0 of a beat frame's flags byte indicates a downbeat.
+FLAG_DOWNBEAT = 0b0000_0001
 
 
-def pack_visualization_message(
-    *,
-    frames: list[ExtractedFrame],
-    config: StreamStartVisualizer,
-) -> bytes:
-    """Pack a complete visualization data binary message (type 16).
-
-    Wire format per spec:
-        Byte 0: message type 16 (uint8)
-        Byte 1: frame count (uint8)
-        Remaining: frames [...] each: [timestamp:8][data per types]
-    """
-    if not frames:
-        raise ValueError("cannot pack empty visualizer frame list")
-    if len(frames) > 255:
-        raise ValueError(f"max 255 frames per message, got {len(frames)}")
-
-    output = bytearray()
-    output.append(BinaryMessageType.VISUALIZATION_DATA.value)
-    output.append(len(frames))
-
-    for frame in frames:
-        output.extend(struct.pack(">q", frame.timestamp_us))
-        for typed in config.types:
-            if typed == "loudness":
-                value = 0 if frame.loudness is None else frame.loudness
-                output.extend(struct.pack(">H", int(np.clip(value, 0, 65535))))
-            elif typed == "f_peak":
-                value = 0 if frame.f_peak is None else frame.f_peak
-                output.extend(struct.pack(">H", int(np.clip(value, 0, 65535))))
-            elif typed == "spectrum":
-                if frame.spectrum is None:
-                    if config.spectrum is None:
-                        raise ValueError("spectrum in config.types but config.spectrum is None")
-                    zeros = np.zeros(config.spectrum.n_disp_bins, dtype=np.uint16)
-                    output.extend(zeros.astype(">u2").tobytes())
-                else:
-                    output.extend(frame.spectrum.astype(">u2", copy=False).tobytes())
-
-    return bytes(output)
+def pack_visualizer_frame(msg_type: BinaryMessageType, timestamp_us: int, payload: bytes) -> bytes:
+    """Pack one visualizer binary: `[type:1][ts:8][payload]`."""
+    return bytes((msg_type.value,)) + struct.pack(">q", timestamp_us) + payload

--- a/aiosendspin/server/roles/visualizer/types.py
+++ b/aiosendspin/server/roles/visualizer/types.py
@@ -1,0 +1,39 @@
+"""Shared visualizer role protocols."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from aiosendspin.models.visualizer import BeatAvailability, BeatTiming
+
+
+@runtime_checkable
+class VisualizerRoleProtocol(Protocol):
+    """Protocol for visualizer role implementations.
+
+    Defines the hooks that VisualizerGroupRole invokes on subscribed roles
+    to drive the beat schedule. Roles that do not negotiate the "beat" type
+    may treat both methods as no-ops.
+    """
+
+    @property
+    def role_id(self) -> str:
+        """Return the versioned role identifier."""
+        ...
+
+    @property
+    def wants_beats(self) -> bool:
+        """True if the client negotiated `beat` and beats are not unavailable."""
+        ...
+
+    def append_beats(self, beats: list[BeatTiming]) -> None:
+        """Extend the pending beat schedule for this role."""
+        ...
+
+    def clear_beats(self) -> None:
+        """Drop any pending beat schedule for this role."""
+        ...
+
+    def set_beat_availability(self, availability: BeatAvailability) -> None:
+        """Declare whether beats will arrive for the current source."""
+        ...

--- a/aiosendspin/server/roles/visualizer/v1.py
+++ b/aiosendspin/server/roles/visualizer/v1.py
@@ -1,9 +1,34 @@
-"""Visualizer role implementation for draft visualizer streaming."""
+"""Visualizer role implementation for the `visualizer@v1` wire.
+
+Each binary message carries exactly one frame of one type. The role emits:
+- `loudness` (msg 16) — per audio chunk
+- `beat` (msg 17) — fed in via `append_beats` from offline analysis
+- `f_peak` (msg 18) — per audio chunk
+- `spectrum` (msg 19) — per audio chunk
+- `peak` (msg 20) — per audio chunk when the onset detector fires
+- `pitch` (msg 21) — per audio chunk when a confident pitch is detected
+
+`beat` is *deferred* from `stream/start.types` until the first non-empty
+schedule actually lands. While beats are still being computed upstream
+the role advertises only the FFT-driven types so clients can render a
+`peak`-based fallback without flicker; once `append_beats` first
+delivers, the role re-emits `stream/start` with `beat` added and beats
+begin riding the wire interleaved with periodic frames.
+
+All beats drain through `on_audio_chunk` (audio chunks are delivered to
+this role's `on_audio_chunk` regardless of negotiated types), so no
+separate clock-based scheduler is needed.
+"""
 
 from __future__ import annotations
 
 import logging
+import struct
+from collections import deque
+from dataclasses import replace
 from typing import TYPE_CHECKING
+
+import numpy as np
 
 from aiosendspin.models.core import (
     StreamClearMessage,
@@ -16,8 +41,11 @@ from aiosendspin.models.core import (
 )
 from aiosendspin.models.types import BinaryMessageType
 from aiosendspin.models.visualizer import (
+    BeatAvailability,
+    BeatTiming,
     ClientHelloVisualizerSupport,
     StreamStartVisualizer,
+    SupportedVisualizerType,
 )
 from aiosendspin.server.audio import BufferTracker
 from aiosendspin.server.roles.base import (
@@ -27,40 +55,86 @@ from aiosendspin.server.roles.base import (
     Role,
     StreamRequirements,
 )
-from aiosendspin.server.roles.visualizer.features import VisualizerFeatureExtractor
-from aiosendspin.server.roles.visualizer.packing import pack_visualization_message
+from aiosendspin.server.roles.visualizer.features import (
+    ExtractedFrame,
+    VisualizerFeatureExtractor,
+)
+from aiosendspin.server.roles.visualizer.packing import (
+    FLAG_DOWNBEAT,
+    pack_visualizer_frame,
+)
 
 if TYPE_CHECKING:
     from aiosendspin.server.client import SendspinClient
 
 _LOGGER = logging.getLogger(__name__)
 
+# Types the reference implementation knows how to compute. Unsupported
+# types requested by the client are silently dropped per spec.
+_IMPLEMENTED_TYPES: frozenset[SupportedVisualizerType] = frozenset(
+    {"loudness", "f_peak", "spectrum", "beat", "peak", "pitch"}
+)
+# Types whose computation requires the FFT extractor. `beat` is the only
+# supplied-externally type and does not require the extractor.
+_FFT_DRIVEN_TYPES: frozenset[SupportedVisualizerType] = frozenset(
+    {"loudness", "f_peak", "spectrum", "peak", "pitch"}
+)
+
 
 class VisualizerV1Role(Role):
-    """Role implementation for draft visualizer streaming."""
+    """Role implementation for `visualizer@v1` streaming."""
 
     def __init__(self, client: SendspinClient | None = None) -> None:
         """Initialize VisualizerV1Role."""
         if client is None:
-            msg = "VisualizerV1Role requires a client"
-            raise ValueError(msg)
+            raise ValueError("VisualizerV1Role requires a client")
         self._client = client
         self._stream_started = False
-        self._buffer_tracker = None
-        self._group_role = None
+        self._buffer_tracker: BufferTracker | None = None
         self._support: ClientHelloVisualizerSupport | None = None
         self._stream_config: StreamStartVisualizer | None = None
         self._extractor: VisualizerFeatureExtractor | None = None
+        # Beats queued for delivery on the next audio chunk's drain.
+        self._pending_beats: deque[BeatTiming] = deque()
+        # True once `append_beats` has delivered a non-empty schedule for
+        # the current stream. Gates `beat` in the negotiated types.
+        self._has_beats_landed: bool = False
+        # Server-side capability metadata for downbeat tracking, set via
+        # `set_tracks_downbeats()` before `stream/start` is sent.
+        self._tracks_downbeats: bool = False
+        # Last-emitted timestamp across all visualizer binaries. The spec
+        # requires non-decreasing timestamp order within the role; beats
+        # interleave with audio-chunk-driven periodic frames to satisfy
+        # it. None means the cursor has not been primed yet.
+        self._last_wire_emit_ts_us: int | None = None
+        # Beat availability for the current source. UNAVAILABLE drops
+        # `beat` from the negotiated set and discards pending beats.
+        self._beat_availability: BeatAvailability = BeatAvailability.PENDING
 
     @property
     def role_id(self) -> str:
         """Versioned role identifier."""
-        return "visualizer@_draft_r1"
+        return "visualizer@v1"
 
     @property
     def role_family(self) -> str:
         """Role family name for protocol messages."""
         return "visualizer"
+
+    @property
+    def wants_beats(self) -> bool:
+        """True if the client negotiated `beat` and beats are not unavailable.
+
+        Reads the client's requested types (`_support`), not the exposed
+        `stream/start` types, so it is True from the moment the client
+        asks for beats — before the first schedule activates the type on
+        the wire.
+        """
+        return (
+            self._support is not None
+            and "beat" in self._support.types
+            and self._beat_availability is not BeatAvailability.UNAVAILABLE
+        )
 
     def get_stream_requirements(self) -> StreamRequirements:
         """Visualizer role sends binary streams."""
@@ -77,16 +151,58 @@ class VisualizerV1Role(Role):
 
     def get_binary_handling(self, message_type: int) -> BinaryHandling | None:
         """Return handling policy for visualizer binary frames."""
-        if message_type == BinaryMessageType.VISUALIZATION_DATA.value:
-            return BinaryHandling(drop_late=True, grace_period_us=2_000_000, buffer_track=True)
+        for member in (
+            BinaryMessageType.VISUALIZATION_LOUDNESS,
+            BinaryMessageType.VISUALIZATION_BEAT,
+            BinaryMessageType.VISUALIZATION_F_PEAK,
+            BinaryMessageType.VISUALIZATION_SPECTRUM,
+            BinaryMessageType.VISUALIZATION_PEAK,
+            BinaryMessageType.VISUALIZATION_PITCH,
+        ):
+            if message_type == member.value:
+                return BinaryHandling(drop_late=True, grace_period_us=2_000_000, buffer_track=True)
         return None
 
     def get_buffer_tracker(self) -> BufferTracker | None:
         """Return the visualizer buffer tracker."""
         return self._buffer_tracker
 
+    def set_tracks_downbeats(self, *, tracks: bool) -> None:
+        """Mark whether the upstream beat detector identifies bar starts."""
+        self._tracks_downbeats = bool(tracks)
+
+    def set_beat_availability(self, availability: BeatAvailability) -> None:
+        """Declare whether beats will arrive for the current source.
+
+        `beat` rides in `stream/start.types` whenever the client wants
+        beats AND a schedule has already landed. Switching to
+        UNAVAILABLE drops any pending schedule and re-issues
+        `stream/start` so the client falls back to the FFT-driven types.
+        """
+        if self._beat_availability is availability:
+            return
+        previous_beat_in_types = self._beat_in_negotiated_types()
+        self._beat_availability = availability
+        if availability is BeatAvailability.UNAVAILABLE:
+            self._pending_beats.clear()
+            self._has_beats_landed = False
+        if (
+            self._support is None
+            or "beat" not in self._support.types
+            or self._stream_config is None
+        ):
+            return
+        if previous_beat_in_types != self._beat_in_negotiated_types():
+            self._reissue_stream_start()
+
     def _ensure_buffer_tracker(self) -> None:
-        """Create or update buffer tracker from negotiated config."""
+        """Create or update the buffer tracker from negotiated config.
+
+        Capacity changes update the limit but never reset the buffered
+        byte count — the client still holds previously sent bytes and a
+        reset would under-count, disabling backpressure until the real
+        client buffer overflowed.
+        """
         if self._support is None:
             self._buffer_tracker = None
             return
@@ -99,7 +215,6 @@ class VisualizerV1Role(Role):
             )
         else:
             self._buffer_tracker.capacity_bytes = capacity
-            self._buffer_tracker.reset()
 
     def on_connect(self) -> None:
         """Initialize stream config and subscribe to group role."""
@@ -107,97 +222,399 @@ class VisualizerV1Role(Role):
         self._subscribe_to_group_role()
 
     def on_disconnect(self) -> None:
-        """Unsubscribe from VisualizerGroupRole."""
+        """Unsubscribe from VisualizerGroupRole and reset state."""
         self._unsubscribe_from_group_role()
         self._stream_started = False
         self._extractor = None
+        self._pending_beats.clear()
+        self._has_beats_landed = False
+        self._last_wire_emit_ts_us = None
+        self._beat_availability = BeatAvailability.PENDING
         self.reset_binary_timing()
 
     def on_stream_start(self) -> None:
-        """Start extractor state for a new audio stream."""
-        if self._stream_config is None:
+        """Start extractor state and emit `stream/start` on a fresh stream."""
+        if self._support is None:
             return
+        # Rebuild the config so any beats that landed before this
+        # `on_stream_start` (mid-stream join replay) are reflected.
+        self._stream_config = self._build_stream_config()
         self.reset_binary_timing()
-        # stream/end clears client-side visualizer config, so resend stream/start
-        # at each new stream boundary.
+        # Prime the wire-ts cursor to the current playhead so a stale
+        # replayed beat can't poison the cursor backward into the past.
+        self._last_wire_emit_ts_us = self._client._server.clock.now_us()  # noqa: SLF001
+        # `stream/start` is just a config update during an active stream
+        # (`stream/clear` keeps the stream alive). Skip the resend when
+        # we have already announced a config; mid-stream config changes
+        # go through `_reissue_stream_start` which bypasses this guard.
         if not self._stream_started:
             self._send_stream_start()
+        self._rebuild_extractor()
+        self._stream_started = True
+        self._ensure_buffer_tracker()
+
+    def _rebuild_extractor(self) -> None:
+        """Create the FFT extractor when at least one FFT-driven type is negotiated.
+
+        Beat-only configurations have no use for the extractor; leaving
+        it None lets `on_audio_chunk` early-return after the beat drain.
+        """
+        if self._stream_config is None:
+            self._extractor = None
+            return
+        if not any(t in self._stream_config.types for t in _FFT_DRIVEN_TYPES):
+            self._extractor = None
+            return
         req = self.get_audio_requirements()
         self._extractor = VisualizerFeatureExtractor(
             sample_rate=req.sample_rate,
             channels=req.channels,
             config=self._stream_config,
         )
-        self._stream_started = True
-        self._ensure_buffer_tracker()
 
     def on_audio_chunk(self, chunk: AudioChunk) -> None:
-        """Process audio chunk and emit visualizer binary frame."""
-        if not self.has_connection() or self._stream_config is None or self._extractor is None:
-            return
+        """Extract per-chunk features and emit one binary per enabled type.
 
-        frame = self._extractor.process_chunk(chunk.data, chunk.timestamp_us)
-        message = pack_visualization_message(frames=[frame], config=self._stream_config)
+        Beats are drained up to each emit ts so the visualizer wire stays
+        in non-decreasing ts order. Audio chunks are delivered regardless
+        of which types are negotiated, so this method is also the drain
+        driver for beat-only configurations.
+        """
+        if not self.has_connection() or self._stream_config is None:
+            return
+        # Drain pending beats that fall at or before this chunk's start
+        # so they precede the chunk's periodic frames. Frames inside the
+        # chunk drain further as they emit.
+        self._drain_beats_up_to(chunk.timestamp_us)
+        if self._extractor is None:
+            return
+        end_time_us = chunk.timestamp_us + chunk.duration_us
+        for frame in self._extractor.process_chunk(chunk.data, chunk.timestamp_us):
+            self._drain_beats_up_to(frame.timestamp_us)
+            self._emit_frame(frame, end_time_us=end_time_us, duration_us=chunk.duration_us)
+
+    def _emit_frame(
+        self,
+        frame: ExtractedFrame,
+        *,
+        end_time_us: int,
+        duration_us: int,
+    ) -> None:
+        """Pack and send all configured binaries for a single extractor frame."""
+        if self._stream_config is None:
+            return
+        types = self._stream_config.types
+        ts = frame.timestamp_us
+        if "loudness" in types and frame.loudness is not None:
+            payload = struct.pack(">H", int(np.clip(frame.loudness, 0, 65535)))
+            self._dispatch_frame(
+                pack_visualizer_frame(BinaryMessageType.VISUALIZATION_LOUDNESS, ts, payload),
+                ts_us=ts,
+                msg_type=BinaryMessageType.VISUALIZATION_LOUDNESS,
+                end_time_us=end_time_us,
+                duration_us=duration_us,
+            )
+        if "f_peak" in types and frame.f_peak_freq is not None and frame.f_peak_amp is not None:
+            # Wire invariant: `freq == 0 implies amp == 0` so a misbehaving
+            # extractor cannot emit "no peak with non-zero amp".
+            freq = int(np.clip(frame.f_peak_freq, 0, 65535))
+            amp = int(np.clip(frame.f_peak_amp, 0, 65535)) if freq != 0 else 0
+            payload = struct.pack(">HH", freq, amp)
+            self._dispatch_frame(
+                pack_visualizer_frame(BinaryMessageType.VISUALIZATION_F_PEAK, ts, payload),
+                ts_us=ts,
+                msg_type=BinaryMessageType.VISUALIZATION_F_PEAK,
+                end_time_us=end_time_us,
+                duration_us=duration_us,
+            )
+        if "spectrum" in types and frame.spectrum is not None:
+            payload = frame.spectrum.astype(">u2", copy=False).tobytes()
+            self._dispatch_frame(
+                pack_visualizer_frame(BinaryMessageType.VISUALIZATION_SPECTRUM, ts, payload),
+                ts_us=ts,
+                msg_type=BinaryMessageType.VISUALIZATION_SPECTRUM,
+                end_time_us=end_time_us,
+                duration_us=duration_us,
+            )
+        if "peak" in types and frame.peak is not None:
+            payload = bytes((int(np.clip(frame.peak, 0, 255)),))
+            self._dispatch_frame(
+                pack_visualizer_frame(BinaryMessageType.VISUALIZATION_PEAK, ts, payload),
+                ts_us=ts,
+                msg_type=BinaryMessageType.VISUALIZATION_PEAK,
+                end_time_us=end_time_us,
+                duration_us=duration_us,
+            )
+        if (
+            "pitch" in types
+            and frame.pitch_midi_q88 is not None
+            and frame.pitch_confidence is not None
+        ):
+            midi = int(np.clip(frame.pitch_midi_q88, 0, 65535))
+            confidence = int(np.clip(frame.pitch_confidence, 0, 255))
+            payload = struct.pack(">H", midi) + bytes((confidence,))
+            self._dispatch_frame(
+                pack_visualizer_frame(BinaryMessageType.VISUALIZATION_PITCH, ts, payload),
+                ts_us=ts,
+                msg_type=BinaryMessageType.VISUALIZATION_PITCH,
+                end_time_us=end_time_us,
+                duration_us=duration_us,
+            )
+
+    def _dispatch_frame(
+        self,
+        message: bytes,
+        *,
+        ts_us: int,
+        msg_type: BinaryMessageType,
+        end_time_us: int,
+        duration_us: int,
+    ) -> None:
+        """Reserve the wire ts and enqueue a periodic binary frame."""
+        self._reserve_wire_ts(ts_us)
         self._client.send_binary(
             message,
             role_family=self.role_family,
-            timestamp_us=frame.timestamp_us,
-            message_type=BinaryMessageType.VISUALIZATION_DATA.value,
-            buffer_end_time_us=chunk.timestamp_us + chunk.duration_us,
+            timestamp_us=ts_us,
+            message_type=msg_type.value,
+            buffer_end_time_us=end_time_us,
             buffer_byte_count=len(message),
-            duration_us=chunk.duration_us,
+            duration_us=duration_us,
         )
 
+    def _reserve_wire_ts(self, ts_us: int) -> None:
+        """Advance the wire-ts cursor; callers must not regress below it."""
+        last = self._last_wire_emit_ts_us
+        self._last_wire_emit_ts_us = max(ts_us, last) if last is not None else ts_us
+
+    def append_beats(self, beats: list[BeatTiming]) -> None:
+        """Append beat timings for delivery interleaved with audio chunks.
+
+        Beats land here from `VisualizerGroupRole.append_beat_schedule`
+        (server-fed offline analysis). They drain on the next
+        `on_audio_chunk` whose timestamp matches or exceeds each beat's
+        ts.
+
+        No-op while `BeatAvailability.UNAVAILABLE` or when the client
+        did not request `beat`. The first non-empty delivery re-emits
+        `stream/start` so the client sees `beat` added to the negotiated
+        types.
+        """
+        if self._support is None or "beat" not in self._support.types:
+            return
+        if self._beat_availability is BeatAvailability.UNAVAILABLE:
+            return
+        if not beats:
+            return
+        first_landing = not self._has_beats_landed
+        self._pending_beats.extend(beats)
+        self._has_beats_landed = True
+        if first_landing and self._stream_started and self._stream_config is not None:
+            # Beat is now legitimately part of the negotiated types — tell
+            # the client. Subsequent audio chunks will drain the queue.
+            self._reissue_stream_start()
+
+    def _reissue_stream_start(self) -> None:
+        """Rebuild stream config from current state and re-send `stream/start`."""
+        if self._support is None:
+            return
+        self._stream_config = self._build_stream_config()
+        self._send_stream_start()
+
+    def clear_beats(self) -> None:
+        """Drop any pending beat schedule (`stream/clear` carries this on the wire)."""
+        self._pending_beats.clear()
+        if self._has_beats_landed:
+            self._has_beats_landed = False
+            if self._stream_started and self._stream_config is not None:
+                self._reissue_stream_start()
+
+    def _drain_beats_up_to(self, max_ts_us: int) -> None:
+        """Emit any pending beats whose ts is <= `max_ts_us`."""
+        if self._stream_config is None or "beat" not in self._stream_config.types:
+            return
+        due: list[BeatTiming] = []
+        while self._pending_beats and self._pending_beats[0].timestamp_us <= max_ts_us:
+            due.append(self._pending_beats.popleft())
+        if due:
+            self._emit_beats(due)
+
+    def _emit_beats(self, beats: list[BeatTiming]) -> None:
+        """Emit each beat as its own msg 17 binary.
+
+        Drops any beat whose ts would regress (or duplicate) the wire
+        cursor — the wire must stay strictly non-decreasing.
+        """
+        if self._stream_config is None or not beats:
+            return
+        for beat in beats:
+            last = self._last_wire_emit_ts_us
+            # `<=` drops duplicates as well as strict regressions — the
+            # group enforces strict monotonicity within a single schedule
+            # but a resubscribe replay can deliver a beat whose ts equals
+            # the most-recently-emitted one.
+            if last is not None and beat.timestamp_us <= last:
+                continue
+            self._reserve_wire_ts(beat.timestamp_us)
+            flags = FLAG_DOWNBEAT if beat.is_downbeat else 0
+            message = pack_visualizer_frame(
+                BinaryMessageType.VISUALIZATION_BEAT, beat.timestamp_us, bytes((flags,))
+            )
+            self._client.send_binary(
+                message,
+                role_family=self.role_family,
+                timestamp_us=beat.timestamp_us,
+                message_type=BinaryMessageType.VISUALIZATION_BEAT.value,
+                buffer_end_time_us=beat.timestamp_us,
+                buffer_byte_count=len(message),
+                duration_us=0,
+            )
+
     def on_stream_clear(self) -> None:
-        """Reset visualizer state and notify client to clear buffered data."""
+        """Reset extractor state, drop pending beats, notify client."""
         if self._extractor is not None:
             self._extractor.reset()
+        self._pending_beats.clear()
+        # Seek re-pushes the schedule, so beats arrive again shortly.
+        # Drop the wire-ts guard so post-seek frames with earlier
+        # timestamps are not silently blocked.
+        self._last_wire_emit_ts_us = None
+        had_beats = self._has_beats_landed
+        self._has_beats_landed = False
         self.send_message(StreamClearMessage(payload=StreamClearPayload(roles=["visualizer"])))
         self.reset_binary_timing()
         if self._buffer_tracker is not None:
             self._buffer_tracker.reset()
+        if had_beats and self._stream_started and self._stream_config is not None:
+            # `beat` is no longer in the negotiated types until a fresh
+            # schedule arrives; tell the client.
+            self._reissue_stream_start()
 
     def on_stream_end(self) -> None:
-        """Reset visualizer state and notify client that stream has ended."""
+        """End the visualizer stream and reset state."""
         self._extractor = None
         self._stream_started = False
+        self._pending_beats.clear()
+        self._has_beats_landed = False
         self.send_message(StreamEndMessage(payload=StreamEndPayload(roles=["visualizer"])))
         self.reset_binary_timing()
         if self._buffer_tracker is not None:
             self._buffer_tracker.reset()
 
-    def on_stream_request_format(self, payload: StreamRequestFormatPayload) -> None:  # noqa: ARG002
-        """Ignore runtime visualizer renegotiation for now."""
-        _LOGGER.debug(
-            "Ignoring visualizer stream/request-format from client %s",
-            self._client.client_id,
-        )
+    def on_stream_request_format(self, payload: StreamRequestFormatPayload) -> None:
+        """Apply mid-stream renegotiation. All v1 fields are optional and merged."""
+        request = payload.visualizer
+        if request is None or self._stream_config is None or self._support is None:
+            return
+
+        # Build the merged payload as a plain dict so the support
+        # dataclass's `__post_init__` validation only runs once after
+        # normalization — avoiding a "spectrum in types without spectrum
+        # config" ValueError during intermediate `replace()` calls.
+        merged: dict[str, object] = self._support.to_dict()
+        if request.types is not None:
+            merged["types"] = list(request.types)
+        if request.rate_max is not None:
+            merged["rate_max"] = request.rate_max
+        if request.buffer_capacity is not None:
+            merged["buffer_capacity"] = request.buffer_capacity
+        if request.spectrum is not None:
+            merged["spectrum"] = request.spectrum.to_dict()
+
+        normalized = self._normalize_support_payload(merged)
+        new_support = ClientHelloVisualizerSupport.from_dict(normalized)
+        kept: list[str] = [t for t in new_support.types if t in _IMPLEMENTED_TYPES]
+        if not kept:
+            kept = ["loudness"]
+        new_support = replace(new_support, types=kept)
+
+        # Pending beats are pinned to the old config (e.g. stale rate);
+        # drop them and re-arm `_has_beats_landed` so the new config
+        # waits for fresh beats before re-advertising `beat`.
+        self._pending_beats.clear()
+        self._has_beats_landed = False
+
+        self._support = new_support
+        self._stream_config = self._build_stream_config()
+        # rate_max / types change rebuilds the extractor (new hop). Drop
+        # the wire-ts guard so the new config takes effect immediately.
+        self._last_wire_emit_ts_us = None
+        self._rebuild_extractor()
+        self._ensure_buffer_tracker()
+        self._send_stream_start()
 
     def _init_stream_config(self) -> None:
         """Parse visualizer support config from client/hello."""
         support_raw = self._client.info.visualizer_support
         if support_raw is None:
-            raise ValueError("visualizer support object missing for draft visualizer role")
+            raise ValueError("visualizer support object missing for visualizer@v1 role")
         self._support = ClientHelloVisualizerSupport.from_dict(
             self._normalize_support_payload(support_raw)
         )
-        self._stream_config = StreamStartVisualizer.from_support(self._support)
+        kept: list[str] = [t for t in self._support.types if t in _IMPLEMENTED_TYPES]
+        dropped = [t for t in self._support.types if t not in _IMPLEMENTED_TYPES]
+        if dropped:
+            _LOGGER.warning(
+                "client %s requested unimplemented visualizer types %s; ignoring",
+                self._client.client_id,
+                dropped,
+            )
+        if not kept:
+            _LOGGER.warning(
+                "client %s requested no implemented visualizer types; falling back to ['loudness']",
+                self._client.client_id,
+            )
+            kept = ["loudness"]
+        self._support = replace(self._support, types=kept)
+        self._stream_config = self._build_stream_config()
+
+    def _beat_in_negotiated_types(self) -> bool:
+        """Whether `beat` is currently exposed in `stream/start.types`."""
+        return (
+            self._support is not None
+            and "beat" in self._support.types
+            and self._has_beats_landed
+            and self._beat_availability is not BeatAvailability.UNAVAILABLE
+        )
+
+    def _build_stream_config(self) -> StreamStartVisualizer:
+        """Derive the current `stream/start` config from support + beat state.
+
+        `beat` is deferred: it is exposed only once a non-empty beat
+        schedule has actually landed for the current stream (and the
+        client requested it, and availability is not UNAVAILABLE).
+        Until then the client sees only the FFT-driven types and can
+        render a `peak`-based fallback without flicker.
+
+        Exception: beat-only clients (`types == ["beat"]`) get `beat`
+        from the start — there is no FFT-driven type to fall back to.
+        """
+        if self._support is None:
+            raise ValueError("support must be initialised before building stream config")
+        client_types = list(self._support.types)
+        beat_only = client_types == ["beat"]
+        if beat_only or self._beat_in_negotiated_types():
+            exposed_types = client_types
+        else:
+            exposed_types = [t for t in client_types if t != "beat"]
+        derived_support = replace(self._support, types=exposed_types)
+        return StreamStartVisualizer.from_support(
+            derived_support, tracks_downbeats=self._tracks_downbeats
+        )
 
     def _normalize_support_payload(self, support_raw: object) -> dict[str, object]:
-        """Normalize legacy/minimal support payloads to draft visualizer schema."""
+        """Normalize a client/hello support payload to the v1 schema."""
         if isinstance(support_raw, dict):
             payload: dict[str, object] = dict(support_raw)
         elif isinstance(support_raw, ClientHelloVisualizerSupport):
-            # Legacy and draft payloads represented by model object.
             payload = support_raw.to_dict()
         else:
             raise TypeError("visualizer support object must be a JSON object")
 
-        # Backward-compatible defaults when client sends only buffer capacity.
         if "types" not in payload:
             payload["types"] = ["loudness", "f_peak"]
-        if "batch_max" not in payload:
-            payload["batch_max"] = 8
+        if "rate_max" not in payload or payload.get("rate_max") is None:
+            payload["rate_max"] = 30
 
         raw_types = payload.get("types")
         if isinstance(raw_types, list):
@@ -211,7 +628,7 @@ class VisualizerV1Role(Role):
         return payload
 
     def _send_stream_start(self) -> None:
-        """Send stream/start with negotiated visualizer configuration."""
+        """Send `stream/start` with the negotiated visualizer configuration."""
         if self._stream_config is None:
             return
         message = StreamStartMessage(payload=StreamStartPayload(visualizer=self._stream_config))

--- a/aiosendspin/server/roles/visualizer/v1.py
+++ b/aiosendspin/server/roles/visualizer/v1.py
@@ -149,6 +149,10 @@ class VisualizerV1Role(Role):
             frame_duration_us=25_000,
         )
 
+    def replay_from_pcm_cache(self) -> bool:
+        """Replay buffered PCM on late join (visualizer is analysis-only)."""
+        return True
+
     def get_binary_handling(self, message_type: int) -> BinaryHandling | None:
         """Return handling policy for visualizer binary frames."""
         for member in (

--- a/aiosendspin/server/roles/visualizer/v1.py
+++ b/aiosendspin/server/roles/visualizer/v1.py
@@ -22,6 +22,7 @@ separate clock-based scheduler is needed.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import struct
 from collections import deque
@@ -79,6 +80,13 @@ _IMPLEMENTED_TYPES: frozenset[SupportedVisualizerType] = frozenset(
 _FFT_DRIVEN_TYPES: frozenset[SupportedVisualizerType] = frozenset(
     {"loudness", "f_peak", "spectrum", "peak", "pitch"}
 )
+# While a beat-wanting client waits for the first schedule, periodic frames
+# are held to this lead ahead of the playhead. Keeping the wire-ts cursor
+# near the playhead means that when beats land only a small window of them
+# trails the cursor (and is dropped), instead of the whole schedule being
+# dropped behind a cursor already pushed seconds into the future by frames.
+# Lifted to full send-ahead once beats land (or are declared UNAVAILABLE).
+_WARMUP_LEAD_US = 3_000_000
 
 
 class VisualizerV1Role(Role):
@@ -110,6 +118,13 @@ class VisualizerV1Role(Role):
         # Beat availability for the current source. UNAVAILABLE drops
         # `beat` from the negotiated set and discards pending beats.
         self._beat_availability: BeatAvailability = BeatAvailability.PENDING
+        # Warmup holdback: while the client wants beats but none have landed,
+        # periodic frames beyond `_WARMUP_LEAD_US` are parked here instead of
+        # sent, and released by `_release_timer` as the playhead advances. The
+        # first schedule (or UNAVAILABLE) flushes them and lifts the cap.
+        self._holdback_active: bool = False
+        self._pending_frames: deque[tuple[int, bytes, BinaryMessageType, int, int]] = deque()
+        self._release_timer: asyncio.TimerHandle | None = None
 
     @property
     def role_id(self) -> str:
@@ -190,6 +205,8 @@ class VisualizerV1Role(Role):
         if availability is BeatAvailability.UNAVAILABLE:
             self._pending_beats.clear()
             self._has_beats_landed = False
+            # No beats will arrive — lift the cap and release held frames.
+            self._end_holdback()
         if (
             self._support is None
             or "beat" not in self._support.types
@@ -234,6 +251,9 @@ class VisualizerV1Role(Role):
         self._has_beats_landed = False
         self._last_wire_emit_ts_us = None
         self._beat_availability = BeatAvailability.PENDING
+        self._cancel_release_timer()
+        self._pending_frames.clear()
+        self._holdback_active = False
         self.reset_binary_timing()
 
     def on_stream_start(self) -> None:
@@ -247,6 +267,10 @@ class VisualizerV1Role(Role):
         # Prime the wire-ts cursor to the current playhead so a stale
         # replayed beat can't poison the cursor backward into the past.
         self._last_wire_emit_ts_us = self._client._server.clock.now_us()  # noqa: SLF001
+        # Arm the warmup holdback if beats are wanted but none have landed yet.
+        self._cancel_release_timer()
+        self._pending_frames.clear()
+        self._holdback_active = self._holdback_should_be_active()
         # `stream/start` is just a config update during an active stream
         # (`stream/clear` keeps the stream alive). Skip the resend when
         # we have already announced a config; mid-stream config changes
@@ -374,7 +398,22 @@ class VisualizerV1Role(Role):
         end_time_us: int,
         duration_us: int,
     ) -> None:
-        """Reserve the wire ts and enqueue a periodic binary frame."""
+        """Send a periodic frame now, or park it while the warmup cap is active."""
+        if self._holdback_active and ts_us > self._warmup_cutoff_us():
+            self._pending_frames.append((ts_us, message, msg_type, end_time_us, duration_us))
+            self._arm_release_timer()
+            return
+        self._send_frame_now(ts_us, message, msg_type, end_time_us, duration_us)
+
+    def _send_frame_now(
+        self,
+        ts_us: int,
+        message: bytes,
+        msg_type: BinaryMessageType,
+        end_time_us: int,
+        duration_us: int,
+    ) -> None:
+        """Reserve the wire ts and enqueue a periodic binary frame for sending."""
         self._reserve_wire_ts(ts_us)
         self._client.send_binary(
             message,
@@ -385,6 +424,57 @@ class VisualizerV1Role(Role):
             buffer_byte_count=len(message),
             duration_us=duration_us,
         )
+
+    def _holdback_should_be_active(self) -> bool:
+        """Whether the warmup cap applies: client wants beats, none landed yet."""
+        return self.wants_beats and not self._has_beats_landed
+
+    def _warmup_cutoff_us(self) -> int:
+        """Wire ts above which periodic frames are held during warmup."""
+        return self._client._server.clock.now_us() + _WARMUP_LEAD_US  # noqa: SLF001
+
+    def _cancel_release_timer(self) -> None:
+        """Cancel the pending held-frame release timer, if any."""
+        if self._release_timer is not None:
+            self._release_timer.cancel()
+            self._release_timer = None
+
+    def _arm_release_timer(self) -> None:
+        """Schedule the next held-frame release at the warmup lead."""
+        if self._release_timer is not None or not self._pending_frames or not self.has_connection():
+            return
+        now_us = self._client._server.clock.now_us()  # noqa: SLF001
+        head_ts = self._pending_frames[0][0]
+        delay_s = max(0, head_ts - _WARMUP_LEAD_US - now_us) / 1_000_000
+        loop = asyncio.get_running_loop()
+        self._release_timer = loop.call_later(delay_s, self._run_release_scheduler)
+
+    def _run_release_scheduler(self) -> None:
+        """Release held periodic frames whose ts is within the warmup lead."""
+        self._release_timer = None
+        if not self.has_connection():
+            return
+        cutoff_us = self._warmup_cutoff_us()
+        while self._pending_frames and self._pending_frames[0][0] <= cutoff_us:
+            ts_us, message, msg_type, end_time_us, duration_us = self._pending_frames.popleft()
+            self._send_frame_now(ts_us, message, msg_type, end_time_us, duration_us)
+        self._arm_release_timer()
+
+    def _end_holdback(self) -> None:
+        """Lift the warmup cap and flush held frames, interleaving due beats.
+
+        Held periodic frames are released in ts order; pending beats at or
+        below each frame's ts emit first so the wire stays non-decreasing.
+        Beats beyond the held frontier stay queued for `on_audio_chunk` to
+        drain. After this, periodic frames send immediately.
+        """
+        self._holdback_active = False
+        self._cancel_release_timer()
+        while self._pending_frames:
+            frame_ts = self._pending_frames[0][0]
+            self._drain_beats_up_to(frame_ts)
+            ts_us, message, msg_type, end_time_us, duration_us = self._pending_frames.popleft()
+            self._send_frame_now(ts_us, message, msg_type, end_time_us, duration_us)
 
     def _reserve_wire_ts(self, ts_us: int) -> None:
         """Advance the wire-ts cursor; callers must not regress below it."""
@@ -417,6 +507,10 @@ class VisualizerV1Role(Role):
             # Beat is now legitimately part of the negotiated types — tell
             # the client. Subsequent audio chunks will drain the queue.
             self._reissue_stream_start()
+        if first_landing:
+            # Lift the warmup cap: beats are here, flush held frames (with
+            # beats interleaved) and restore full send-ahead.
+            self._end_holdback()
 
     def _reissue_stream_start(self) -> None:
         """Rebuild stream config from current state and re-send `stream/start`."""
@@ -485,6 +579,12 @@ class VisualizerV1Role(Role):
         self._last_wire_emit_ts_us = None
         had_beats = self._has_beats_landed
         self._has_beats_landed = False
+        # Re-arm warmup: a seek re-pushes the (already-computed) schedule, so
+        # beats arrive again shortly; hold periodic frames near the playhead
+        # until they do.
+        self._cancel_release_timer()
+        self._pending_frames.clear()
+        self._holdback_active = self._holdback_should_be_active()
         self.send_message(StreamClearMessage(payload=StreamClearPayload(roles=["visualizer"])))
         self.reset_binary_timing()
         if self._buffer_tracker is not None:
@@ -500,6 +600,9 @@ class VisualizerV1Role(Role):
         self._stream_started = False
         self._pending_beats.clear()
         self._has_beats_landed = False
+        self._cancel_release_timer()
+        self._pending_frames.clear()
+        self._holdback_active = False
         self.send_message(StreamEndMessage(payload=StreamEndPayload(roles=["visualizer"])))
         self.reset_binary_timing()
         if self._buffer_tracker is not None:
@@ -540,6 +643,11 @@ class VisualizerV1Role(Role):
 
         self._support = new_support
         self._stream_config = self._build_stream_config()
+        # Held frames carry old-config payloads (e.g. stale spectrum bins);
+        # drop them and re-evaluate the warmup cap against the new support.
+        self._cancel_release_timer()
+        self._pending_frames.clear()
+        self._holdback_active = self._holdback_should_be_active()
         # rate_max / types change rebuilds the extractor (new hop). Drop
         # the wire-ts guard so the new config takes effect immediately.
         self._last_wire_emit_ts_us = None

--- a/aiosendspin/server/roles/visualizer/v1.py
+++ b/aiosendspin/server/roles/visualizer/v1.py
@@ -709,10 +709,37 @@ class VisualizerV1Role(Role):
             exposed_types = client_types
         else:
             exposed_types = [t for t in client_types if t != "beat"]
+        # Server-wide pitch shed: drop the (heavy) pitch feature unless it is
+        # the only exposed type — `stream/start` must keep at least one, and we
+        # cannot add a type the client did not request.
+        if not self._client._server.visualizer_pitch_enabled:  # noqa: SLF001
+            without_pitch = [t for t in exposed_types if t != "pitch"]
+            if without_pitch:
+                exposed_types = without_pitch
         derived_support = replace(self._support, types=exposed_types)
         return StreamStartVisualizer.from_support(
             derived_support, tracks_downbeats=self._tracks_downbeats
         )
+
+    def refresh_pitch_setting(self) -> None:
+        """Re-apply the server-wide pitch toggle to the live stream config.
+
+        Called by the server when `set_visualizer_pitch_enabled` flips. Rebuilds
+        the config and, if the exposed types changed, rebuilds the extractor and
+        re-emits `stream/start` so the client sees the new set.
+        """
+        if self._support is None or self._stream_config is None:
+            return
+        new_config = self._build_stream_config()
+        if new_config.types == self._stream_config.types:
+            return
+        self._stream_config = new_config
+        # Types changed (pitch added/removed) — let the new config take effect
+        # immediately rather than being blocked by the prior wire-ts cursor.
+        self._last_wire_emit_ts_us = None
+        self._rebuild_extractor()
+        if self._stream_started:
+            self._send_stream_start()
 
     def _normalize_support_payload(self, support_raw: object) -> dict[str, object]:
         """Normalize a client/hello support payload to the v1 schema."""

--- a/aiosendspin/server/roles/visualizer/v1.py
+++ b/aiosendspin/server/roles/visualizer/v1.py
@@ -435,16 +435,20 @@ class VisualizerV1Role(Role):
         return self.wants_beats and not self._has_beats_landed
 
     def _rearm_warmup_holdback(self) -> None:
-        """Re-arm the warmup cap and drop the wire-ts cursor for a fresh schedule.
+        """Re-arm the warmup cap for a fresh schedule.
 
         Used whenever a schedule is dropped (seek, beat-schedule clear) or beats
         become wanted again (availability back to PENDING): the next schedule
-        arrives shortly, so hold periodic frames near the playhead and clear the
-        cursor so a landing beat is not dropped behind a far-ahead frontier.
+        arrives shortly, so cap periodic frames near the playhead again.
+
+        Does NOT reset the wire-ts cursor: callers that did not also send a
+        `stream/clear` must keep it, so a late beat landing below an
+        already-sent frame is dropped by the `<=` guard rather than emitted out
+        of order. Only `on_stream_clear` resets the cursor (it pairs the reset
+        with a `stream/clear` so the client discards the ahead binaries).
         """
         self._cancel_release_timer()
         self._pending_frames.clear()
-        self._last_wire_emit_ts_us = None
         self._holdback_active = self._holdback_should_be_active()
 
     def _warmup_cutoff_us(self) -> int:
@@ -598,9 +602,11 @@ class VisualizerV1Role(Role):
         had_beats = self._has_beats_landed
         self._has_beats_landed = False
         # Seek re-pushes the schedule, so beats arrive again shortly: re-arm
-        # warmup and drop the wire-ts guard so post-seek frames with earlier
-        # timestamps are not silently blocked.
+        # warmup. The accompanying `stream/clear` makes the client discard
+        # ahead binaries, so the wire-ts guard can be dropped too — post-seek
+        # frames with earlier timestamps are then not silently blocked.
         self._rearm_warmup_holdback()
+        self._last_wire_emit_ts_us = None
         self.send_message(StreamClearMessage(payload=StreamClearPayload(roles=["visualizer"])))
         self.reset_binary_timing()
         if self._buffer_tracker is not None:

--- a/aiosendspin/server/roles/visualizer/v1.py
+++ b/aiosendspin/server/roles/visualizer/v1.py
@@ -207,6 +207,11 @@ class VisualizerV1Role(Role):
             self._has_beats_landed = False
             # No beats will arrive — lift the cap and release held frames.
             self._end_holdback()
+        elif self._holdback_should_be_active() and not self._holdback_active:
+            # Beats are wanted again (e.g. UNAVAILABLE → PENDING on a new track)
+            # but the cap was lifted earlier. Re-arm it so a schedule landing
+            # after a few seconds of audio is not dropped behind the cursor.
+            self._rearm_warmup_holdback()
         if (
             self._support is None
             or "beat" not in self._support.types
@@ -429,6 +434,19 @@ class VisualizerV1Role(Role):
         """Whether the warmup cap applies: client wants beats, none landed yet."""
         return self.wants_beats and not self._has_beats_landed
 
+    def _rearm_warmup_holdback(self) -> None:
+        """Re-arm the warmup cap and drop the wire-ts cursor for a fresh schedule.
+
+        Used whenever a schedule is dropped (seek, beat-schedule clear) or beats
+        become wanted again (availability back to PENDING): the next schedule
+        arrives shortly, so hold periodic frames near the playhead and clear the
+        cursor so a landing beat is not dropped behind a far-ahead frontier.
+        """
+        self._cancel_release_timer()
+        self._pending_frames.clear()
+        self._last_wire_emit_ts_us = None
+        self._holdback_active = self._holdback_should_be_active()
+
     def _warmup_cutoff_us(self) -> int:
         """Wire ts above which periodic frames are held during warmup."""
         return self._client._server.clock.now_us() + _WARMUP_LEAD_US  # noqa: SLF001
@@ -524,6 +542,10 @@ class VisualizerV1Role(Role):
         self._pending_beats.clear()
         if self._has_beats_landed:
             self._has_beats_landed = False
+            # A landed schedule was dropped while the stream continues (track
+            # change, analysis re-clear). Re-arm warmup so the next schedule is
+            # not lost behind a wire cursor already pushed far ahead.
+            self._rearm_warmup_holdback()
             if self._stream_started and self._stream_config is not None:
                 self._reissue_stream_start()
 
@@ -573,18 +595,12 @@ class VisualizerV1Role(Role):
         if self._extractor is not None:
             self._extractor.reset()
         self._pending_beats.clear()
-        # Seek re-pushes the schedule, so beats arrive again shortly.
-        # Drop the wire-ts guard so post-seek frames with earlier
-        # timestamps are not silently blocked.
-        self._last_wire_emit_ts_us = None
         had_beats = self._has_beats_landed
         self._has_beats_landed = False
-        # Re-arm warmup: a seek re-pushes the (already-computed) schedule, so
-        # beats arrive again shortly; hold periodic frames near the playhead
-        # until they do.
-        self._cancel_release_timer()
-        self._pending_frames.clear()
-        self._holdback_active = self._holdback_should_be_active()
+        # Seek re-pushes the schedule, so beats arrive again shortly: re-arm
+        # warmup and drop the wire-ts guard so post-seek frames with earlier
+        # timestamps are not silently blocked.
+        self._rearm_warmup_holdback()
         self.send_message(StreamClearMessage(payload=StreamClearPayload(roles=["visualizer"])))
         self.reset_binary_timing()
         if self._buffer_tracker is not None:

--- a/aiosendspin/server/roles/visualizer_draft_r1/__init__.py
+++ b/aiosendspin/server/roles/visualizer_draft_r1/__init__.py
@@ -1,0 +1,14 @@
+"""Visualizer draft_r1 role.
+
+Backwards-compat with clients on the `visualizer@_draft_r1` wire. The
+shared `VisualizerGroupRole` (registered by the `visualizer@v1` package)
+handles both wire versions across one role family. This package only
+registers the role implementation.
+"""
+
+from aiosendspin.server.roles.registry import register_role
+from aiosendspin.server.roles.visualizer_draft_r1.role import VisualizerDraftR1Role
+
+register_role("visualizer@_draft_r1", lambda client: VisualizerDraftR1Role(client=client))
+
+__all__ = ["VisualizerDraftR1Role"]

--- a/aiosendspin/server/roles/visualizer_draft_r1/features.py
+++ b/aiosendspin/server/roles/visualizer_draft_r1/features.py
@@ -1,0 +1,242 @@
+"""Feature extraction for draft visualizer role."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+from aiosendspin.models.visualizer_draft_r1 import StreamStartVisualizer
+
+
+@dataclass(frozen=True)
+class ExtractedFrame:
+    """Computed visualizer features for one audio chunk."""
+
+    timestamp_us: int
+    loudness: int | None = None
+    f_peak: int | None = None
+    spectrum: np.ndarray | None = None
+
+
+def _hz_to_mel(hz: np.ndarray) -> np.ndarray:
+    return 2595.0 * np.log10(1.0 + hz / 700.0)
+
+
+def _mel_to_hz(mel: np.ndarray) -> np.ndarray:
+    return 700.0 * (10.0 ** (mel / 2595.0) - 1.0)
+
+
+class VisualizerFeatureExtractor:
+    """Compute visualizer features from PCM chunks."""
+
+    def __init__(
+        self,
+        *,
+        sample_rate: int,
+        channels: int,
+        config: StreamStartVisualizer,
+    ) -> None:
+        """Create a feature extractor for negotiated stream config."""
+        self._sample_rate = sample_rate
+        self._channels = channels
+        self._config = config
+        self._last_spectrum_ts_us: int | None = None
+        self._last_spectrum: np.ndarray | None = None
+        self._a_weight_cache: np.ndarray | None = None
+
+    def reset(self) -> None:
+        """Reset extractor state at stream boundaries."""
+        self._last_spectrum_ts_us = None
+        self._last_spectrum = None
+
+    def process_chunk(self, pcm: bytes, timestamp_us: int) -> ExtractedFrame:
+        """Compute a single frame from a PCM chunk."""
+        mono = self._decode_pcm_to_mono_float32(pcm)
+
+        needs_fft = any(t in self._config.types for t in ("loudness", "f_peak", "spectrum"))
+
+        loudness: int | None = None
+        f_peak: int | None = None
+        spectrum: np.ndarray | None = None
+
+        if needs_fft:
+            freqs, magnitude = self._fft_magnitude(mono)
+            compensated = self._apply_psychoacoustic_compensation(freqs, magnitude)
+
+            if "loudness" in self._config.types:
+                # A-weighted RMS via Parseval's theorem for one-sided rfft:
+                # RMS ≈ sqrt(2 * sum(|X|^2)) / N
+                if compensated.size == 0:
+                    loudness = 0
+                else:
+                    n = mono.size
+                    weighted_power = float(np.sum(np.square(compensated, dtype=np.float64)))
+                    rms = np.sqrt(2.0 * weighted_power) / max(n, 1)
+                    # A full-scale sine through Hanning has RMS ≈ sqrt(3/16) ≈ 0.43
+                    # (amplitude 1.0, mean(sin^2)=0.5, mean(hann^2)=3/8).
+                    # A-weight gain ~1.0 at 1-4 kHz.
+                    ref = np.sqrt(3.0 / 16.0)
+                    normalized = float(np.clip(rms / ref, 0.0, 1.0))
+                    loudness = int(normalized * 65535.0)
+
+            if "f_peak" in self._config.types:
+                if compensated.size == 0:
+                    f_peak = 0
+                else:
+                    idx = int(np.argmax(compensated))
+                    peak_hz = int(freqs[idx]) if idx < freqs.size else 0
+                    f_peak = int(np.clip(peak_hz, 0, 65535))
+
+            if "spectrum" in self._config.types:
+                spectrum = self._maybe_compute_spectrum(freqs, compensated, timestamp_us)
+
+        return ExtractedFrame(
+            timestamp_us=timestamp_us,
+            loudness=loudness,
+            f_peak=f_peak,
+            spectrum=spectrum,
+        )
+
+    def _decode_pcm_to_mono_float32(self, pcm: bytes) -> np.ndarray:
+        """Decode little-endian signed PCM16 to mono float32 in [-1, 1]."""
+        raw = np.frombuffer(pcm, dtype="<i2")
+        if raw.size == 0:
+            return np.zeros(1, dtype=np.float32)
+
+        if self._channels > 1:
+            frame_count = raw.size // self._channels
+            if frame_count <= 0:
+                return np.zeros(1, dtype=np.float32)
+            reshaped = raw[: frame_count * self._channels].reshape(frame_count, self._channels)
+            mono = np.mean(reshaped.astype(np.float32), axis=1, dtype=np.float32)
+        else:
+            mono = raw.astype(np.float32)
+
+        return np.asarray(np.clip(mono / 32768.0, -1.0, 1.0))
+
+    def _fft_magnitude(self, mono: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Return FFT frequency bins and normalized magnitudes."""
+        if mono.size <= 1:
+            return np.zeros(0, dtype=np.float32), np.zeros(0, dtype=np.float32)
+
+        windowed = mono * np.hanning(mono.size).astype(np.float32)
+        spectrum = np.fft.rfft(windowed)
+        magnitude = np.abs(spectrum).astype(np.float32)
+        freqs = np.fft.rfftfreq(mono.size, d=1.0 / float(self._sample_rate)).astype(np.float32)
+
+        # Drop DC for peak/spectrum display.
+        if magnitude.size > 0:
+            magnitude[0] = 0.0
+        return freqs, magnitude
+
+    def _apply_psychoacoustic_compensation(
+        self, freqs: np.ndarray, magnitude: np.ndarray
+    ) -> np.ndarray:
+        """Apply A-weighting gain so display tracks perceived loudness better."""
+        if freqs.size == 0 or magnitude.size == 0:
+            return magnitude
+
+        # Cache A-weight gains for the current FFT size.
+        if self._a_weight_cache is None or self._a_weight_cache.size != freqs.size:
+            f = np.maximum(freqs.astype(np.float64), 1.0)
+            f2 = f * f
+            ra_num = (12194.0**2) * (f2**2)
+            ra_den = (f2 + 20.6**2) * np.sqrt((f2 + 107.7**2) * (f2 + 737.9**2)) * (f2 + 12194.0**2)
+            ra = np.clip(ra_num / np.maximum(ra_den, 1e-20), 1e-12, None)
+            a_db = 2.0 + (20.0 * np.log10(ra))
+            a_db = np.clip(a_db, -50.0, 6.0)
+            self._a_weight_cache = np.power(10.0, a_db / 20.0).astype(np.float32)
+
+        result: np.ndarray = magnitude * self._a_weight_cache
+        return result
+
+    def _maybe_compute_spectrum(
+        self, freqs: np.ndarray, magnitude: np.ndarray, timestamp_us: int
+    ) -> np.ndarray:
+        spectrum_cfg = self._config.spectrum
+        if spectrum_cfg is None:
+            raise ValueError("spectrum in config.types but config.spectrum is None")
+
+        if self._last_spectrum_ts_us is not None:
+            min_delta_us = int(1_000_000 / spectrum_cfg.rate_max)
+            if (
+                timestamp_us - self._last_spectrum_ts_us < min_delta_us
+                and self._last_spectrum is not None
+            ):
+                return self._last_spectrum
+
+        computed = self._compute_binned_spectrum(
+            freqs=freqs,
+            magnitude=magnitude,
+            n_bins=spectrum_cfg.n_disp_bins,
+            f_min=spectrum_cfg.f_min,
+            f_max=spectrum_cfg.f_max,
+            scale=spectrum_cfg.scale,
+        )
+        self._last_spectrum_ts_us = timestamp_us
+        self._last_spectrum = computed
+        return computed
+
+    def _compute_binned_spectrum(
+        self,
+        *,
+        freqs: np.ndarray,
+        magnitude: np.ndarray,
+        n_bins: int,
+        f_min: int,
+        f_max: int,
+        scale: Literal["lin", "log", "mel"],
+    ) -> np.ndarray:
+        if freqs.size == 0 or magnitude.size == 0:
+            return np.zeros(n_bins, dtype=np.uint16)
+
+        lo = max(0, f_min)
+        hi = min(int(self._sample_rate / 2), f_max)
+        if hi <= lo:
+            return np.zeros(n_bins, dtype=np.uint16)
+
+        edges = self._frequency_bin_edges(n_bins=n_bins, f_min=lo, f_max=hi, scale=scale)
+
+        # Vectorized binning via np.digitize.
+        bin_indices = np.digitize(freqs, edges) - 1
+        valid = (bin_indices >= 0) & (bin_indices < n_bins)
+        idx = bin_indices[valid]
+        mag = magnitude[valid]
+
+        sq = mag.astype(np.float64) ** 2
+        sums = np.bincount(idx, weights=sq, minlength=n_bins).astype(np.float32)
+        binned = np.sqrt(sums)
+
+        # dB scale: map [-60 dB, 0 dB] relative to full-scale sine → [0, 65535].
+        # Full-scale sine has rfft peak N/2, reduced to N/4 by Hanning window.
+        n = freqs.size * 2 - 1  # original time-domain sample count
+        ref = max(float(n) / 4.0, 1.0)
+        ratio = np.maximum(binned / ref, 1e-10)
+        db = 20.0 * np.log10(ratio)
+        db_floor = -60.0
+        normalized = np.clip((db - db_floor) / -db_floor, 0.0, 1.0)
+        return (normalized * 65535.0).astype(np.uint16)
+
+    def _frequency_bin_edges(
+        self, *, n_bins: int, f_min: int, f_max: int, scale: Literal["lin", "log", "mel"]
+    ) -> np.ndarray:
+        if scale == "lin":
+            return np.linspace(float(f_min), float(f_max), n_bins + 1, dtype=np.float32)
+        if scale == "log":
+            safe_min = max(f_min, 1)
+            return np.logspace(
+                np.log10(float(safe_min)),
+                np.log10(float(f_max)),
+                n_bins + 1,
+                dtype=np.float32,
+            )
+
+        mel_edges = np.linspace(
+            _hz_to_mel(np.array([float(f_min)], dtype=np.float32))[0],
+            _hz_to_mel(np.array([float(f_max)], dtype=np.float32))[0],
+            n_bins + 1,
+            dtype=np.float32,
+        )
+        return _mel_to_hz(mel_edges).astype(np.float32)

--- a/aiosendspin/server/roles/visualizer_draft_r1/packing.py
+++ b/aiosendspin/server/roles/visualizer_draft_r1/packing.py
@@ -1,0 +1,53 @@
+"""Binary packing helpers for draft visualizer role."""
+
+from __future__ import annotations
+
+import struct
+
+import numpy as np
+
+from aiosendspin.models.types import BinaryMessageType
+from aiosendspin.models.visualizer_draft_r1 import StreamStartVisualizer
+from aiosendspin.server.roles.visualizer_draft_r1.features import ExtractedFrame
+
+
+def pack_visualization_message(
+    *,
+    frames: list[ExtractedFrame],
+    config: StreamStartVisualizer,
+) -> bytes:
+    """Pack a complete visualization data binary message (type 16).
+
+    Wire format per spec:
+        Byte 0: message type 16 (uint8)
+        Byte 1: frame count (uint8)
+        Remaining: frames [...] each: [timestamp:8][data per types]
+    """
+    if not frames:
+        raise ValueError("cannot pack empty visualizer frame list")
+    if len(frames) > 255:
+        raise ValueError(f"max 255 frames per message, got {len(frames)}")
+
+    output = bytearray()
+    output.append(BinaryMessageType.VISUALIZATION_DATA.value)
+    output.append(len(frames))
+
+    for frame in frames:
+        output.extend(struct.pack(">q", frame.timestamp_us))
+        for typed in config.types:
+            if typed == "loudness":
+                value = 0 if frame.loudness is None else frame.loudness
+                output.extend(struct.pack(">H", int(np.clip(value, 0, 65535))))
+            elif typed == "f_peak":
+                value = 0 if frame.f_peak is None else frame.f_peak
+                output.extend(struct.pack(">H", int(np.clip(value, 0, 65535))))
+            elif typed == "spectrum":
+                if frame.spectrum is None:
+                    if config.spectrum is None:
+                        raise ValueError("spectrum in config.types but config.spectrum is None")
+                    zeros = np.zeros(config.spectrum.n_disp_bins, dtype=np.uint16)
+                    output.extend(zeros.astype(">u2").tobytes())
+                else:
+                    output.extend(frame.spectrum.astype(">u2", copy=False).tobytes())
+
+    return bytes(output)

--- a/aiosendspin/server/roles/visualizer_draft_r1/role.py
+++ b/aiosendspin/server/roles/visualizer_draft_r1/role.py
@@ -1,0 +1,219 @@
+"""Visualizer role implementation for draft visualizer streaming."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from aiosendspin.models.core import (
+    StreamClearMessage,
+    StreamClearPayload,
+    StreamEndMessage,
+    StreamEndPayload,
+    StreamRequestFormatPayload,
+    StreamStartMessage,
+    StreamStartPayload,
+)
+from aiosendspin.models.types import BinaryMessageType
+from aiosendspin.models.visualizer_draft_r1 import (
+    ClientHelloVisualizerSupport,
+    StreamStartVisualizer,
+)
+from aiosendspin.server.audio import BufferTracker
+from aiosendspin.server.roles.base import (
+    AudioChunk,
+    AudioRequirements,
+    BinaryHandling,
+    Role,
+    StreamRequirements,
+)
+from aiosendspin.server.roles.visualizer_draft_r1.features import VisualizerFeatureExtractor
+from aiosendspin.server.roles.visualizer_draft_r1.packing import pack_visualization_message
+
+if TYPE_CHECKING:
+    from aiosendspin.server.client import SendspinClient
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class VisualizerDraftR1Role(Role):
+    """Role implementation for draft visualizer streaming."""
+
+    def __init__(self, client: SendspinClient | None = None) -> None:
+        """Initialize VisualizerDraftR1Role."""
+        if client is None:
+            msg = "VisualizerDraftR1Role requires a client"
+            raise ValueError(msg)
+        self._client = client
+        self._stream_started = False
+        self._buffer_tracker = None
+        self._group_role = None
+        self._support: ClientHelloVisualizerSupport | None = None
+        self._stream_config: StreamStartVisualizer | None = None
+        self._extractor: VisualizerFeatureExtractor | None = None
+
+    @property
+    def role_id(self) -> str:
+        """Versioned role identifier."""
+        return "visualizer@_draft_r1"
+
+    @property
+    def role_family(self) -> str:
+        """Role family name for protocol messages."""
+        return "visualizer"
+
+    def get_stream_requirements(self) -> StreamRequirements:
+        """Visualizer role sends binary streams."""
+        return StreamRequirements()
+
+    def get_audio_requirements(self) -> AudioRequirements:
+        """Return audio requirements for visualizer analysis."""
+        return AudioRequirements(
+            sample_rate=48_000,
+            bit_depth=16,
+            channels=2,
+            frame_duration_us=25_000,
+        )
+
+    def get_binary_handling(self, message_type: int) -> BinaryHandling | None:
+        """Return handling policy for visualizer binary frames."""
+        if message_type == BinaryMessageType.VISUALIZATION_DATA.value:
+            return BinaryHandling(drop_late=True, grace_period_us=2_000_000, buffer_track=True)
+        return None
+
+    def get_buffer_tracker(self) -> BufferTracker | None:
+        """Return the visualizer buffer tracker."""
+        return self._buffer_tracker
+
+    def _ensure_buffer_tracker(self) -> None:
+        """Create or update buffer tracker from negotiated config."""
+        if self._support is None:
+            self._buffer_tracker = None
+            return
+        capacity = max(1, self._support.buffer_capacity)
+        if self._buffer_tracker is None:
+            self._buffer_tracker = BufferTracker(
+                clock=self._client._server.clock,  # noqa: SLF001
+                client_id=self._client.client_id,
+                capacity_bytes=capacity,
+            )
+        else:
+            self._buffer_tracker.capacity_bytes = capacity
+            self._buffer_tracker.reset()
+
+    def on_connect(self) -> None:
+        """Initialize stream config and subscribe to group role."""
+        self._init_stream_config()
+        self._subscribe_to_group_role()
+
+    def on_disconnect(self) -> None:
+        """Unsubscribe from VisualizerGroupRole."""
+        self._unsubscribe_from_group_role()
+        self._stream_started = False
+        self._extractor = None
+        self.reset_binary_timing()
+
+    def on_stream_start(self) -> None:
+        """Start extractor state for a new audio stream."""
+        if self._stream_config is None:
+            return
+        self.reset_binary_timing()
+        # stream/end clears client-side visualizer config, so resend stream/start
+        # at each new stream boundary.
+        if not self._stream_started:
+            self._send_stream_start()
+        req = self.get_audio_requirements()
+        self._extractor = VisualizerFeatureExtractor(
+            sample_rate=req.sample_rate,
+            channels=req.channels,
+            config=self._stream_config,
+        )
+        self._stream_started = True
+        self._ensure_buffer_tracker()
+
+    def on_audio_chunk(self, chunk: AudioChunk) -> None:
+        """Process audio chunk and emit visualizer binary frame."""
+        if not self.has_connection() or self._stream_config is None or self._extractor is None:
+            return
+
+        frame = self._extractor.process_chunk(chunk.data, chunk.timestamp_us)
+        message = pack_visualization_message(frames=[frame], config=self._stream_config)
+        self._client.send_binary(
+            message,
+            role_family=self.role_family,
+            timestamp_us=frame.timestamp_us,
+            message_type=BinaryMessageType.VISUALIZATION_DATA.value,
+            buffer_end_time_us=chunk.timestamp_us + chunk.duration_us,
+            buffer_byte_count=len(message),
+            duration_us=chunk.duration_us,
+        )
+
+    def on_stream_clear(self) -> None:
+        """Reset visualizer state and notify client to clear buffered data."""
+        if self._extractor is not None:
+            self._extractor.reset()
+        self.send_message(StreamClearMessage(payload=StreamClearPayload(roles=["visualizer"])))
+        self.reset_binary_timing()
+        if self._buffer_tracker is not None:
+            self._buffer_tracker.reset()
+
+    def on_stream_end(self) -> None:
+        """Reset visualizer state and notify client that stream has ended."""
+        self._extractor = None
+        self._stream_started = False
+        self.send_message(StreamEndMessage(payload=StreamEndPayload(roles=["visualizer"])))
+        self.reset_binary_timing()
+        if self._buffer_tracker is not None:
+            self._buffer_tracker.reset()
+
+    def on_stream_request_format(self, payload: StreamRequestFormatPayload) -> None:  # noqa: ARG002
+        """Ignore runtime visualizer renegotiation for now."""
+        _LOGGER.debug(
+            "Ignoring visualizer stream/request-format from client %s",
+            self._client.client_id,
+        )
+
+    def _init_stream_config(self) -> None:
+        """Parse visualizer support config from client/hello."""
+        support_raw = self._client.info.visualizer_draft_r1_support
+        if support_raw is None:
+            raise ValueError("visualizer support object missing for draft visualizer role")
+        self._support = ClientHelloVisualizerSupport.from_dict(
+            self._normalize_support_payload(support_raw)
+        )
+        self._stream_config = StreamStartVisualizer.from_support(self._support)
+
+    def _normalize_support_payload(self, support_raw: object) -> dict[str, object]:
+        """Normalize legacy/minimal support payloads to draft visualizer schema."""
+        if isinstance(support_raw, dict):
+            payload: dict[str, object] = dict(support_raw)
+        elif isinstance(support_raw, ClientHelloVisualizerSupport):
+            # Legacy and draft payloads represented by model object.
+            payload = support_raw.to_dict()
+        else:
+            raise TypeError("visualizer support object must be a JSON object")
+
+        # Backward-compatible defaults when client sends only buffer capacity.
+        if "types" not in payload:
+            payload["types"] = ["loudness", "f_peak"]
+        if "batch_max" not in payload:
+            payload["batch_max"] = 8
+
+        raw_types = payload.get("types")
+        if isinstance(raw_types, list):
+            normalized_types = [v for v in raw_types if isinstance(v, str)]
+            if "spectrum" in normalized_types and payload.get("spectrum") is None:
+                normalized_types = [v for v in normalized_types if v != "spectrum"]
+            if not normalized_types:
+                normalized_types = ["loudness", "f_peak"]
+            payload["types"] = normalized_types
+
+        return payload
+
+    def _send_stream_start(self) -> None:
+        """Send stream/start with negotiated visualizer configuration."""
+        if self._stream_config is None:
+            return
+        message = StreamStartMessage(payload=StreamStartPayload(visualizer=self._stream_config))
+        self.send_message(message)
+        self._stream_started = True

--- a/aiosendspin/server/roles/visualizer_draft_r1/role.py
+++ b/aiosendspin/server/roles/visualizer_draft_r1/role.py
@@ -75,6 +75,10 @@ class VisualizerDraftR1Role(Role):
             frame_duration_us=25_000,
         )
 
+    def replay_from_pcm_cache(self) -> bool:
+        """Replay buffered PCM on late join (visualizer is analysis-only)."""
+        return True
+
     def get_binary_handling(self, message_type: int) -> BinaryHandling | None:
         """Return handling policy for visualizer binary frames."""
         if message_type == BinaryMessageType.VISUALIZATION_DATA.value:

--- a/aiosendspin/server/server.py
+++ b/aiosendspin/server/server.py
@@ -128,6 +128,11 @@ class SendspinServer:
 
         self._clients: dict[str, SendspinClient] = {}
         self._event_cbs: list[Callable[[SendspinServer, SendspinEvent], None]] = []
+        # Server-wide toggle for the visualizer `pitch` feature. Pitch (YINFFT)
+        # is the heaviest per-frame visualizer computation; disable it to shed
+        # load on constrained hardware. Read by VisualizerV1Role when building
+        # its stream config.
+        self._visualizer_pitch_enabled: bool = True
 
         if client_session is None:
             self._client_session = ClientSession(loop=self._loop, timeout=ClientTimeout(total=30))
@@ -196,6 +201,28 @@ class SendspinServer:
     def get_client(self, client_id: str) -> SendspinClient | None:
         """Get a persistent client device by id, if known."""
         return self._clients.get(client_id)
+
+    @property
+    def visualizer_pitch_enabled(self) -> bool:
+        """Whether visualizer roles compute the `pitch` feature (default True)."""
+        return self._visualizer_pitch_enabled
+
+    def set_visualizer_pitch_enabled(self, *, enabled: bool) -> None:
+        """Enable or disable the visualizer `pitch` feature server-wide.
+
+        Pitch (YINFFT) is the heaviest per-frame visualizer computation.
+        Disabling sheds that cost on constrained hardware: live visualizer
+        roles drop `pitch` from their negotiated types and re-emit
+        `stream/start`; new roles pick the setting up when they connect.
+        """
+        if enabled == self._visualizer_pitch_enabled:
+            return
+        self._visualizer_pitch_enabled = enabled
+        for client in self._clients.values():
+            for role in client.active_roles:
+                refresh = getattr(role, "refresh_pitch_setting", None)
+                if callable(refresh):
+                    refresh()
 
     def get_or_create_client(self, client_id: str) -> SendspinClient:
         """Get or create a persistent client device by id."""

--- a/tests/models/test_stream_start_visualizer_union.py
+++ b/tests/models/test_stream_start_visualizer_union.py
@@ -1,0 +1,69 @@
+"""Round-trip tests for the StreamStartPayload.visualizer union.
+
+`StreamStartPayload.visualizer` is `StreamStartVisualizer (v1) |
+StreamStartVisualizerDraftR1 | None`. The two schemas overlap on `types` /
+`spectrum` and differ only by the required `rate_max` (v1) vs `batch_max`
+(draft). These guard that mashumaro resolves each payload to the correct
+branch so the v1 client SDK's `isinstance` check does not silently treat a
+message as "no visualizer config".
+"""
+
+from __future__ import annotations
+
+from aiosendspin.models.core import StreamStartPayload
+from aiosendspin.models.visualizer import (
+    ClientHelloVisualizerSpectrum,
+    StreamStartVisualizer,
+)
+from aiosendspin.models.visualizer_draft_r1 import (
+    ClientHelloVisualizerSpectrum as ClientHelloVisualizerSpectrumDraftR1,
+)
+from aiosendspin.models.visualizer_draft_r1 import (
+    StreamStartVisualizer as StreamStartVisualizerDraftR1,
+)
+
+
+def _spectrum() -> ClientHelloVisualizerSpectrum:
+    return ClientHelloVisualizerSpectrum(n_disp_bins=8, scale="lin", f_min=20, f_max=16_000)
+
+
+def _draft_spectrum() -> ClientHelloVisualizerSpectrumDraftR1:
+    # The draft spectrum schema still carries `rate_max`, dropped in v1.
+    return ClientHelloVisualizerSpectrumDraftR1(
+        n_disp_bins=8, scale="lin", f_min=20, f_max=16_000, rate_max=30
+    )
+
+
+def test_v1_stream_start_round_trips_to_v1_branch() -> None:
+    """A v1 visualizer payload deserializes back to the v1 schema."""
+    payload = StreamStartPayload(
+        visualizer=StreamStartVisualizer(
+            types=("loudness", "spectrum"),
+            rate_max=30,
+            spectrum=_spectrum(),
+        )
+    )
+    restored = StreamStartPayload.from_json(payload.to_json())
+    assert isinstance(restored.visualizer, StreamStartVisualizer)
+    assert restored.visualizer.rate_max == 30
+
+
+def test_draft_stream_start_round_trips_to_draft_branch() -> None:
+    """A draft visualizer payload deserializes back to the draft schema, not None."""
+    payload = StreamStartPayload(
+        visualizer=StreamStartVisualizerDraftR1(
+            types=("loudness", "spectrum"),
+            batch_max=8,
+            spectrum=_draft_spectrum(),
+        )
+    )
+    restored = StreamStartPayload.from_json(payload.to_json())
+    assert isinstance(restored.visualizer, StreamStartVisualizerDraftR1)
+    assert restored.visualizer.batch_max == 8
+
+
+def test_v1_branch_preferred_when_rate_max_present() -> None:
+    """A payload carrying rate_max resolves to v1 even with overlapping fields."""
+    restored = StreamStartPayload.from_dict({"visualizer": {"types": ["loudness"], "rate_max": 45}})
+    assert isinstance(restored.visualizer, StreamStartVisualizer)
+    assert restored.visualizer.rate_max == 45

--- a/tests/server/roles/visualizer/test_features.py
+++ b/tests/server/roles/visualizer/test_features.py
@@ -395,3 +395,26 @@ def test_window_samples_scales_with_sample_rate() -> None:
     )
     assert extractor_48k._window_samples == 2048  # noqa: SLF001
     assert extractor_96k._window_samples == 4096  # noqa: SLF001
+
+
+def test_fft_size_caches_reused_across_frames() -> None:
+    """Per-window-size caches (hann, rfftfreq, bin assignment) are reused, not rebuilt."""
+    config = _spectrum_config(rate_max=60)
+    extractor = VisualizerFeatureExtractor(sample_rate=48_000, channels=2, config=config)
+    # 100ms chunk fills the rolling buffer so the window settles to its full
+    # size (2048) on the very first frame.
+    pcm = sine_pcm_16bit(sample_rate=48_000, channels=2, hz=1000.0, duration_s=0.1)
+
+    assert extractor.process_chunk(pcm, 1_000_000)
+    hann = extractor._hann_window  # noqa: SLF001
+    freqs = extractor._rfftfreq  # noqa: SLF001
+    bin_cache = extractor._spectrum_bin_cache  # noqa: SLF001
+    assert hann is not None
+    assert freqs is not None
+    assert bin_cache is not None
+
+    # Contiguous second chunk → same window size → cached arrays reused verbatim.
+    assert extractor.process_chunk(pcm, 1_100_000)
+    assert extractor._hann_window is hann  # noqa: SLF001
+    assert extractor._rfftfreq is freqs  # noqa: SLF001
+    assert extractor._spectrum_bin_cache is bin_cache  # noqa: SLF001

--- a/tests/server/roles/visualizer/test_features.py
+++ b/tests/server/roles/visualizer/test_features.py
@@ -7,12 +7,13 @@ import struct
 
 import numpy as np
 
+from aiosendspin.models.types import BinaryMessageType
 from aiosendspin.models.visualizer import (
     ClientHelloVisualizerSpectrum,
     StreamStartVisualizer,
 )
 from aiosendspin.server.roles.visualizer.features import VisualizerFeatureExtractor
-from aiosendspin.server.roles.visualizer.packing import pack_visualization_message
+from aiosendspin.server.roles.visualizer.packing import pack_visualizer_frame
 from tests.server.roles.visualizer.conftest import sine_pcm_16bit
 
 
@@ -36,59 +37,67 @@ def _dual_sine_pcm_16bit(
     return bytes(frame_bytes)
 
 
-def test_extractor_produces_loudness_peak_and_spectrum() -> None:
-    """Extractor returns non-empty features for a sine wave."""
-    config = StreamStartVisualizer(
+def _spectrum_config(rate_max: int = 60, n_bins: int = 12) -> StreamStartVisualizer:
+    return StreamStartVisualizer(
         types=("loudness", "f_peak", "spectrum"),
-        batch_max=4,
+        rate_max=rate_max,
         spectrum=ClientHelloVisualizerSpectrum(
-            n_disp_bins=12,
+            n_disp_bins=n_bins,
             scale="lin",
             f_min=20,
             f_max=16_000,
-            rate_max=60,
         ),
     )
+
+
+def test_extractor_produces_loudness_peak_and_spectrum() -> None:
+    """Extractor returns non-empty features for a sine wave."""
+    config = _spectrum_config()
     extractor = VisualizerFeatureExtractor(sample_rate=48_000, channels=2, config=config)
     pcm = sine_pcm_16bit(sample_rate=48_000, channels=2, hz=1000.0, duration_s=0.025)
 
-    frame = extractor.process_chunk(pcm, 1_000_000)
+    frames = extractor.process_chunk(pcm, 1_000_000)
 
+    assert frames, "first chunk should produce at least one frame"
+    frame = frames[0]
+    # Trailing window: first chunk's frame is anchored at chunk end.
+    assert frame.timestamp_us == 1_025_000
     assert frame.loudness is not None
     assert frame.loudness > 0
-    assert frame.f_peak is not None
-    assert abs(frame.f_peak - 1000) < 300
+    assert frame.f_peak_freq is not None
+    assert abs(frame.f_peak_freq - 1000) < 300
+    assert frame.f_peak_amp is not None
+    assert frame.f_peak_amp > 0
     assert frame.spectrum is not None
-    assert isinstance(frame.spectrum, np.ndarray)
     assert frame.spectrum.shape == (12,)
     assert frame.spectrum.dtype == np.uint16
 
 
-def test_pack_visualization_message_binary_layout() -> None:
-    """Packed message starts with type byte, frame count, and then frame data."""
-    config = StreamStartVisualizer(
-        types=("loudness", "f_peak"),
-        batch_max=4,
-        spectrum=None,
-    )
-    extractor = VisualizerFeatureExtractor(sample_rate=48_000, channels=2, config=config)
-    pcm = sine_pcm_16bit(sample_rate=48_000, channels=2, hz=500.0, duration_s=0.025)
-    frame = extractor.process_chunk(pcm, 1_234_000)
+def test_pack_visualizer_frame_layout_loudness() -> None:
+    """[16][ts:8][uint16] = 11 bytes."""
+    payload = struct.pack(">H", 0x7FFF)
+    packed = pack_visualizer_frame(BinaryMessageType.VISUALIZATION_LOUDNESS, 1_234_000, payload)
+    assert packed[0] == 16
+    assert struct.unpack(">q", packed[1:9])[0] == 1_234_000
+    assert struct.unpack(">H", packed[9:11])[0] == 0x7FFF
+    assert len(packed) == 11
 
-    packed = pack_visualization_message(frames=[frame], config=config)
 
-    assert packed[0] == 16  # message type
-    assert packed[1] == 1  # frame count
-    assert struct.unpack(">q", packed[2:10])[0] == 1_234_000
-    # type(1) + count(1) + timestamp(8) + loudness(2) + f_peak(2) = 14
-    assert len(packed) == 1 + 1 + 8 + 2 + 2
+def test_pack_visualizer_frame_layout_spectrum() -> None:
+    """[19][ts:8][uint16 * n_bins]."""
+    bins = np.arange(8, dtype=np.uint16) * 100
+    payload = bins.astype(">u2", copy=False).tobytes()
+    packed = pack_visualizer_frame(BinaryMessageType.VISUALIZATION_SPECTRUM, 42, payload)
+    assert packed[0] == 19
+    assert struct.unpack(">q", packed[1:9])[0] == 42
+    assert len(packed) == 1 + 8 + 16
 
 
 def test_peak_frequency_uses_compensated_magnitude() -> None:
     """A-weighting should prefer perceptually louder mids over deep bass."""
     config = StreamStartVisualizer(
         types=("f_peak",),
-        batch_max=4,
+        rate_max=30,
         spectrum=None,
     )
     extractor = VisualizerFeatureExtractor(sample_rate=48_000, channels=2, config=config)
@@ -100,7 +109,289 @@ def test_peak_frequency_uses_compensated_magnitude() -> None:
         duration_s=0.05,
     )
 
-    frame = extractor.process_chunk(pcm, 2_000_000)
+    frames = extractor.process_chunk(pcm, 2_000_000)
 
-    assert frame.f_peak is not None
-    assert abs(frame.f_peak - 2_000) < 400
+    assert frames
+    frame = frames[0]
+    assert frame.f_peak_freq is not None
+    assert abs(frame.f_peak_freq - 2_000) < 400
+
+
+# ---------------------------------------------------------------------------
+# Hop scheduling: rate_max drives multi-frame emission
+# ---------------------------------------------------------------------------
+
+
+def _feed_steady_chunks(
+    extractor: VisualizerFeatureExtractor,
+    *,
+    sample_rate: int,
+    channels: int,
+    hz: float,
+    chunks: int,
+    chunk_duration_s: float = 0.025,
+    start_ts_us: int = 0,
+) -> list:
+    """Feed `chunks` back-to-back 25 ms chunks; return concatenated frames."""
+    frames: list = []
+    chunk_duration_us = int(chunk_duration_s * 1_000_000)
+    for i in range(chunks):
+        pcm = sine_pcm_16bit(
+            sample_rate=sample_rate, channels=channels, hz=hz, duration_s=chunk_duration_s
+        )
+        ts = start_ts_us + i * chunk_duration_us
+        frames.extend(extractor.process_chunk(pcm, ts))
+    return frames
+
+
+def test_hop_matches_rate_max_60_over_one_second() -> None:
+    """rate_max=60 should yield ~60 frames over 1 s of audio."""
+    config = _spectrum_config(rate_max=60)
+    extractor = VisualizerFeatureExtractor(sample_rate=48_000, channels=2, config=config)
+
+    frames = _feed_steady_chunks(extractor, sample_rate=48_000, channels=2, hz=1000.0, chunks=40)
+    # 40 chunks x 25 ms = 1 s. Expect 60 ± a few frames (quantization slack).
+    assert 55 <= len(frames) <= 62
+    # Steady-state timestamps spaced ~16_666 µs apart.
+    diffs = [frames[i + 1].timestamp_us - frames[i].timestamp_us for i in range(1, len(frames) - 1)]
+    assert all(15_000 <= d <= 18_000 for d in diffs), diffs
+
+
+def test_hop_matches_rate_max_30_over_one_second() -> None:
+    """rate_max=30 yields ~30 frames over 1 s."""
+    config = _spectrum_config(rate_max=30)
+    extractor = VisualizerFeatureExtractor(sample_rate=48_000, channels=2, config=config)
+
+    frames = _feed_steady_chunks(extractor, sample_rate=48_000, channels=2, hz=1000.0, chunks=40)
+    assert 28 <= len(frames) <= 32
+
+
+def test_one_frame_per_chunk_with_rate_max_equal_chunk_rate() -> None:
+    """At rate_max=40 (chunk cadence) every chunk yields exactly one frame."""
+    config = _spectrum_config(rate_max=40)
+    extractor = VisualizerFeatureExtractor(sample_rate=48_000, channels=2, config=config)
+
+    frames = _feed_steady_chunks(extractor, sample_rate=48_000, channels=2, hz=1000.0, chunks=10)
+    assert len(frames) == 10
+
+
+def test_high_rate_max_caps_at_window_resolution() -> None:
+    """rate_max much higher than chunk rate still emits each hop, bounded by buffer."""
+    config = _spectrum_config(rate_max=120)
+    extractor = VisualizerFeatureExtractor(sample_rate=48_000, channels=2, config=config)
+
+    frames = _feed_steady_chunks(extractor, sample_rate=48_000, channels=2, hz=1000.0, chunks=40)
+    # 120 fps x 1 s = 120 expected.
+    assert 110 <= len(frames) <= 125
+
+
+def test_reset_clears_emit_cursor_and_buffer() -> None:
+    """reset() returns extractor to a pristine state."""
+    config = _spectrum_config(rate_max=60)
+    extractor = VisualizerFeatureExtractor(sample_rate=48_000, channels=2, config=config)
+
+    _feed_steady_chunks(extractor, sample_rate=48_000, channels=2, hz=1000.0, chunks=5)
+    extractor.reset()
+
+    # After reset, first chunk anchors emit cursor to its chunk end again.
+    pcm = sine_pcm_16bit(sample_rate=48_000, channels=2, hz=1000.0, duration_s=0.025)
+    frames = extractor.process_chunk(pcm, 9_000_000)
+    assert frames[0].timestamp_us == 9_025_000
+
+
+# ---------------------------------------------------------------------------
+# Steady-state stability (Problem 2: spectrum flicker)
+# ---------------------------------------------------------------------------
+
+
+def test_spectrum_stable_on_constant_tone() -> None:
+    """A pure sine over 1 s should produce a low-variance spectrum bin."""
+    config = _spectrum_config(rate_max=60)
+    extractor = VisualizerFeatureExtractor(sample_rate=48_000, channels=2, config=config)
+
+    frames = _feed_steady_chunks(extractor, sample_rate=48_000, channels=2, hz=1000.0, chunks=40)
+    # Drop the warmup half: EMA + larger windows need time to stabilize.
+    steady = frames[len(frames) // 2 :]
+    assert steady
+    spectra = np.stack([f.spectrum for f in steady if f.spectrum is not None])
+    # Identify the loudest bin once stable.
+    loudest_idx = int(np.argmax(spectra.mean(axis=0)))
+    column = spectra[:, loudest_idx].astype(np.float64)
+    mean = column.mean()
+    std = column.std()
+    assert mean > 1000, f"loudest bin should be well above floor (mean={mean})"
+    # Coefficient of variation below 5% — far tighter than per-chunk FFT yields.
+    assert std / mean < 0.05, f"loudest bin too jittery: mean={mean}, std={std}"
+
+
+def test_f_peak_stable_on_constant_tone() -> None:
+    """Reported f_peak frequency stays within ±5 Hz across steady-state frames."""
+    config = StreamStartVisualizer(
+        types=("f_peak",),
+        rate_max=60,
+        spectrum=None,
+    )
+    extractor = VisualizerFeatureExtractor(sample_rate=48_000, channels=2, config=config)
+
+    frames = _feed_steady_chunks(extractor, sample_rate=48_000, channels=2, hz=1000.0, chunks=40)
+    steady = frames[len(frames) // 2 :]
+    freqs = np.array([f.f_peak_freq for f in steady if f.f_peak_freq is not None])
+    assert freqs.size > 5
+    # All frames should sit within a ±5 Hz envelope of the median peak.
+    median = float(np.median(freqs))
+    assert (np.abs(freqs - median) <= 5).all(), f"f_peak jitter: {freqs.tolist()}"
+    # And the median itself should be near the true 1 kHz tone.
+    assert abs(median - 1000.0) < 30.0
+
+
+def test_spectrum_ema_converges_after_silence_to_tone_transition() -> None:
+    """After step input, spectrum EMA reaches >=95% of steady value within a few hops."""
+    config = _spectrum_config(rate_max=60)
+    extractor = VisualizerFeatureExtractor(sample_rate=48_000, channels=2, config=config)
+
+    # First half: silence. Second half: tone. Feed via independent calls so
+    # the buffer transitions cleanly.
+    silence = sine_pcm_16bit(sample_rate=48_000, channels=2, hz=1000.0, duration_s=0.025)
+    silence = b"\x00" * len(silence)
+    for i in range(10):
+        extractor.process_chunk(silence, i * 25_000)
+    # Now feed tone chunks and collect frames.
+    tone_frames: list = []
+    for i in range(40):
+        pcm = sine_pcm_16bit(sample_rate=48_000, channels=2, hz=1000.0, duration_s=0.025)
+        tone_frames.extend(extractor.process_chunk(pcm, (10 + i) * 25_000))
+
+    assert tone_frames
+    spectra = np.stack([f.spectrum for f in tone_frames if f.spectrum is not None])
+    loudest_idx = int(np.argmax(spectra[-1]))
+    steady_value = float(spectra[-5:, loudest_idx].mean())
+    # Find when EMA crosses 95% of steady.
+    column = spectra[:, loudest_idx].astype(np.float64)
+    crossing = np.argmax(column >= 0.95 * steady_value)
+    assert crossing > 0, "EMA never reached steady"
+    # alpha=0.4 → 95% within ~6 frames; allow generous slack.
+    assert crossing < 15, f"EMA convergence too slow: {crossing} frames"
+
+
+def test_loudness_ema_smooths_step_input() -> None:
+    """Loudness on step input rises monotonically over ~3-5 frames."""
+    config = StreamStartVisualizer(
+        types=("loudness",),
+        rate_max=60,
+        spectrum=None,
+    )
+    extractor = VisualizerFeatureExtractor(sample_rate=48_000, channels=2, config=config)
+
+    silence = b"\x00" * (48_000 * 2 * 2 // 40)  # 25 ms stereo PCM16
+    for i in range(5):
+        extractor.process_chunk(silence, i * 25_000)
+    loudness_trace: list = []
+    for i in range(20):
+        pcm = sine_pcm_16bit(sample_rate=48_000, channels=2, hz=1000.0, duration_s=0.025)
+        loudness_trace.extend(
+            frame.loudness
+            for frame in extractor.process_chunk(pcm, (5 + i) * 25_000)
+            if frame.loudness is not None
+        )
+    assert len(loudness_trace) >= 5
+    # Loudness should rise (EMA-smoothed), not snap to peak instantly.
+    first = loudness_trace[0]
+    last = loudness_trace[-1]
+    assert last > first
+    # Smoothing visible: no single-frame jump from 0 to peak.
+    assert first < 0.8 * last
+
+
+# ---------------------------------------------------------------------------
+# Pitch detection
+# ---------------------------------------------------------------------------
+
+
+def _pitch_only_config(rate_max: int = 30) -> StreamStartVisualizer:
+    return StreamStartVisualizer(
+        types=("pitch",),
+        rate_max=rate_max,
+        spectrum=None,
+    )
+
+
+def _dc_pcm_16bit(*, sample_rate: int, channels: int, level: int, duration_s: float) -> bytes:
+    """Pure-DC PCM at a given level — used to verify the silence/DC gate."""
+    sample_count = int(sample_rate * duration_s)
+    packed = struct.pack("<h", level)
+    return packed * (sample_count * channels)
+
+
+def test_pitch_a4_detected_with_high_confidence() -> None:
+    """440 Hz sine resolves to MIDI 69 with confidence > 128."""
+    extractor = VisualizerFeatureExtractor(
+        sample_rate=48_000, channels=2, config=_pitch_only_config()
+    )
+    pcm = sine_pcm_16bit(sample_rate=48_000, channels=2, hz=440.0, duration_s=0.05)
+    frames = extractor.process_chunk(pcm, 1_000_000)
+    assert frames
+    frame = frames[0]
+    assert frame.pitch_midi_q88 is not None
+    assert frame.pitch_confidence is not None
+    midi = frame.pitch_midi_q88 / 256.0
+    assert abs(midi - 69.0) < 0.5
+    assert frame.pitch_confidence > 128
+
+
+def test_pitch_a3_vocal_range_not_octave_up() -> None:
+    """220 Hz sine (A3) resolves correctly — no octave-up bias from A-weighting.
+
+    Regression: A-weighting attenuates ~220 Hz by ~13 dB while boosting
+    the 2nd-3rd harmonics by 0-1.2 dB. Feeding A-weighted magnitude to
+    the ACF would shift the YIN dip to a harmonic period (MIDI ≈ 81
+    instead of 69). The extractor now uses the unweighted magnitude for
+    pitch.
+    """
+    extractor = VisualizerFeatureExtractor(
+        sample_rate=48_000, channels=2, config=_pitch_only_config()
+    )
+    pcm = sine_pcm_16bit(sample_rate=48_000, channels=2, hz=220.0, duration_s=0.05)
+    frames = extractor.process_chunk(pcm, 1_000_000)
+    assert frames
+    frame = frames[0]
+    assert frame.pitch_midi_q88 is not None
+    midi = frame.pitch_midi_q88 / 256.0
+    # A3 is MIDI 57; an octave-up bias would land us near 69.
+    assert abs(midi - 57.0) < 1.0, f"expected ~57, got {midi}"
+
+
+def test_pitch_returns_none_for_dc_input() -> None:
+    """Pure DC must not produce a confident ghost pitch."""
+    extractor = VisualizerFeatureExtractor(
+        sample_rate=48_000, channels=2, config=_pitch_only_config()
+    )
+    # 1% full-scale DC bias — well above the -45 dBFS RMS floor, so
+    # the older code path emitted a spurious confident pitch.
+    pcm = _dc_pcm_16bit(sample_rate=48_000, channels=2, level=327, duration_s=0.05)
+    frames = extractor.process_chunk(pcm, 1_000_000)
+    for frame in frames:
+        assert frame.pitch_midi_q88 is None
+        assert frame.pitch_confidence is None
+
+
+def test_pitch_returns_none_for_silence() -> None:
+    """Silence is unvoiced."""
+    extractor = VisualizerFeatureExtractor(
+        sample_rate=48_000, channels=2, config=_pitch_only_config()
+    )
+    pcm = b"\x00" * (48_000 * 2 * 2 // 20)  # 50 ms stereo silence
+    frames = extractor.process_chunk(pcm, 1_000_000)
+    for frame in frames:
+        assert frame.pitch_midi_q88 is None
+
+
+def test_window_samples_scales_with_sample_rate() -> None:
+    """At 96 kHz the FFT window doubles to keep the time span constant."""
+    extractor_48k = VisualizerFeatureExtractor(
+        sample_rate=48_000, channels=2, config=_pitch_only_config()
+    )
+    extractor_96k = VisualizerFeatureExtractor(
+        sample_rate=96_000, channels=2, config=_pitch_only_config()
+    )
+    assert extractor_48k._window_samples == 2048  # noqa: SLF001
+    assert extractor_96k._window_samples == 4096  # noqa: SLF001

--- a/tests/server/roles/visualizer/test_group.py
+++ b/tests/server/roles/visualizer/test_group.py
@@ -4,12 +4,25 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
+from aiosendspin.models.visualizer import BeatAvailability, BeatTiming
 from aiosendspin.server.roles.visualizer.group import VisualizerGroupRole
+from aiosendspin.server.roles.visualizer.types import VisualizerRoleProtocol
 
 
-def _make_group_stub() -> MagicMock:
+def _make_group_stub(*, now_us: int = 0) -> MagicMock:
     """Create a mock group for testing."""
-    return MagicMock()
+    group = MagicMock()
+    group._server.clock.now_us.return_value = now_us  # noqa: SLF001
+    return group
+
+
+def _make_member_stub(*, wants_beats: bool = True) -> MagicMock:
+    """Create a member mock that satisfies VisualizerRoleProtocol."""
+    member = MagicMock(spec=VisualizerRoleProtocol)
+    member.wants_beats = wants_beats
+    return member
 
 
 def test_visualizer_group_role_family() -> None:
@@ -24,7 +37,7 @@ def test_visualizer_group_role_subscribe() -> None:
     group = _make_group_stub()
     vgr = VisualizerGroupRole(group)
 
-    member = MagicMock()
+    member = _make_member_stub()
     vgr.subscribe(member)
 
     assert member in vgr._members  # noqa: SLF001
@@ -35,8 +48,292 @@ def test_visualizer_group_role_unsubscribe() -> None:
     group = _make_group_stub()
     vgr = VisualizerGroupRole(group)
 
-    member = MagicMock()
+    member = _make_member_stub()
     vgr.subscribe(member)
     vgr.unsubscribe(member)
 
     assert member not in vgr._members  # noqa: SLF001
+
+
+def test_append_beat_schedule_broadcasts() -> None:
+    """append_beat_schedule pushes beats to every subscribed member."""
+    group = _make_group_stub()
+    vgr = VisualizerGroupRole(group)
+
+    member_a = _make_member_stub()
+    member_b = _make_member_stub()
+    vgr.subscribe(member_a)
+    vgr.subscribe(member_b)
+
+    beats = [BeatTiming(100), BeatTiming(200, is_downbeat=True), BeatTiming(300)]
+    vgr.append_beat_schedule(beats)
+
+    member_a.append_beats.assert_called_once_with(beats)
+    member_b.append_beats.assert_called_once_with(beats)
+
+
+def test_beats_wanted_false_when_no_members() -> None:
+    """beats_wanted is False with no subscribers."""
+    vgr = VisualizerGroupRole(_make_group_stub())
+    assert vgr.beats_wanted is False
+
+
+def test_beats_wanted_true_when_member_wants_beats() -> None:
+    """beats_wanted is True when a subscribed member wants beats."""
+    vgr = VisualizerGroupRole(_make_group_stub())
+    member = _make_member_stub()
+    member.wants_beats = True
+    vgr.subscribe(member)
+    assert vgr.beats_wanted is True
+
+
+def test_beats_wanted_false_after_last_wanter_leaves() -> None:
+    """beats_wanted drops to False once the only beat-wanting member unsubscribes."""
+    vgr = VisualizerGroupRole(_make_group_stub())
+    member = _make_member_stub()
+    member.wants_beats = True
+    vgr.subscribe(member)
+    vgr.unsubscribe(member)
+    assert vgr.beats_wanted is False
+
+
+def test_beats_wanted_false_when_no_member_wants() -> None:
+    """beats_wanted is False when members exist but none want beats."""
+    vgr = VisualizerGroupRole(_make_group_stub())
+    member = _make_member_stub()
+    member.wants_beats = False
+    vgr.subscribe(member)
+    assert vgr.beats_wanted is False
+
+
+def test_append_beat_schedule_extends_existing() -> None:
+    """A second append extends the stored schedule and pushes only the new tail."""
+    group = _make_group_stub()
+    vgr = VisualizerGroupRole(group)
+
+    member = _make_member_stub()
+    vgr.subscribe(member)
+
+    vgr.append_beat_schedule([BeatTiming(100), BeatTiming(200)])
+    vgr.append_beat_schedule([BeatTiming(300), BeatTiming(400)])
+
+    assert [b.timestamp_us for b in vgr.current_beats] == [100, 200, 300, 400]
+    assert member.append_beats.call_count == 2
+    second_call = member.append_beats.call_args_list[1]
+    assert [b.timestamp_us for b in second_call.args[0]] == [300, 400]
+
+
+def test_append_beat_schedule_rejects_non_monotonic() -> None:
+    """Out-of-order timestamps raise ValueError."""
+    group = _make_group_stub()
+    vgr = VisualizerGroupRole(group)
+    vgr.append_beat_schedule([BeatTiming(100), BeatTiming(200)])
+    with pytest.raises(ValueError, match="strictly increasing"):
+        vgr.append_beat_schedule([BeatTiming(150)])
+
+
+def test_append_beat_schedule_empty_is_noop() -> None:
+    """Empty append does not broadcast."""
+    group = _make_group_stub()
+    vgr = VisualizerGroupRole(group)
+
+    member = _make_member_stub()
+    vgr.subscribe(member)
+    vgr.append_beat_schedule([])
+
+    member.append_beats.assert_not_called()
+
+
+def test_clear_beat_schedule_broadcasts_clear() -> None:
+    """clear_beat_schedule wipes state and calls clear_beats on every member."""
+    group = _make_group_stub()
+    vgr = VisualizerGroupRole(group)
+
+    member = _make_member_stub()
+    vgr.subscribe(member)
+
+    vgr.append_beat_schedule([BeatTiming(42)])
+    member.reset_mock()
+    vgr.clear_beat_schedule()
+
+    assert vgr.current_beats == []
+    member.clear_beats.assert_called_once_with()
+    member.append_beats.assert_not_called()
+
+
+def test_on_member_join_replays_clear_then_append() -> None:
+    """A late joiner gets a clear followed by the current schedule."""
+    group = _make_group_stub()
+    vgr = VisualizerGroupRole(group)
+    vgr.append_beat_schedule([BeatTiming(10), BeatTiming(20)])
+
+    member = _make_member_stub()
+    vgr.subscribe(member)
+
+    member.clear_beats.assert_called_once_with()
+    member.append_beats.assert_called_once()
+    assert [b.timestamp_us for b in member.append_beats.call_args.args[0]] == [10, 20]
+
+
+def test_on_member_join_empty_schedule_only_clears() -> None:
+    """A late joiner with no schedule sees only the clear."""
+    group = _make_group_stub()
+    vgr = VisualizerGroupRole(group)
+
+    member = _make_member_stub()
+    vgr.subscribe(member)
+
+    member.clear_beats.assert_called_once_with()
+    member.append_beats.assert_not_called()
+
+
+def test_non_protocol_members_skipped() -> None:
+    """Members lacking the VisualizerRoleProtocol surface are silently skipped."""
+    group = _make_group_stub()
+    vgr = VisualizerGroupRole(group)
+
+    plain_member = MagicMock(spec=[])
+    vgr.subscribe(plain_member)
+
+    vgr.append_beat_schedule([BeatTiming(1), BeatTiming(2)])
+    # No exception, no spurious method calls fabricated.
+    assert not hasattr(plain_member, "append_beats") or not plain_member.append_beats.called
+
+
+def test_set_beat_availability_propagates_to_members() -> None:
+    """Group propagates beat availability to subscribed roles."""
+    group = _make_group_stub()
+    vgr = VisualizerGroupRole(group)
+    member = _make_member_stub()
+    vgr.subscribe(member)
+    member.set_beat_availability.reset_mock()
+
+    vgr.set_beat_availability(BeatAvailability.UNAVAILABLE)
+
+    member.set_beat_availability.assert_called_once_with(BeatAvailability.UNAVAILABLE)
+    assert vgr.beat_availability is BeatAvailability.UNAVAILABLE
+
+
+def test_append_beat_schedule_noop_when_unavailable() -> None:
+    """UNAVAILABLE blocks beat schedule from being broadcast."""
+    group = _make_group_stub()
+    vgr = VisualizerGroupRole(group)
+    member = _make_member_stub()
+    vgr.subscribe(member)
+    vgr.set_beat_availability(BeatAvailability.UNAVAILABLE)
+    member.append_beats.reset_mock()
+
+    vgr.append_beat_schedule([BeatTiming(1)])
+
+    member.append_beats.assert_not_called()
+    assert vgr.current_beats == []
+
+
+def test_on_member_join_replays_availability() -> None:
+    """A late-joining role gets the current availability."""
+    group = _make_group_stub()
+    vgr = VisualizerGroupRole(group)
+    vgr.set_beat_availability(BeatAvailability.UNAVAILABLE)
+
+    member = _make_member_stub()
+    vgr.subscribe(member)
+
+    member.set_beat_availability.assert_called_once_with(BeatAvailability.UNAVAILABLE)
+
+
+def test_unavailable_clears_current_beats() -> None:
+    """set_beat_availability(UNAVAILABLE) drops any stored schedule."""
+    vgr = VisualizerGroupRole(_make_group_stub())
+    vgr.append_beat_schedule([BeatTiming(1), BeatTiming(2)])
+    assert vgr.current_beats != []
+
+    vgr.set_beat_availability(BeatAvailability.UNAVAILABLE)
+
+    assert vgr.current_beats == []
+
+
+def test_clear_beat_schedule_resets_availability_to_pending() -> None:
+    """clear_beat_schedule resets availability for the next track."""
+    vgr = VisualizerGroupRole(_make_group_stub())
+    vgr.set_beat_availability(BeatAvailability.UNAVAILABLE)
+    assert vgr.beat_availability is BeatAvailability.UNAVAILABLE
+
+    vgr.clear_beat_schedule()
+
+    assert vgr.beat_availability is BeatAvailability.PENDING
+
+
+def test_clear_beat_schedule_re_declares_pending_to_members() -> None:
+    """Members hear the PENDING reset alongside the clear."""
+    vgr = VisualizerGroupRole(_make_group_stub())
+    member = _make_member_stub()
+    vgr.subscribe(member)
+    vgr.set_beat_availability(BeatAvailability.UNAVAILABLE)
+    member.reset_mock()
+
+    vgr.clear_beat_schedule()
+
+    member.clear_beats.assert_called_once_with()
+    member.set_beat_availability.assert_called_once_with(BeatAvailability.PENDING)
+
+
+def test_append_beat_schedule_allows_shared_segment_boundary() -> None:
+    """Adjacent calls may share a boundary ts; the duplicate head is dropped."""
+    vgr = VisualizerGroupRole(_make_group_stub())
+    member = _make_member_stub()
+    vgr.subscribe(member)
+    vgr.append_beat_schedule([BeatTiming(100), BeatTiming(200)])
+    member.reset_mock()
+
+    vgr.append_beat_schedule([BeatTiming(200), BeatTiming(300)])  # shared 200
+
+    assert [b.timestamp_us for b in vgr.current_beats] == [100, 200, 300]
+    second_call_args = member.append_beats.call_args.args[0]
+    # Duplicate boundary dropped; only the new tail is broadcast.
+    assert [b.timestamp_us for b in second_call_args] == [300]
+
+
+def test_append_beat_schedule_strict_inside_segment() -> None:
+    """Strict-`>` still enforced within a single call (only the head dedupe is allowed)."""
+    vgr = VisualizerGroupRole(_make_group_stub())
+    with pytest.raises(ValueError, match="strictly increasing"):
+        vgr.append_beat_schedule([BeatTiming(100), BeatTiming(100)])
+
+
+def test_on_member_join_skips_role_that_does_not_want_beats() -> None:
+    """A subscribing role whose wants_beats is False gets no schedule replay."""
+    vgr = VisualizerGroupRole(_make_group_stub())
+    vgr.append_beat_schedule([BeatTiming(10), BeatTiming(20)])
+    member = _make_member_stub(wants_beats=False)
+
+    vgr.subscribe(member)
+
+    member.set_beat_availability.assert_called_once_with(BeatAvailability.PENDING)
+    member.append_beats.assert_not_called()
+    member.clear_beats.assert_not_called()
+
+
+def test_on_member_join_filters_past_beats() -> None:
+    """Beats whose ts is < current playhead are not replayed (joiner-side burden)."""
+    vgr = VisualizerGroupRole(_make_group_stub(now_us=1_000))
+    vgr.append_beat_schedule([BeatTiming(500), BeatTiming(1_500), BeatTiming(2_500)])
+    member = _make_member_stub()
+
+    vgr.subscribe(member)
+
+    replayed = [b.timestamp_us for b in member.append_beats.call_args.args[0]]
+    assert replayed == [1_500, 2_500]
+
+
+def test_append_beat_schedule_snapshots_caller_list() -> None:
+    """Post-call mutation of the caller's list must not change broadcast contents."""
+    vgr = VisualizerGroupRole(_make_group_stub())
+    member = _make_member_stub()
+    vgr.subscribe(member)
+
+    mutable: list[BeatTiming] = [BeatTiming(1), BeatTiming(2)]
+    vgr.append_beat_schedule(mutable)
+    mutable.append(BeatTiming(3))
+
+    broadcast = member.append_beats.call_args.args[0]
+    assert [b.timestamp_us for b in broadcast] == [1, 2]

--- a/tests/server/roles/visualizer/test_v1.py
+++ b/tests/server/roles/visualizer/test_v1.py
@@ -1052,3 +1052,36 @@ async def test_server_set_pitch_enabled_fans_out_to_roles() -> None:
     role.refresh_pitch_setting.reset_mock()
     server.set_visualizer_pitch_enabled(enabled=False)  # idempotent
     role.refresh_pitch_setting.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Warmup re-arm on beat-schedule clear / availability flip
+# ---------------------------------------------------------------------------
+
+
+async def test_clear_beats_reholds_far_future_frames_after_schedule_landed() -> None:
+    """Dropping a landed schedule re-arms warmup so the next schedule is protected."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client)
+    role.on_connect()
+    role.on_stream_start()
+    role.append_beats([BeatTiming(1_000_000)])  # first landing → holdback lifted
+    role.clear_beats()  # schedule dropped while stream continues → re-arm
+    client.send_binary.reset_mock()
+    role.on_audio_chunk(_audio_chunk(timestamp_us=5_000_000))  # > lead → must be held
+    assert _periodic_calls(client) == []
+    role._cancel_release_timer()  # noqa: SLF001
+
+
+async def test_pending_after_unavailable_reholds_far_future_frames() -> None:
+    """UNAVAILABLE → PENDING re-arms warmup (beats wanted again on a new source)."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client)
+    role.on_connect()
+    role.on_stream_start()
+    role.set_beat_availability(BeatAvailability.UNAVAILABLE)  # holdback lifted
+    role.set_beat_availability(BeatAvailability.PENDING)  # beats wanted again → re-arm
+    client.send_binary.reset_mock()
+    role.on_audio_chunk(_audio_chunk(timestamp_us=5_000_000))
+    assert _periodic_calls(client) == []
+    role._cancel_release_timer()  # noqa: SLF001

--- a/tests/server/roles/visualizer/test_v1.py
+++ b/tests/server/roles/visualizer/test_v1.py
@@ -1,17 +1,23 @@
-"""Tests for VisualizerV1Role draft visualizer implementation."""
+"""Tests for VisualizerV1Role (the visualizer@v1 wire)."""
 
 from __future__ import annotations
 
 import struct
 from unittest.mock import MagicMock
 
-import pytest
-
-from aiosendspin.models.core import StreamClearMessage, StreamEndMessage, StreamStartMessage
+from aiosendspin.models.core import (
+    StreamClearMessage,
+    StreamEndMessage,
+    StreamRequestFormatPayload,
+    StreamStartMessage,
+)
 from aiosendspin.models.types import BinaryMessageType
 from aiosendspin.models.visualizer import (
+    BeatAvailability,
+    BeatTiming,
     ClientHelloVisualizerSpectrum,
     ClientHelloVisualizerSupport,
+    StreamRequestFormatVisualizer,
 )
 from aiosendspin.server.roles.base import AudioChunk
 from aiosendspin.server.roles.visualizer.v1 import VisualizerV1Role
@@ -19,7 +25,7 @@ from tests.server.roles.visualizer.conftest import sine_pcm_16bit
 
 
 def _make_client_stub() -> MagicMock:
-    """Create a mock client for testing."""
+    """Create a mock client preconfigured for visualizer@v1 tests."""
     client = MagicMock()
     client.client_id = "client-1"
     client.group = MagicMock()
@@ -28,13 +34,12 @@ def _make_client_stub() -> MagicMock:
     client.info.visualizer_support = {
         "types": ["loudness", "f_peak", "spectrum"],
         "buffer_capacity": 65536,
-        "batch_max": 8,
+        "rate_max": 60,
         "spectrum": {
             "n_disp_bins": 8,
             "scale": "lin",
             "f_min": 20,
             "f_max": 16_000,
-            "rate_max": 60,
         },
     }
     client.send_role_message = MagicMock()
@@ -45,28 +50,66 @@ def _make_client_stub() -> MagicMock:
     return client
 
 
-def test_visualizer_role_has_role_id() -> None:
-    """VisualizerV1Role has role_id of 'visualizer@_draft_r1'."""
+def _make_beat_client_stub() -> MagicMock:
+    """Client stub negotiating both loudness and beat."""
     client = _make_client_stub()
-    role = VisualizerV1Role(client=client)
-    assert role.role_id == "visualizer@_draft_r1"
+    client.info.visualizer_support = {
+        "types": ["loudness", "beat"],
+        "buffer_capacity": 65536,
+        "rate_max": 60,
+    }
+    return client
 
 
-def test_visualizer_role_has_role_family() -> None:
-    """VisualizerV1Role has role_family of 'visualizer'."""
+def _audio_chunk(timestamp_us: int = 1_000_000) -> AudioChunk:
+    pcm = sine_pcm_16bit(sample_rate=48_000, channels=2, hz=1000.0, duration_s=0.025)
+    return AudioChunk(
+        data=pcm,
+        timestamp_us=timestamp_us,
+        duration_us=25_000,
+        byte_count=len(pcm),
+    )
+
+
+def _last_stream_start(client: MagicMock) -> StreamStartMessage:
+    for call in reversed(client.send_role_message.call_args_list):
+        msg = call.args[1]
+        if isinstance(msg, StreamStartMessage):
+            return msg
+    raise AssertionError("no StreamStartMessage was sent")
+
+
+def _stream_start_count(client: MagicMock) -> int:
+    return sum(
+        1
+        for call in client.send_role_message.call_args_list
+        if isinstance(call.args[1], StreamStartMessage)
+    )
+
+
+def _beat_calls(client: MagicMock) -> list:
+    return [
+        call
+        for call in client.send_binary.call_args_list
+        if call.kwargs["message_type"] == BinaryMessageType.VISUALIZATION_BEAT.value
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Role identity + lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_role_id_is_v1() -> None:
+    """Role id is v1."""
     client = _make_client_stub()
     role = VisualizerV1Role(client=client)
+    assert role.role_id == "visualizer@v1"
     assert role.role_family == "visualizer"
 
 
-def test_visualizer_role_requires_client() -> None:
-    """VisualizerV1Role raises ValueError if no client provided."""
-    with pytest.raises(ValueError, match="requires a client"):
-        VisualizerV1Role(client=None)
-
-
-def test_visualizer_role_on_connect_subscribes_to_group_role() -> None:
-    """on_connect() subscribes to VisualizerGroupRole."""
+def test_on_connect_subscribes_to_group_role() -> None:
+    """On connect subscribes to group role."""
     client = _make_client_stub()
     group_role = MagicMock()
     client.group.group_role.return_value = group_role
@@ -78,83 +121,8 @@ def test_visualizer_role_on_connect_subscribes_to_group_role() -> None:
     group_role.subscribe.assert_called_once_with(role)
 
 
-def test_visualizer_role_on_stream_start_sends_stream_start() -> None:
-    """on_stream_start() sends stream/start with negotiated config."""
-    client = _make_client_stub()
-    role = VisualizerV1Role(client=client)
-    role.on_connect()
-
-    role.on_stream_start()
-
-    client.send_role_message.assert_called()
-    _family, message = client.send_role_message.call_args.args
-    assert isinstance(message, StreamStartMessage)
-    assert message.payload.visualizer is not None
-    assert list(message.payload.visualizer.types) == ["loudness", "f_peak", "spectrum"]
-    assert message.payload.visualizer.batch_max == 8
-
-
-def test_visualizer_role_on_connect_does_not_send_stream_start() -> None:
-    """on_connect() initializes config but does not send stream/start."""
-    client = _make_client_stub()
-    role = VisualizerV1Role(client=client)
-
-    role.on_connect()
-
-    # No stream/start should be sent until on_stream_start is called.
-    for call in client.send_role_message.call_args_list:
-        assert not isinstance(call.args[1], StreamStartMessage)
-
-
-def test_visualizer_role_accepts_legacy_support_object() -> None:
-    """Legacy visualizer support shape still initializes draft role."""
-    client = _make_client_stub()
-    client.info.visualizer_support = ClientHelloVisualizerSupport(buffer_capacity=65536)
-    role = VisualizerV1Role(client=client)
-    role.on_connect()
-
-    role.on_stream_start()
-
-    client.send_role_message.assert_called()
-    _family, message = client.send_role_message.call_args.args
-    assert isinstance(message, StreamStartMessage)
-    assert message.payload.visualizer is not None
-    assert list(message.payload.visualizer.types) == ["loudness", "f_peak"]
-    assert message.payload.visualizer.batch_max == 8
-
-
-def test_visualizer_role_preserves_draft_support_fields() -> None:
-    """Draft support fields survive model parsing and are used in stream/start."""
-    client = _make_client_stub()
-    client.info.visualizer_support = ClientHelloVisualizerSupport(
-        types=["loudness", "f_peak", "spectrum"],
-        buffer_capacity=65536,
-        batch_max=6,
-        spectrum=ClientHelloVisualizerSpectrum(
-            n_disp_bins=16,
-            scale="lin",
-            f_min=40,
-            f_max=14000,
-            rate_max=30,
-        ),
-    )
-    role = VisualizerV1Role(client=client)
-    role.on_connect()
-
-    role.on_stream_start()
-
-    client.send_role_message.assert_called()
-    _family, message = client.send_role_message.call_args.args
-    assert isinstance(message, StreamStartMessage)
-    assert message.payload.visualizer is not None
-    assert list(message.payload.visualizer.types) == ["loudness", "f_peak", "spectrum"]
-    assert message.payload.visualizer.batch_max == 6
-    assert message.payload.visualizer.spectrum is not None
-    assert message.payload.visualizer.spectrum.n_disp_bins == 16
-
-
-def test_visualizer_role_on_disconnect_unsubscribes_from_group_role() -> None:
-    """on_disconnect() unsubscribes from VisualizerGroupRole."""
+def test_on_disconnect_unsubscribes() -> None:
+    """On disconnect unsubscribes."""
     client = _make_client_stub()
     group_role = MagicMock()
     client.group.group_role.return_value = group_role
@@ -166,229 +134,718 @@ def test_visualizer_role_on_disconnect_unsubscribes_from_group_role() -> None:
     group_role.unsubscribe.assert_called_once_with(role)
 
 
-def test_visualizer_role_has_stream_requirements() -> None:
-    """Visualizer role declares stream requirements."""
-    client = _make_client_stub()
-    role = VisualizerV1Role(client=client)
-    assert role.get_stream_requirements() is not None
+def test_wants_beats_true_when_beat_negotiated() -> None:
+    """wants_beats is True once the client negotiated `beat` (PENDING default)."""
+    role = VisualizerV1Role(client=_make_beat_client_stub())
+    role.on_connect()
+    assert role.wants_beats is True
 
 
-def test_visualizer_role_has_audio_requirements() -> None:
-    """Visualizer role consumes audio for feature extraction."""
-    client = _make_client_stub()
-    role = VisualizerV1Role(client=client)
-    req = role.get_audio_requirements()
-    assert req is not None
-    assert req.sample_rate == 48_000
-    assert req.bit_depth == 16
-    assert req.channels == 2
+def test_wants_beats_false_when_beat_not_negotiated() -> None:
+    """wants_beats is False when the client never requested `beat`."""
+    role = VisualizerV1Role(client=_make_client_stub())
+    role.on_connect()
+    assert role.wants_beats is False
 
 
-def test_visualizer_role_emits_binary_visualization_frame() -> None:
-    """on_audio_chunk() sends binary type 16 frame."""
+def test_wants_beats_false_when_unavailable() -> None:
+    """UNAVAILABLE locks beats out even when the client requested `beat`."""
+    role = VisualizerV1Role(client=_make_beat_client_stub())
+    role.on_connect()
+    role.set_beat_availability(BeatAvailability.UNAVAILABLE)
+    assert role.wants_beats is False
+
+
+def test_on_stream_start_sends_stream_start_with_negotiated_config() -> None:
+    """on_stream_start emits stream/start with the negotiated config."""
     client = _make_client_stub()
     role = VisualizerV1Role(client=client)
     role.on_connect()
     role.on_stream_start()
 
-    pcm = sine_pcm_16bit(sample_rate=48_000, channels=2, hz=1000.0, duration_s=0.025)
-    role.on_audio_chunk(
-        AudioChunk(
-            data=pcm,
-            timestamp_us=1_000_000,
-            duration_us=25_000,
-            byte_count=len(pcm),
-        )
-    )
-
-    client.send_binary.assert_called()
-    kwargs = client.send_binary.call_args.kwargs
-    payload = client.send_binary.call_args.args[0]
-
-    assert kwargs["role_family"] == "visualizer"
-    assert kwargs["message_type"] == BinaryMessageType.VISUALIZATION_DATA.value
-    assert kwargs["timestamp_us"] == 1_000_000
-
-    assert payload[0] == BinaryMessageType.VISUALIZATION_DATA.value
-    assert payload[1] == 1  # frame count
-    assert struct.unpack(">q", payload[2:10])[0] == 1_000_000
+    message = _last_stream_start(client)
+    assert message.payload.visualizer is not None
+    assert list(message.payload.visualizer.types) == ["loudness", "f_peak", "spectrum"]
+    assert message.payload.visualizer.rate_max == 60
+    assert message.payload.visualizer.spectrum is not None
+    assert message.payload.visualizer.spectrum.n_disp_bins == 8
 
 
-def test_visualizer_role_on_stream_clear_sends_clear_message() -> None:
-    """on_stream_clear() sends stream/clear for visualizer role."""
+def test_on_stream_start_resent_after_stream_end() -> None:
+    """stream/start is re-sent after stream/end → on_stream_start cycle."""
+    client = _make_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+    role.on_stream_end()
+    role.on_stream_start()
+
+    assert _stream_start_count(client) == 2
+
+
+def test_on_stream_start_not_resent_during_active_stream() -> None:
+    """A second on_stream_start with no stream/end in between is a no-op (per #239)."""
+    client = _make_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+    role.on_stream_start()
+
+    assert _stream_start_count(client) == 1
+
+
+def test_on_stream_clear_sends_clear_message() -> None:
+    """on_stream_clear emits stream/clear."""
     client = _make_client_stub()
     role = VisualizerV1Role(client=client)
     role.on_connect()
     role.on_stream_clear()
 
-    _family, message = client.send_role_message.call_args.args
-    assert isinstance(message, StreamClearMessage)
-    assert message.payload.roles == ["visualizer"]
+    last = client.send_role_message.call_args.args[1]
+    assert isinstance(last, StreamClearMessage)
+    assert last.payload.roles == ["visualizer"]
 
 
-def test_visualizer_role_on_stream_end_sends_end_message() -> None:
-    """on_stream_end() sends stream/end for visualizer role."""
+def test_on_stream_end_sends_end_message() -> None:
+    """on_stream_end emits stream/end."""
     client = _make_client_stub()
     role = VisualizerV1Role(client=client)
     role.on_connect()
     role.on_stream_end()
 
-    _family, message = client.send_role_message.call_args.args
-    assert isinstance(message, StreamEndMessage)
-    assert message.payload.roles == ["visualizer"]
+    last = client.send_role_message.call_args.args[1]
+    assert isinstance(last, StreamEndMessage)
+    assert last.payload.roles == ["visualizer"]
 
 
-def test_visualizer_role_sends_buffer_tracking_metadata() -> None:
-    """send_binary must include buffer tracking parameters."""
+# ---------------------------------------------------------------------------
+# Periodic per-type emission from on_audio_chunk
+# ---------------------------------------------------------------------------
+
+
+def test_on_audio_chunk_emits_one_binary_per_periodic_type() -> None:
+    """on_audio_chunk emits one binary per negotiated periodic type."""
     client = _make_client_stub()
     role = VisualizerV1Role(client=client)
     role.on_connect()
     role.on_stream_start()
+    client.send_binary.reset_mock()
 
-    pcm = sine_pcm_16bit(sample_rate=48_000, channels=2, hz=1000.0, duration_s=0.025)
-    role.on_audio_chunk(
-        AudioChunk(
-            data=pcm,
-            timestamp_us=1_000_000,
-            duration_us=25_000,
-            byte_count=len(pcm),
-        )
+    role.on_audio_chunk(_audio_chunk(1_000_000))
+
+    msg_types = [call.kwargs["message_type"] for call in client.send_binary.call_args_list]
+    assert sorted(msg_types) == sorted(
+        [
+            BinaryMessageType.VISUALIZATION_LOUDNESS.value,
+            BinaryMessageType.VISUALIZATION_F_PEAK.value,
+            BinaryMessageType.VISUALIZATION_SPECTRUM.value,
+        ]
     )
 
-    client.send_binary.assert_called()
+
+def test_loudness_binary_layout_is_type_ts_value() -> None:
+    """`loudness`: [16][ts:8][uint16] = 11 bytes."""
+    client = _make_client_stub()
+    client.info.visualizer_support = {
+        "types": ["loudness"],
+        "buffer_capacity": 65536,
+        "rate_max": 60,
+    }
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+    client.send_binary.reset_mock()
+
+    role.on_audio_chunk(_audio_chunk(1_234_000))
+
+    client.send_binary.assert_called_once()
+    payload = client.send_binary.call_args.args[0]
     kwargs = client.send_binary.call_args.kwargs
-    assert kwargs["buffer_end_time_us"] == 1_025_000  # timestamp + 25ms frame duration
-    assert kwargs["buffer_byte_count"] > 0
-    assert kwargs["duration_us"] == 25_000
+    assert payload[0] == BinaryMessageType.VISUALIZATION_LOUDNESS.value
+    expected_ts = 1_234_000 + 25_000
+    assert struct.unpack(">q", payload[1:9])[0] == expected_ts
+    assert len(payload) == 11
+    assert kwargs["timestamp_us"] == expected_ts
 
 
-def test_visualizer_role_creates_buffer_tracker_on_stream_start() -> None:
-    """on_stream_start() creates a BufferTracker with negotiated capacity."""
+def test_f_peak_binary_carries_freq_and_amp() -> None:
+    """`f_peak`: [18][ts:8][uint16 freq][uint16 amp] = 13 bytes."""
+    client = _make_client_stub()
+    client.info.visualizer_support = {
+        "types": ["f_peak"],
+        "buffer_capacity": 65536,
+        "rate_max": 60,
+    }
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+    client.send_binary.reset_mock()
+
+    role.on_audio_chunk(_audio_chunk(2_000_000))
+
+    client.send_binary.assert_called_once()
+    payload = client.send_binary.call_args.args[0]
+    assert payload[0] == BinaryMessageType.VISUALIZATION_F_PEAK.value
+    assert struct.unpack(">q", payload[1:9])[0] == 2_000_000 + 25_000
+    freq, amp = struct.unpack(">HH", payload[9:13])
+    assert freq > 0
+    assert amp > 0
+
+
+def test_on_audio_chunk_emits_no_periodic_when_only_beat_negotiated() -> None:
+    """Beat-only client: no periodic binaries on audio chunks (no FFT extractor)."""
+    client = _make_client_stub()
+    client.info.visualizer_support = {
+        "types": ["beat"],
+        "buffer_capacity": 65536,
+        "rate_max": 30,
+    }
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+    client.send_binary.reset_mock()
+
+    role.on_audio_chunk(_audio_chunk())
+
+    client.send_binary.assert_not_called()
+    assert role._extractor is None  # noqa: SLF001
+
+
+def test_audio_chunk_without_stream_start_is_noop() -> None:
+    """on_audio_chunk before on_stream_start is a no-op."""
     client = _make_client_stub()
     role = VisualizerV1Role(client=client)
     role.on_connect()
+    role.on_audio_chunk(_audio_chunk())
+    client.send_binary.assert_not_called()
+    assert role._extractor is None  # noqa: SLF001
 
-    assert role.get_buffer_tracker() is None
 
+# ---------------------------------------------------------------------------
+# Beats — deferred type, drained via on_audio_chunk
+# ---------------------------------------------------------------------------
+
+
+def test_initial_stream_start_omits_beat_until_schedule_lands() -> None:
+    """`beat` is deferred from the negotiated types until the first schedule arrives."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
     role.on_stream_start()
 
+    initial = _last_stream_start(client).payload.visualizer
+    assert initial is not None
+    assert "beat" not in initial.types
+    # tracks_downbeats only meaningful when `beat` is negotiated.
+    assert initial.tracks_downbeats is None
+
+
+def test_first_beats_landing_reissues_stream_start_with_beat() -> None:
+    """The first non-empty append_beats activates `beat` in the negotiated types."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.set_tracks_downbeats(tracks=True)
+    role.on_connect()
+    role.on_stream_start()
+    assert "beat" not in _last_stream_start(client).payload.visualizer.types
+    starts_before = _stream_start_count(client)
+
+    role.append_beats([BeatTiming(1_000_000)])
+
+    assert _stream_start_count(client) == starts_before + 1
+    after = _last_stream_start(client).payload.visualizer
+    assert after is not None
+    assert "beat" in after.types
+    assert after.tracks_downbeats is True
+
+
+def test_subsequent_beats_landings_do_not_reissue_stream_start() -> None:
+    """Only the first batch flips `_has_beats_landed`; later batches are no-ops on the config."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+    role.append_beats([BeatTiming(1_000_000)])  # first landing — re-emits
+    starts_after_first = _stream_start_count(client)
+
+    role.append_beats([BeatTiming(2_000_000)])
+    role.append_beats([BeatTiming(3_000_000)])
+
+    assert _stream_start_count(client) == starts_after_first
+
+
+def test_beats_drain_on_next_audio_chunk() -> None:
+    """Beats sit in the pending queue and emit on the next on_audio_chunk drain."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+
+    role.append_beats([BeatTiming(500_000), BeatTiming(1_500_000)])
+    # No beats on the wire yet — drain is audio-driven.
+    assert _beat_calls(client) == []
+
+    role.on_audio_chunk(_audio_chunk(1_000_000))
+
+    beat_ts = [c.kwargs["timestamp_us"] for c in _beat_calls(client)]
+    assert beat_ts == [500_000]
+
+    role.on_audio_chunk(_audio_chunk(2_000_000))
+    beat_ts = [c.kwargs["timestamp_us"] for c in _beat_calls(client)]
+    assert beat_ts == [500_000, 1_500_000]
+
+
+def test_beats_interleave_with_periodic_frames_in_ts_order() -> None:
+    """All wire timestamps stay non-decreasing across periodic + beat frames."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+    role.append_beats([BeatTiming(500_000), BeatTiming(1_500_000)])
+    client.send_binary.reset_mock()
+
+    role.on_audio_chunk(_audio_chunk(1_000_000))
+    role.on_audio_chunk(_audio_chunk(2_000_000))
+
+    ts_values = [c.kwargs["timestamp_us"] for c in client.send_binary.call_args_list]
+    assert ts_values == sorted(ts_values)
+
+
+def test_beat_binary_layout() -> None:
+    """`beat` binary: [17][ts:8][flags:1] = 10 bytes."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+    role.append_beats(
+        [
+            BeatTiming(100, is_downbeat=True),
+            BeatTiming(200),
+        ]
+    )
+    role.on_audio_chunk(_audio_chunk(1_000_000))
+
+    payloads = [call.args[0] for call in _beat_calls(client)]
+    assert len(payloads) == 2
+    for payload in payloads:
+        assert len(payload) == 10
+        assert payload[0] == BinaryMessageType.VISUALIZATION_BEAT.value
+    assert struct.unpack(">q", payloads[0][1:9])[0] == 100
+    assert payloads[0][9] == 0b0000_0001
+    assert struct.unpack(">q", payloads[1][1:9])[0] == 200
+    assert payloads[1][9] == 0
+
+
+def test_append_beats_empty_is_noop() -> None:
+    """Empty append_beats neither queues nor reissues stream/start."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+    starts_before = _stream_start_count(client)
+
+    role.append_beats([])
+
+    assert _stream_start_count(client) == starts_before
+    assert list(role._pending_beats) == []  # noqa: SLF001
+
+
+def test_append_beats_noop_without_beat_type() -> None:
+    """Client without `beat` in supported types: append_beats has no effect."""
+    client = _make_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+    client.send_binary.reset_mock()
+    starts_before = _stream_start_count(client)
+
+    role.append_beats([BeatTiming(1), BeatTiming(2)])
+    role.on_audio_chunk(_audio_chunk())
+
+    assert _beat_calls(client) == []
+    assert _stream_start_count(client) == starts_before
+
+
+def test_clear_beats_drops_pending() -> None:
+    """clear_beats empties the pending schedule."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+    role.append_beats([BeatTiming(1_000_000), BeatTiming(60_000_000)])
+    assert list(role._pending_beats) != []  # noqa: SLF001
+
+    role.clear_beats()
+
+    assert list(role._pending_beats) == []  # noqa: SLF001
+
+
+def test_clear_beats_reissues_stream_start_to_drop_beat() -> None:
+    """After clear_beats the negotiated types no longer expose `beat` until next landing."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+    role.append_beats([BeatTiming(1_000_000)])
+    assert "beat" in _last_stream_start(client).payload.visualizer.types
+
+    role.clear_beats()
+
+    assert "beat" not in _last_stream_start(client).payload.visualizer.types
+
+
+def test_emit_beats_drops_duplicate_ts() -> None:
+    """Beats whose ts equals the most-recently-emitted one are dropped (`<=` guard)."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+    role.append_beats([BeatTiming(500_000)])
+    role.on_audio_chunk(_audio_chunk(1_000_000))  # emits 500_000
+    client.send_binary.reset_mock()
+
+    # Same ts again — should be dropped by the `<=` wire-ts guard.
+    role._pending_beats.append(BeatTiming(500_000))  # noqa: SLF001
+    role.on_audio_chunk(_audio_chunk(1_025_000))
+
+    assert _beat_calls(client) == []
+
+
+def test_join_ordering_beats_before_stream_start_drains_after_start() -> None:
+    """Beats appended before on_stream_start (mid-stream join) drain after start."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.append_beats([BeatTiming(500_000)])
+    # Before on_stream_start: nothing on the wire (no stream/start emitted yet
+    # either, so the client wouldn't know the config).
+    assert _beat_calls(client) == []
+
+    role.on_stream_start()
+    # The first batch arrived during warmup → `beat` is already in the
+    # initial stream/start (it landed before the start), so no second
+    # stream/start is needed.
+    assert "beat" in _last_stream_start(client).payload.visualizer.types
+    assert _beat_calls(client) == []  # still waiting for a chunk to drain
+
+    role.on_audio_chunk(_audio_chunk(1_000_000))
+    beat_ts = [c.kwargs["timestamp_us"] for c in _beat_calls(client)]
+    assert beat_ts == [500_000]
+
+
+# ---------------------------------------------------------------------------
+# Availability transitions
+# ---------------------------------------------------------------------------
+
+
+def test_unavailable_blocks_beat_activation() -> None:
+    """UNAVAILABLE makes append_beats a no-op and keeps `beat` out of types."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.set_beat_availability(BeatAvailability.UNAVAILABLE)
+    role.on_stream_start()
+
+    role.append_beats([BeatTiming(1_000_000)])
+    role.on_audio_chunk(_audio_chunk(2_000_000))
+
+    assert "beat" not in _last_stream_start(client).payload.visualizer.types
+    assert _beat_calls(client) == []
+
+
+def test_unavailable_after_landing_clears_beats_and_reissues() -> None:
+    """Flipping to UNAVAILABLE drops the pending schedule and re-emits stream/start."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+    role.append_beats([BeatTiming(1_000_000)])
+    assert "beat" in _last_stream_start(client).payload.visualizer.types
+
+    role.set_beat_availability(BeatAvailability.UNAVAILABLE)
+
+    assert "beat" not in _last_stream_start(client).payload.visualizer.types
+    assert list(role._pending_beats) == []  # noqa: SLF001
+
+
+def test_unavailable_then_pending_requires_fresh_beats_for_reactivation() -> None:
+    """PENDING after UNAVAILABLE does not re-add `beat`; a fresh schedule must land."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+    role.append_beats([BeatTiming(1_000_000)])
+    role.set_beat_availability(BeatAvailability.UNAVAILABLE)
+    assert "beat" not in _last_stream_start(client).payload.visualizer.types
+
+    role.set_beat_availability(BeatAvailability.PENDING)
+    # Flipping back to PENDING alone is not enough — the schedule was wiped.
+    assert "beat" not in _last_stream_start(client).payload.visualizer.types
+
+    role.append_beats([BeatTiming(2_000_000)])
+    assert "beat" in _last_stream_start(client).payload.visualizer.types
+
+
+def test_beat_only_stream_initial_includes_beat() -> None:
+    """Beat-only clients see `beat` from the start (no FFT type to fall back to)."""
+    client = _make_client_stub()
+    client.info.visualizer_support = {
+        "types": ["beat"],
+        "buffer_capacity": 65536,
+        "rate_max": 30,
+    }
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+
+    initial = _last_stream_start(client).payload.visualizer
+    assert list(initial.types) == ["beat"]
+
+
+# ---------------------------------------------------------------------------
+# stream/request-format renegotiation
+# ---------------------------------------------------------------------------
+
+
+def test_request_format_replaces_spectrum() -> None:
+    """request-format replaces the spectrum config and rebuilds the extractor."""
+    client = _make_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+    original_extractor = role._extractor  # noqa: SLF001
+
+    new_spectrum = ClientHelloVisualizerSpectrum(
+        n_disp_bins=24, scale="mel", f_min=40, f_max=14_000
+    )
+    payload = StreamRequestFormatPayload(
+        visualizer=StreamRequestFormatVisualizer(spectrum=new_spectrum)
+    )
+    role.on_stream_request_format(payload)
+
+    assert role._stream_config is not None  # noqa: SLF001
+    assert role._stream_config.spectrum is not None  # noqa: SLF001
+    assert role._stream_config.spectrum.n_disp_bins == 24  # noqa: SLF001
+    assert role._extractor is not original_extractor  # noqa: SLF001
+
+
+def test_request_format_replaces_rate_max() -> None:
+    """request-format replaces rate_max."""
+    client = _make_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+
+    payload = StreamRequestFormatPayload(visualizer=StreamRequestFormatVisualizer(rate_max=15))
+    role.on_stream_request_format(payload)
+
+    assert role._stream_config is not None  # noqa: SLF001
+    assert role._stream_config.rate_max == 15  # noqa: SLF001
+
+
+def test_request_format_replaces_types() -> None:
+    """request-format replaces the negotiated types."""
+    client = _make_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+
+    payload = StreamRequestFormatPayload(
+        visualizer=StreamRequestFormatVisualizer(types=["loudness"])
+    )
+    role.on_stream_request_format(payload)
+
+    assert role._stream_config is not None  # noqa: SLF001
+    assert list(role._stream_config.types) == ["loudness"]  # noqa: SLF001
+
+
+def test_request_format_emits_new_stream_start() -> None:
+    """request-format always emits a fresh stream/start."""
+    client = _make_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+    starts_before = _stream_start_count(client)
+
+    payload = StreamRequestFormatPayload(visualizer=StreamRequestFormatVisualizer(rate_max=20))
+    role.on_stream_request_format(payload)
+
+    assert _stream_start_count(client) == starts_before + 1
+
+
+def test_request_format_adding_spectrum_without_spectrum_object_falls_back() -> None:
+    """A `types` change adding `spectrum` without a `spectrum` object is normalized away."""
+    client = _make_client_stub()
+    client.info.visualizer_support = {
+        "types": ["loudness"],
+        "buffer_capacity": 65536,
+        "rate_max": 60,
+    }
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+
+    payload = StreamRequestFormatPayload(
+        visualizer=StreamRequestFormatVisualizer(types=["loudness", "spectrum"])
+    )
+    role.on_stream_request_format(payload)
+
+    # No spectrum object available → `spectrum` is filtered out by normalization.
+    assert "spectrum" not in role._stream_config.types  # noqa: SLF001
+    # And no crash in pack_spectrum on the next chunk.
+    role.on_audio_chunk(_audio_chunk(1_000_000))
+
+
+def test_request_format_clears_pending_beats_and_re_defers() -> None:
+    """request-format drops pending beats and re-defers `beat` until next landing."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+    role.append_beats([BeatTiming(1_000_000)])
+    assert "beat" in _last_stream_start(client).payload.visualizer.types
+    assert list(role._pending_beats) != []  # noqa: SLF001
+
+    role.on_stream_request_format(
+        StreamRequestFormatPayload(visualizer=StreamRequestFormatVisualizer(rate_max=15))
+    )
+
+    assert "beat" not in _last_stream_start(client).payload.visualizer.types
+    assert list(role._pending_beats) == []  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Buffer tracker + binary handling
+# ---------------------------------------------------------------------------
+
+
+def test_buffer_tracker_uses_negotiated_capacity() -> None:
+    """Buffer tracker uses negotiated capacity."""
+    client = _make_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
     tracker = role.get_buffer_tracker()
     assert tracker is not None
     assert tracker.capacity_bytes == 65536
 
 
-def test_visualizer_role_resets_buffer_tracker_on_stream_clear() -> None:
-    """on_stream_clear() resets the buffer tracker."""
+def test_buffer_tracker_resets_on_stream_clear() -> None:
+    """Buffer tracker resets on stream clear."""
     client = _make_client_stub()
     role = VisualizerV1Role(client=client)
     role.on_connect()
     role.on_stream_start()
+    role.on_stream_clear()
 
     tracker = role.get_buffer_tracker()
     assert tracker is not None
-
-    role.on_stream_clear()
-    # Tracker still exists but was reset (buffered_bytes = 0)
-    assert role.get_buffer_tracker() is not None
-    assert role.get_buffer_tracker().buffered_bytes == 0  # type: ignore[union-attr]
+    assert tracker.buffered_bytes == 0
 
 
-def test_visualizer_role_resets_buffer_tracker_on_stream_end() -> None:
-    """on_stream_end() resets the buffer tracker."""
+def test_buffer_tracker_capacity_shrink_does_not_reset_buffered_bytes() -> None:
+    """Mid-stream capacity changes update the limit but keep buffered_bytes intact."""
     client = _make_client_stub()
     role = VisualizerV1Role(client=client)
     role.on_connect()
     role.on_stream_start()
-
     tracker = role.get_buffer_tracker()
     assert tracker is not None
+    # Simulate already-sent bytes the client still holds.
+    tracker.register(end_time_us=1_000_000, byte_count=4096, duration_us=25_000)
+    assert tracker.buffered_bytes == 4096
 
-    role.on_stream_end()
-    assert role.get_buffer_tracker() is not None
-    assert role.get_buffer_tracker().buffered_bytes == 0  # type: ignore[union-attr]
+    payload = StreamRequestFormatPayload(
+        visualizer=StreamRequestFormatVisualizer(buffer_capacity=32_768)
+    )
+    role.on_stream_request_format(payload)
+
+    assert tracker.capacity_bytes == 32_768
+    assert tracker.buffered_bytes == 4096
 
 
-def test_visualizer_role_stream_start_is_resent_after_stream_end() -> None:
-    """A new stream/start must be sent again after stream/end."""
+def test_binary_handling_for_all_visualizer_types() -> None:
+    """get_binary_handling covers all per-type wire bytes."""
     client = _make_client_stub()
     role = VisualizerV1Role(client=client)
-    role.on_connect()
+    for member in (
+        BinaryMessageType.VISUALIZATION_LOUDNESS,
+        BinaryMessageType.VISUALIZATION_BEAT,
+        BinaryMessageType.VISUALIZATION_F_PEAK,
+        BinaryMessageType.VISUALIZATION_SPECTRUM,
+        BinaryMessageType.VISUALIZATION_PEAK,
+        BinaryMessageType.VISUALIZATION_PITCH,
+    ):
+        handling = role.get_binary_handling(member.value)
+        assert handling is not None
+        assert handling.drop_late is True
+        assert handling.buffer_track is True
 
-    role.on_stream_start()
-    role.on_stream_end()
-    role.on_stream_start()
 
-    stream_start_calls = [
-        call
-        for call in client.send_role_message.call_args_list
-        if isinstance(call.args[1], StreamStartMessage)
-    ]
-    assert len(stream_start_calls) == 2
+# ---------------------------------------------------------------------------
+# Support payload normalization
+# ---------------------------------------------------------------------------
 
 
-def test_visualizer_role_stream_start_skipped_after_stream_clear() -> None:
-    """stream/clear preserves stream/start config, so no resend is needed."""
+def test_role_accepts_support_object_instance() -> None:
+    """Client info may carry a model instance rather than a dict."""
     client = _make_client_stub()
-    role = VisualizerV1Role(client=client)
-    role.on_connect()
-
-    role.on_stream_start()
-    role.on_stream_clear()
-    role.on_stream_start()
-
-    stream_start_calls = [
-        call
-        for call in client.send_role_message.call_args_list
-        if isinstance(call.args[1], StreamStartMessage)
-    ]
-    assert len(stream_start_calls) == 1
-
-
-def test_visualizer_role_resets_binary_timing_on_stream_start() -> None:
-    """on_stream_start() resets binary timing for fresh grace window."""
-    client = _make_client_stub()
-    role = VisualizerV1Role(client=client)
-    role.on_connect()
-
-    # Simulate stale timing from a previous stream
-    role._stream_start_time_us = 1_000_000  # noqa: SLF001
-
-    role.on_stream_start()
-
-    assert role._stream_start_time_us is None  # noqa: SLF001
-
-
-def test_visualizer_role_resets_binary_timing_on_disconnect() -> None:
-    """on_disconnect() resets binary timing to avoid stale grace period."""
-    client = _make_client_stub()
+    client.info.visualizer_support = ClientHelloVisualizerSupport(
+        types=["loudness", "f_peak"],
+        buffer_capacity=65536,
+        rate_max=30,
+    )
     role = VisualizerV1Role(client=client)
     role.on_connect()
     role.on_stream_start()
 
-    role._stream_start_time_us = 5_000_000  # noqa: SLF001
+    message = _last_stream_start(client)
+    assert message.payload.visualizer is not None
+    assert list(message.payload.visualizer.types) == ["loudness", "f_peak"]
+    assert message.payload.visualizer.rate_max == 30
 
-    role.on_disconnect()
 
-    assert role._stream_start_time_us is None  # noqa: SLF001
-
-
-def test_visualizer_role_audio_chunk_without_stream_start_is_noop() -> None:
-    """on_audio_chunk() before on_stream_start() does not send data or self-initialize."""
+def test_unsupported_types_are_filtered() -> None:
+    """Types the reference impl can't produce are dropped from stream/start."""
     client = _make_client_stub()
+    client.info.visualizer_support = {
+        "types": ["loudness", "_not_a_real_type"],
+        "buffer_capacity": 65536,
+        "rate_max": 30,
+    }
     role = VisualizerV1Role(client=client)
     role.on_connect()
+    role.on_stream_start()
 
-    pcm = sine_pcm_16bit(sample_rate=48_000, channels=2, hz=1000.0, duration_s=0.025)
+    message = _last_stream_start(client)
+    assert message.payload.visualizer is not None
+    assert list(message.payload.visualizer.types) == ["loudness"]
+
+
+def test_pitch_emits_msg_21_with_midi_and_confidence() -> None:
+    """Pure-tone audio yields a confident pitch frame in MIDI 8.8 fixed-point."""
+    client = _make_client_stub()
+    client.info.visualizer_support = {
+        "types": ["pitch"],
+        "buffer_capacity": 65536,
+        "rate_max": 30,
+    }
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+    client.send_binary.reset_mock()
+
+    pcm = sine_pcm_16bit(sample_rate=48_000, channels=2, hz=440.0, duration_s=0.05)
     role.on_audio_chunk(
-        AudioChunk(
-            data=pcm,
-            timestamp_us=1_000_000,
-            duration_us=25_000,
-            byte_count=len(pcm),
-        )
+        AudioChunk(data=pcm, timestamp_us=1_000_000, duration_us=50_000, byte_count=len(pcm))
     )
 
-    # Should not have sent binary data or stream/start
-    client.send_binary.assert_not_called()
-    # Should not have self-initialized the extractor
-    assert role._extractor is None  # noqa: SLF001
+    assert client.send_binary.call_count == 1
+    payload = client.send_binary.call_args.args[0]
+    assert payload[0] == BinaryMessageType.VISUALIZATION_PITCH.value
+    assert struct.unpack(">q", payload[1:9])[0] == 1_050_000
+    (midi_q88,) = struct.unpack(">H", payload[9:11])
+    confidence = payload[11]
+    midi_float = midi_q88 / 256.0
+    assert abs(midi_float - 69.0) < 1.0
+    assert confidence > 128

--- a/tests/server/roles/visualizer/test_v1.py
+++ b/tests/server/roles/visualizer/test_v1.py
@@ -849,3 +849,94 @@ def test_pitch_emits_msg_21_with_midi_and_confidence() -> None:
     midi_float = midi_q88 / 256.0
     assert abs(midi_float - 69.0) < 1.0
     assert confidence > 128
+
+
+# ---------------------------------------------------------------------------
+# Warmup holdback: cap periodic send-ahead while beats are pending
+# ---------------------------------------------------------------------------
+
+
+def _periodic_calls(client: MagicMock) -> list:
+    """send_binary calls for periodic (non-beat) frames."""
+    return [
+        call
+        for call in client.send_binary.call_args_list
+        if call.kwargs["message_type"] != BinaryMessageType.VISUALIZATION_BEAT.value
+    ]
+
+
+async def test_warmup_holds_periodic_frames_beyond_lead() -> None:
+    """While beats are pending, periodic frames past the warmup lead are held."""
+    client = _make_beat_client_stub()  # loudness + beat, now_us=0 → cutoff 3s
+    role = VisualizerV1Role(client)
+    role.on_connect()
+    role.on_stream_start()
+    client.send_binary.reset_mock()
+    role.on_audio_chunk(_audio_chunk(timestamp_us=5_000_000))  # frame ~5.025s > lead
+    assert _periodic_calls(client) == []
+    role._cancel_release_timer()  # noqa: SLF001
+
+
+async def test_warmup_passes_frames_within_lead() -> None:
+    """Periodic frames within the warmup lead send immediately while pending."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client)
+    role.on_connect()
+    role.on_stream_start()
+    client.send_binary.reset_mock()
+    role.on_audio_chunk(_audio_chunk(timestamp_us=1_000_000))  # frame ~1.025s < lead
+    assert _periodic_calls(client)
+
+
+async def test_no_holdback_when_beats_not_wanted() -> None:
+    """Without beat negotiated, far-ahead frames are never held."""
+    client = _make_client_stub()  # loudness/f_peak/spectrum, no beat
+    role = VisualizerV1Role(client)
+    role.on_connect()
+    role.on_stream_start()
+    client.send_binary.reset_mock()
+    role.on_audio_chunk(_audio_chunk(timestamp_us=5_000_000))
+    assert _periodic_calls(client)
+
+
+async def test_first_beats_flush_held_frames_in_ts_order() -> None:
+    """Beats landing lifts the cap, flushing held frames with beats interleaved."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client)
+    role.on_connect()
+    role.on_stream_start()
+    client.send_binary.reset_mock()
+    role.on_audio_chunk(_audio_chunk(timestamp_us=5_000_000))  # loudness held ~5.025s
+    assert _periodic_calls(client) == []
+    role.append_beats([BeatTiming(5_010_000)])
+    sent_ts = [call.kwargs["timestamp_us"] for call in client.send_binary.call_args_list]
+    assert sent_ts == sorted(sent_ts), "wire timestamps must stay non-decreasing"
+    assert _beat_calls(client), "beat should emit on flush"
+    assert _periodic_calls(client), "held periodic frame should flush"
+
+
+async def test_unavailable_flushes_held_frames() -> None:
+    """Declaring beats UNAVAILABLE lifts the cap and releases held frames."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client)
+    role.on_connect()
+    role.on_stream_start()
+    client.send_binary.reset_mock()
+    role.on_audio_chunk(_audio_chunk(timestamp_us=5_000_000))
+    assert _periodic_calls(client) == []
+    role.set_beat_availability(BeatAvailability.UNAVAILABLE)
+    assert _periodic_calls(client)
+
+
+async def test_release_scheduler_sends_frames_as_playhead_advances() -> None:
+    """Held frames release once the playhead advances within the warmup lead."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client)
+    role.on_connect()
+    role.on_stream_start()
+    client.send_binary.reset_mock()
+    role.on_audio_chunk(_audio_chunk(timestamp_us=5_000_000))  # held ~5.025s
+    assert _periodic_calls(client) == []
+    client._server.clock.now_us.return_value = 4_000_000  # cutoff 7s  # noqa: SLF001
+    role._run_release_scheduler()  # noqa: SLF001
+    assert _periodic_calls(client)

--- a/tests/server/roles/visualizer/test_v1.py
+++ b/tests/server/roles/visualizer/test_v1.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import struct
 from unittest.mock import MagicMock
 
@@ -21,6 +22,7 @@ from aiosendspin.models.visualizer import (
 )
 from aiosendspin.server.roles.base import AudioChunk
 from aiosendspin.server.roles.visualizer.v1 import VisualizerV1Role
+from aiosendspin.server.server import SendspinServer
 from tests.server.roles.visualizer.conftest import sine_pcm_16bit
 
 
@@ -46,7 +48,19 @@ def _make_client_stub() -> MagicMock:
     client.send_binary = MagicMock()
     client._server = MagicMock()  # noqa: SLF001
     client._server.clock.now_us.return_value = 0  # noqa: SLF001
+    client._server.visualizer_pitch_enabled = True  # noqa: SLF001
     client.connection = MagicMock()
+    return client
+
+
+def _make_pitch_client_stub() -> MagicMock:
+    """Client stub negotiating loudness + pitch."""
+    client = _make_client_stub()
+    client.info.visualizer_support = {
+        "types": ["loudness", "pitch"],
+        "buffer_capacity": 65536,
+        "rate_max": 60,
+    }
     return client
 
 
@@ -940,3 +954,101 @@ async def test_release_scheduler_sends_frames_as_playhead_advances() -> None:
     client._server.clock.now_us.return_value = 4_000_000  # cutoff 7s  # noqa: SLF001
     role._run_release_scheduler()  # noqa: SLF001
     assert _periodic_calls(client)
+
+
+# ---------------------------------------------------------------------------
+# Server-wide pitch shed toggle
+# ---------------------------------------------------------------------------
+
+
+def test_pitch_in_types_when_server_enabled() -> None:
+    """Pitch stays in the negotiated types while the server flag is on (default)."""
+    client = _make_pitch_client_stub()
+    role = VisualizerV1Role(client)
+    role.on_connect()
+    role.on_stream_start()
+    assert "pitch" in _last_stream_start(client).payload.visualizer.types
+
+
+def test_pitch_dropped_when_server_disabled() -> None:
+    """Pitch is excluded from negotiated types when the server flag is off."""
+    client = _make_pitch_client_stub()
+    client._server.visualizer_pitch_enabled = False  # noqa: SLF001
+    role = VisualizerV1Role(client)
+    role.on_connect()
+    role.on_stream_start()
+    types = _last_stream_start(client).payload.visualizer.types
+    assert "pitch" not in types
+    assert "loudness" in types
+
+
+def test_disabled_pitch_emits_no_pitch_binary() -> None:
+    """With pitch disabled, no PITCH binary is produced from an audio chunk."""
+    client = _make_pitch_client_stub()
+    client._server.visualizer_pitch_enabled = False  # noqa: SLF001
+    role = VisualizerV1Role(client)
+    role.on_connect()
+    role.on_stream_start()
+    client.send_binary.reset_mock()
+    role.on_audio_chunk(_audio_chunk(timestamp_us=1_000_000))
+    msg_types = [call.kwargs["message_type"] for call in client.send_binary.call_args_list]
+    assert BinaryMessageType.VISUALIZATION_PITCH.value not in msg_types
+
+
+def test_pitch_kept_when_sole_type_even_if_disabled() -> None:
+    """A pitch-only client keeps pitch — types must not be emptied."""
+    client = _make_client_stub()
+    client.info.visualizer_support = {
+        "types": ["pitch"],
+        "buffer_capacity": 65536,
+        "rate_max": 60,
+    }
+    client._server.visualizer_pitch_enabled = False  # noqa: SLF001
+    role = VisualizerV1Role(client)
+    role.on_connect()
+    role.on_stream_start()
+    assert _last_stream_start(client).payload.visualizer.types == ("pitch",)
+
+
+def test_refresh_pitch_setting_reissues_stream_start_on_change() -> None:
+    """Flipping the server flag live re-emits stream/start without pitch."""
+    client = _make_pitch_client_stub()
+    role = VisualizerV1Role(client)
+    role.on_connect()
+    role.on_stream_start()
+    before = _stream_start_count(client)
+    client._server.visualizer_pitch_enabled = False  # noqa: SLF001
+    role.refresh_pitch_setting()
+    assert _stream_start_count(client) == before + 1
+    assert "pitch" not in _last_stream_start(client).payload.visualizer.types
+
+
+def test_refresh_pitch_setting_noop_when_unchanged() -> None:
+    """refresh_pitch_setting does not re-emit when the resolved types are unchanged."""
+    client = _make_pitch_client_stub()  # flag stays enabled
+    role = VisualizerV1Role(client)
+    role.on_connect()
+    role.on_stream_start()
+    before = _stream_start_count(client)
+    role.refresh_pitch_setting()
+    assert _stream_start_count(client) == before
+
+
+async def test_server_set_pitch_enabled_fans_out_to_roles() -> None:
+    """SendspinServer.set_visualizer_pitch_enabled refreshes every active role once."""
+    server = SendspinServer(asyncio.get_running_loop(), "srv", "Srv", MagicMock())
+    role = MagicMock()
+    role.refresh_pitch_setting = MagicMock()
+    other = MagicMock(spec=[])  # no refresh_pitch_setting attr → skipped
+    client = MagicMock()
+    client.active_roles = [role, other]
+    server._clients["c1"] = client  # noqa: SLF001
+
+    assert server.visualizer_pitch_enabled is True
+    server.set_visualizer_pitch_enabled(enabled=False)
+    assert server.visualizer_pitch_enabled is False
+    role.refresh_pitch_setting.assert_called_once()
+
+    role.refresh_pitch_setting.reset_mock()
+    server.set_visualizer_pitch_enabled(enabled=False)  # idempotent
+    role.refresh_pitch_setting.assert_not_called()

--- a/tests/server/roles/visualizer/test_v1.py
+++ b/tests/server/roles/visualizer/test_v1.py
@@ -1085,3 +1085,22 @@ async def test_pending_after_unavailable_reholds_far_future_frames() -> None:
     role.on_audio_chunk(_audio_chunk(timestamp_us=5_000_000))
     assert _periodic_calls(client) == []
     role._cancel_release_timer()  # noqa: SLF001
+
+
+async def test_clear_beats_keeps_cursor_no_wire_regression() -> None:
+    """clear_beats must not reset the cursor: a below-frontier beat is dropped, not regressed."""
+    client = _make_beat_client_stub()
+    role = VisualizerV1Role(client)
+    role.on_connect()
+    role.on_stream_start()
+    role.append_beats([BeatTiming(1_000_000)])  # land → holdback lifted
+    role.on_audio_chunk(_audio_chunk(timestamp_us=5_000_000))  # frame ~5.025s → cursor advances
+    role.clear_beats()  # re-arm warmup, cursor kept (no stream/clear sent)
+    # New schedule: 2_000_000 is below the already-emitted frontier and must be
+    # dropped, not sent out of order; 6_000_000 is ahead and emits.
+    role.append_beats([BeatTiming(2_000_000), BeatTiming(6_000_000)])
+    role.on_audio_chunk(_audio_chunk(timestamp_us=6_000_000))
+    sent_ts = [call.kwargs["timestamp_us"] for call in client.send_binary.call_args_list]
+    assert sent_ts == sorted(sent_ts), f"wire timestamps regressed: {sent_ts}"
+    assert 2_000_000 not in sent_ts
+    role._cancel_release_timer()  # noqa: SLF001

--- a/tests/server/roles/visualizer_draft_r1/__init__.py
+++ b/tests/server/roles/visualizer_draft_r1/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for visualizer role."""

--- a/tests/server/roles/visualizer_draft_r1/conftest.py
+++ b/tests/server/roles/visualizer_draft_r1/conftest.py
@@ -1,0 +1,18 @@
+"""Shared test helpers for visualizer role tests."""
+
+from __future__ import annotations
+
+import math
+import struct
+
+
+def sine_pcm_16bit(*, sample_rate: int, channels: int, hz: float, duration_s: float) -> bytes:
+    """Generate a sine wave as little-endian signed 16-bit PCM."""
+    sample_count = int(sample_rate * duration_s)
+    frame_bytes = bytearray()
+    for i in range(sample_count):
+        value = int(32767 * math.sin((2.0 * math.pi * hz * i) / sample_rate))
+        packed = struct.pack("<h", value)
+        for _ in range(channels):
+            frame_bytes.extend(packed)
+    return bytes(frame_bytes)

--- a/tests/server/roles/visualizer_draft_r1/test_compat.py
+++ b/tests/server/roles/visualizer_draft_r1/test_compat.py
@@ -1,0 +1,41 @@
+"""Backwards-compat invariants for `VisualizerDraftR1Role`.
+
+The shared `VisualizerGroupRole` (registered for the v1 package) filters
+members by `VisualizerRoleProtocol` (runtime_checkable Protocol →
+attribute presence). draft_r1 must NOT expose those attributes, or it
+would accidentally start receiving beats it can't render.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aiosendspin.server.roles.visualizer.types import VisualizerRoleProtocol
+from aiosendspin.server.roles.visualizer_draft_r1.role import VisualizerDraftR1Role
+
+_BEAT_PROTOCOL_ATTRS = (
+    "wants_beats",
+    "append_beats",
+    "clear_beats",
+    "set_beat_availability",
+)
+
+
+@pytest.mark.parametrize("attr", _BEAT_PROTOCOL_ATTRS)
+def test_draft_r1_role_does_not_expose_beat_attr(attr: str) -> None:
+    """draft_r1 must not advertise beat-protocol attributes."""
+    assert not hasattr(VisualizerDraftR1Role, attr), (
+        f"VisualizerDraftR1Role must not expose `{attr}`; otherwise the shared "
+        f"VisualizerGroupRole would treat it as beat-capable and replay beats "
+        f"onto a wire that cannot carry them."
+    )
+
+
+def test_draft_r1_role_does_not_satisfy_visualizer_role_protocol() -> None:
+    """A draft_r1 instance must not pass the runtime Protocol isinstance check."""
+
+    class _FakeClient:
+        client_id = "x"
+
+    role = VisualizerDraftR1Role(client=_FakeClient())  # type: ignore[arg-type]
+    assert not isinstance(role, VisualizerRoleProtocol)

--- a/tests/server/roles/visualizer_draft_r1/test_features.py
+++ b/tests/server/roles/visualizer_draft_r1/test_features.py
@@ -1,0 +1,106 @@
+"""Tests for visualizer feature extraction and packing."""
+
+from __future__ import annotations
+
+import math
+import struct
+
+import numpy as np
+
+from aiosendspin.models.visualizer_draft_r1 import (
+    ClientHelloVisualizerSpectrum,
+    StreamStartVisualizer,
+)
+from aiosendspin.server.roles.visualizer_draft_r1.features import VisualizerFeatureExtractor
+from aiosendspin.server.roles.visualizer_draft_r1.packing import pack_visualization_message
+from tests.server.roles.visualizer_draft_r1.conftest import sine_pcm_16bit
+
+
+def _dual_sine_pcm_16bit(
+    *,
+    sample_rate: int,
+    channels: int,
+    hz_a: float,
+    hz_b: float,
+    duration_s: float,
+) -> bytes:
+    sample_count = int(sample_rate * duration_s)
+    frame_bytes = bytearray()
+    for i in range(sample_count):
+        v_a = math.sin((2.0 * math.pi * hz_a * i) / sample_rate)
+        v_b = math.sin((2.0 * math.pi * hz_b * i) / sample_rate)
+        value = int(32767 * np.clip(0.5 * (v_a + v_b), -1.0, 1.0))
+        packed = struct.pack("<h", value)
+        for _ in range(channels):
+            frame_bytes.extend(packed)
+    return bytes(frame_bytes)
+
+
+def test_extractor_produces_loudness_peak_and_spectrum() -> None:
+    """Extractor returns non-empty features for a sine wave."""
+    config = StreamStartVisualizer(
+        types=("loudness", "f_peak", "spectrum"),
+        batch_max=4,
+        spectrum=ClientHelloVisualizerSpectrum(
+            n_disp_bins=12,
+            scale="lin",
+            f_min=20,
+            f_max=16_000,
+            rate_max=60,
+        ),
+    )
+    extractor = VisualizerFeatureExtractor(sample_rate=48_000, channels=2, config=config)
+    pcm = sine_pcm_16bit(sample_rate=48_000, channels=2, hz=1000.0, duration_s=0.025)
+
+    frame = extractor.process_chunk(pcm, 1_000_000)
+
+    assert frame.loudness is not None
+    assert frame.loudness > 0
+    assert frame.f_peak is not None
+    assert abs(frame.f_peak - 1000) < 300
+    assert frame.spectrum is not None
+    assert isinstance(frame.spectrum, np.ndarray)
+    assert frame.spectrum.shape == (12,)
+    assert frame.spectrum.dtype == np.uint16
+
+
+def test_pack_visualization_message_binary_layout() -> None:
+    """Packed message starts with type byte, frame count, and then frame data."""
+    config = StreamStartVisualizer(
+        types=("loudness", "f_peak"),
+        batch_max=4,
+        spectrum=None,
+    )
+    extractor = VisualizerFeatureExtractor(sample_rate=48_000, channels=2, config=config)
+    pcm = sine_pcm_16bit(sample_rate=48_000, channels=2, hz=500.0, duration_s=0.025)
+    frame = extractor.process_chunk(pcm, 1_234_000)
+
+    packed = pack_visualization_message(frames=[frame], config=config)
+
+    assert packed[0] == 16  # message type
+    assert packed[1] == 1  # frame count
+    assert struct.unpack(">q", packed[2:10])[0] == 1_234_000
+    # type(1) + count(1) + timestamp(8) + loudness(2) + f_peak(2) = 14
+    assert len(packed) == 1 + 1 + 8 + 2 + 2
+
+
+def test_peak_frequency_uses_compensated_magnitude() -> None:
+    """A-weighting should prefer perceptually louder mids over deep bass."""
+    config = StreamStartVisualizer(
+        types=("f_peak",),
+        batch_max=4,
+        spectrum=None,
+    )
+    extractor = VisualizerFeatureExtractor(sample_rate=48_000, channels=2, config=config)
+    pcm = _dual_sine_pcm_16bit(
+        sample_rate=48_000,
+        channels=2,
+        hz_a=80.0,
+        hz_b=2_000.0,
+        duration_s=0.05,
+    )
+
+    frame = extractor.process_chunk(pcm, 2_000_000)
+
+    assert frame.f_peak is not None
+    assert abs(frame.f_peak - 2_000) < 400

--- a/tests/server/roles/visualizer_draft_r1/test_v1.py
+++ b/tests/server/roles/visualizer_draft_r1/test_v1.py
@@ -1,0 +1,394 @@
+"""Tests for VisualizerDraftR1Role draft visualizer implementation."""
+
+from __future__ import annotations
+
+import struct
+from unittest.mock import MagicMock
+
+import pytest
+
+from aiosendspin.models.core import StreamClearMessage, StreamEndMessage, StreamStartMessage
+from aiosendspin.models.types import BinaryMessageType
+from aiosendspin.models.visualizer_draft_r1 import (
+    ClientHelloVisualizerSpectrum,
+    ClientHelloVisualizerSupport,
+)
+from aiosendspin.server.roles.base import AudioChunk
+from aiosendspin.server.roles.visualizer_draft_r1.role import VisualizerDraftR1Role
+from tests.server.roles.visualizer_draft_r1.conftest import sine_pcm_16bit
+
+
+def _make_client_stub() -> MagicMock:
+    """Create a mock client for testing."""
+    client = MagicMock()
+    client.client_id = "client-1"
+    client.group = MagicMock()
+    client.group.group_role.return_value = None
+    client.info = MagicMock()
+    client.info.visualizer_draft_r1_support = {
+        "types": ["loudness", "f_peak", "spectrum"],
+        "buffer_capacity": 65536,
+        "batch_max": 8,
+        "spectrum": {
+            "n_disp_bins": 8,
+            "scale": "lin",
+            "f_min": 20,
+            "f_max": 16_000,
+            "rate_max": 60,
+        },
+    }
+    client.send_role_message = MagicMock()
+    client.send_binary = MagicMock()
+    client._server = MagicMock()  # noqa: SLF001
+    client._server.clock.now_us.return_value = 0  # noqa: SLF001
+    client.connection = MagicMock()
+    return client
+
+
+def test_visualizer_role_has_role_id() -> None:
+    """VisualizerDraftR1Role has role_id of 'visualizer@_draft_r1'."""
+    client = _make_client_stub()
+    role = VisualizerDraftR1Role(client=client)
+    assert role.role_id == "visualizer@_draft_r1"
+
+
+def test_visualizer_role_has_role_family() -> None:
+    """VisualizerDraftR1Role has role_family of 'visualizer'."""
+    client = _make_client_stub()
+    role = VisualizerDraftR1Role(client=client)
+    assert role.role_family == "visualizer"
+
+
+def test_visualizer_role_requires_client() -> None:
+    """VisualizerDraftR1Role raises ValueError if no client provided."""
+    with pytest.raises(ValueError, match="requires a client"):
+        VisualizerDraftR1Role(client=None)
+
+
+def test_visualizer_role_on_connect_subscribes_to_group_role() -> None:
+    """on_connect() subscribes to VisualizerGroupRole."""
+    client = _make_client_stub()
+    group_role = MagicMock()
+    client.group.group_role.return_value = group_role
+
+    role = VisualizerDraftR1Role(client=client)
+    role.on_connect()
+
+    client.group.group_role.assert_called_with("visualizer")
+    group_role.subscribe.assert_called_once_with(role)
+
+
+def test_visualizer_role_on_stream_start_sends_stream_start() -> None:
+    """on_stream_start() sends stream/start with negotiated config."""
+    client = _make_client_stub()
+    role = VisualizerDraftR1Role(client=client)
+    role.on_connect()
+
+    role.on_stream_start()
+
+    client.send_role_message.assert_called()
+    _family, message = client.send_role_message.call_args.args
+    assert isinstance(message, StreamStartMessage)
+    assert message.payload.visualizer is not None
+    assert list(message.payload.visualizer.types) == ["loudness", "f_peak", "spectrum"]
+    assert message.payload.visualizer.batch_max == 8
+
+
+def test_visualizer_role_on_connect_does_not_send_stream_start() -> None:
+    """on_connect() initializes config but does not send stream/start."""
+    client = _make_client_stub()
+    role = VisualizerDraftR1Role(client=client)
+
+    role.on_connect()
+
+    # No stream/start should be sent until on_stream_start is called.
+    for call in client.send_role_message.call_args_list:
+        assert not isinstance(call.args[1], StreamStartMessage)
+
+
+def test_visualizer_role_accepts_legacy_support_object() -> None:
+    """Legacy visualizer support shape still initializes draft role."""
+    client = _make_client_stub()
+    client.info.visualizer_draft_r1_support = ClientHelloVisualizerSupport(buffer_capacity=65536)
+    role = VisualizerDraftR1Role(client=client)
+    role.on_connect()
+
+    role.on_stream_start()
+
+    client.send_role_message.assert_called()
+    _family, message = client.send_role_message.call_args.args
+    assert isinstance(message, StreamStartMessage)
+    assert message.payload.visualizer is not None
+    assert list(message.payload.visualizer.types) == ["loudness", "f_peak"]
+    assert message.payload.visualizer.batch_max == 8
+
+
+def test_visualizer_role_preserves_draft_support_fields() -> None:
+    """Draft support fields survive model parsing and are used in stream/start."""
+    client = _make_client_stub()
+    client.info.visualizer_draft_r1_support = ClientHelloVisualizerSupport(
+        types=["loudness", "f_peak", "spectrum"],
+        buffer_capacity=65536,
+        batch_max=6,
+        spectrum=ClientHelloVisualizerSpectrum(
+            n_disp_bins=16,
+            scale="lin",
+            f_min=40,
+            f_max=14000,
+            rate_max=30,
+        ),
+    )
+    role = VisualizerDraftR1Role(client=client)
+    role.on_connect()
+
+    role.on_stream_start()
+
+    client.send_role_message.assert_called()
+    _family, message = client.send_role_message.call_args.args
+    assert isinstance(message, StreamStartMessage)
+    assert message.payload.visualizer is not None
+    assert list(message.payload.visualizer.types) == ["loudness", "f_peak", "spectrum"]
+    assert message.payload.visualizer.batch_max == 6
+    assert message.payload.visualizer.spectrum is not None
+    assert message.payload.visualizer.spectrum.n_disp_bins == 16
+
+
+def test_visualizer_role_on_disconnect_unsubscribes_from_group_role() -> None:
+    """on_disconnect() unsubscribes from VisualizerGroupRole."""
+    client = _make_client_stub()
+    group_role = MagicMock()
+    client.group.group_role.return_value = group_role
+
+    role = VisualizerDraftR1Role(client=client)
+    role.on_connect()
+    role.on_disconnect()
+
+    group_role.unsubscribe.assert_called_once_with(role)
+
+
+def test_visualizer_role_has_stream_requirements() -> None:
+    """Visualizer role declares stream requirements."""
+    client = _make_client_stub()
+    role = VisualizerDraftR1Role(client=client)
+    assert role.get_stream_requirements() is not None
+
+
+def test_visualizer_role_has_audio_requirements() -> None:
+    """Visualizer role consumes audio for feature extraction."""
+    client = _make_client_stub()
+    role = VisualizerDraftR1Role(client=client)
+    req = role.get_audio_requirements()
+    assert req is not None
+    assert req.sample_rate == 48_000
+    assert req.bit_depth == 16
+    assert req.channels == 2
+
+
+def test_visualizer_role_emits_binary_visualization_frame() -> None:
+    """on_audio_chunk() sends binary type 16 frame."""
+    client = _make_client_stub()
+    role = VisualizerDraftR1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+
+    pcm = sine_pcm_16bit(sample_rate=48_000, channels=2, hz=1000.0, duration_s=0.025)
+    role.on_audio_chunk(
+        AudioChunk(
+            data=pcm,
+            timestamp_us=1_000_000,
+            duration_us=25_000,
+            byte_count=len(pcm),
+        )
+    )
+
+    client.send_binary.assert_called()
+    kwargs = client.send_binary.call_args.kwargs
+    payload = client.send_binary.call_args.args[0]
+
+    assert kwargs["role_family"] == "visualizer"
+    assert kwargs["message_type"] == BinaryMessageType.VISUALIZATION_DATA.value
+    assert kwargs["timestamp_us"] == 1_000_000
+
+    assert payload[0] == BinaryMessageType.VISUALIZATION_DATA.value
+    assert payload[1] == 1  # frame count
+    assert struct.unpack(">q", payload[2:10])[0] == 1_000_000
+
+
+def test_visualizer_role_on_stream_clear_sends_clear_message() -> None:
+    """on_stream_clear() sends stream/clear for visualizer role."""
+    client = _make_client_stub()
+    role = VisualizerDraftR1Role(client=client)
+    role.on_connect()
+    role.on_stream_clear()
+
+    _family, message = client.send_role_message.call_args.args
+    assert isinstance(message, StreamClearMessage)
+    assert message.payload.roles == ["visualizer"]
+
+
+def test_visualizer_role_on_stream_end_sends_end_message() -> None:
+    """on_stream_end() sends stream/end for visualizer role."""
+    client = _make_client_stub()
+    role = VisualizerDraftR1Role(client=client)
+    role.on_connect()
+    role.on_stream_end()
+
+    _family, message = client.send_role_message.call_args.args
+    assert isinstance(message, StreamEndMessage)
+    assert message.payload.roles == ["visualizer"]
+
+
+def test_visualizer_role_sends_buffer_tracking_metadata() -> None:
+    """send_binary must include buffer tracking parameters."""
+    client = _make_client_stub()
+    role = VisualizerDraftR1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+
+    pcm = sine_pcm_16bit(sample_rate=48_000, channels=2, hz=1000.0, duration_s=0.025)
+    role.on_audio_chunk(
+        AudioChunk(
+            data=pcm,
+            timestamp_us=1_000_000,
+            duration_us=25_000,
+            byte_count=len(pcm),
+        )
+    )
+
+    client.send_binary.assert_called()
+    kwargs = client.send_binary.call_args.kwargs
+    assert kwargs["buffer_end_time_us"] == 1_025_000  # timestamp + 25ms frame duration
+    assert kwargs["buffer_byte_count"] > 0
+    assert kwargs["duration_us"] == 25_000
+
+
+def test_visualizer_role_creates_buffer_tracker_on_stream_start() -> None:
+    """on_stream_start() creates a BufferTracker with negotiated capacity."""
+    client = _make_client_stub()
+    role = VisualizerDraftR1Role(client=client)
+    role.on_connect()
+
+    assert role.get_buffer_tracker() is None
+
+    role.on_stream_start()
+
+    tracker = role.get_buffer_tracker()
+    assert tracker is not None
+    assert tracker.capacity_bytes == 65536
+
+
+def test_visualizer_role_resets_buffer_tracker_on_stream_clear() -> None:
+    """on_stream_clear() resets the buffer tracker."""
+    client = _make_client_stub()
+    role = VisualizerDraftR1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+
+    tracker = role.get_buffer_tracker()
+    assert tracker is not None
+
+    role.on_stream_clear()
+    # Tracker still exists but was reset (buffered_bytes = 0)
+    assert role.get_buffer_tracker() is not None
+    assert role.get_buffer_tracker().buffered_bytes == 0  # type: ignore[union-attr]
+
+
+def test_visualizer_role_resets_buffer_tracker_on_stream_end() -> None:
+    """on_stream_end() resets the buffer tracker."""
+    client = _make_client_stub()
+    role = VisualizerDraftR1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+
+    tracker = role.get_buffer_tracker()
+    assert tracker is not None
+
+    role.on_stream_end()
+    assert role.get_buffer_tracker() is not None
+    assert role.get_buffer_tracker().buffered_bytes == 0  # type: ignore[union-attr]
+
+
+def test_visualizer_role_stream_start_is_resent_after_stream_end() -> None:
+    """A new stream/start must be sent again after stream/end."""
+    client = _make_client_stub()
+    role = VisualizerDraftR1Role(client=client)
+    role.on_connect()
+
+    role.on_stream_start()
+    role.on_stream_end()
+    role.on_stream_start()
+
+    stream_start_calls = [
+        call
+        for call in client.send_role_message.call_args_list
+        if isinstance(call.args[1], StreamStartMessage)
+    ]
+    assert len(stream_start_calls) == 2
+
+
+def test_visualizer_role_stream_start_skipped_after_stream_clear() -> None:
+    """stream/clear preserves stream/start config, so no resend is needed."""
+    client = _make_client_stub()
+    role = VisualizerDraftR1Role(client=client)
+    role.on_connect()
+
+    role.on_stream_start()
+    role.on_stream_clear()
+    role.on_stream_start()
+
+    stream_start_calls = [
+        call
+        for call in client.send_role_message.call_args_list
+        if isinstance(call.args[1], StreamStartMessage)
+    ]
+    assert len(stream_start_calls) == 1
+
+
+def test_visualizer_role_resets_binary_timing_on_stream_start() -> None:
+    """on_stream_start() resets binary timing for fresh grace window."""
+    client = _make_client_stub()
+    role = VisualizerDraftR1Role(client=client)
+    role.on_connect()
+
+    # Simulate stale timing from a previous stream
+    role._stream_start_time_us = 1_000_000  # noqa: SLF001
+
+    role.on_stream_start()
+
+    assert role._stream_start_time_us is None  # noqa: SLF001
+
+
+def test_visualizer_role_resets_binary_timing_on_disconnect() -> None:
+    """on_disconnect() resets binary timing to avoid stale grace period."""
+    client = _make_client_stub()
+    role = VisualizerDraftR1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+
+    role._stream_start_time_us = 5_000_000  # noqa: SLF001
+
+    role.on_disconnect()
+
+    assert role._stream_start_time_us is None  # noqa: SLF001
+
+
+def test_visualizer_role_audio_chunk_without_stream_start_is_noop() -> None:
+    """on_audio_chunk() before on_stream_start() does not send data or self-initialize."""
+    client = _make_client_stub()
+    role = VisualizerDraftR1Role(client=client)
+    role.on_connect()
+
+    pcm = sine_pcm_16bit(sample_rate=48_000, channels=2, hz=1000.0, duration_s=0.025)
+    role.on_audio_chunk(
+        AudioChunk(
+            data=pcm,
+            timestamp_us=1_000_000,
+            duration_us=25_000,
+            byte_count=len(pcm),
+        )
+    )
+
+    # Should not have sent binary data or stream/start
+    client.send_binary.assert_not_called()
+    # Should not have self-initialized the extractor
+    assert role._extractor is None  # noqa: SLF001

--- a/tests/server/test_multi_server.py
+++ b/tests/server/test_multi_server.py
@@ -333,7 +333,7 @@ class TestCustomRoleSupportParsing:
                 "visualizer@_custom_version",
                 "visualizer@_custom_version_support",
                 "visualizer_support",
-                {"buffer_capacity": 100_000},
+                {"buffer_capacity": 100_000, "rate_max": 30, "types": ["loudness"]},
             ),
         ],
     )
@@ -431,11 +431,11 @@ class TestCustomRoleSupportParsing:
                     "client_id": "c1",
                     "name": "Client",
                     "version": 1,
-                    "supported_roles": ["visualizer@_draft_r1"],
+                    "supported_roles": ["visualizer@_custom_r1"],
                     "visualizer_support": {
                         "types": ["loudness", "f_peak"],
                         "buffer_capacity": 65536,
-                        "batch_max": 8,
+                        "rate_max": 30,
                     },
                 },
             }
@@ -539,6 +539,29 @@ class TestCustomRoleSupportParsing:
 
         with pytest.raises(ValueError, match="player@v2_support"):
             SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
+
+    def test_legacy_family_support_key_used_for_custom_role(self) -> None:
+        """A client that sends the legacy <family>_support key still binds for custom roles."""
+        raw = orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "c1",
+                    "name": "Client",
+                    "version": 1,
+                    "supported_roles": ["visualizer@v1", "visualizer@_custom_legacy"],
+                    "visualizer_support": {
+                        "types": ["loudness"],
+                        "buffer_capacity": 65_536,
+                        "rate_max": 30,
+                    },
+                },
+            }
+        ).decode()
+
+        msg = SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
+        assert isinstance(msg, ClientHelloMessage)
+        assert msg.payload.visualizer_support is not None
 
 
 class TestClientUrlRegistration:

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -113,14 +113,24 @@ class _FakeConnection:
 
 
 class _DummyRole:
-    def __init__(self, requirements: AudioRequirements, *, static_delay_us: int = 0) -> None:
+    def __init__(
+        self,
+        requirements: AudioRequirements,
+        *,
+        static_delay_us: int = 0,
+        replay_from_pcm_cache: bool = False,
+    ) -> None:
         self._requirements = requirements
         self._static_delay_us = static_delay_us
+        self._replay_from_pcm_cache = replay_from_pcm_cache
         self.received: list[AudioChunk] = []
         self.started = 0
 
     def get_audio_requirements(self) -> AudioRequirements | None:
         return self._requirements
+
+    def replay_from_pcm_cache(self) -> bool:
+        return self._replay_from_pcm_cache
 
     def get_static_delay_us(self) -> int:
         return self._static_delay_us
@@ -2428,6 +2438,117 @@ async def test_catchup_quantizer_does_not_share_live_cache(
         f"Expected 0 drift-triggered rebuilds during catch-up, got {catchup_drifts} "
         f"(likely shared quantizer cache causing timestamp jump)"
     )
+
+
+async def test_replay_from_pcm_cache_overrides_established_resampler_skip() -> None:
+    """Late join with an established resampler at the role's shape.
+
+    A live role builds a resampler at 48k/16/2. When a second role joins with
+    that same target shape, the established-resampler guard normally skips PCM
+    replay (re-running the shared resampler would shift the live role's audio).
+    Analysis-only roles opt in via `replay_from_pcm_cache()` so they get the
+    buffered PCM immediately instead of waiting for the next live commit, which
+    may sit far ahead behind a producer buffer.
+
+    Asserts the flag is the only thing that flips the decision: same scenario,
+    replay=True is fed cached audio; replay=False is not.
+    """
+
+    class TransformerA:
+        pending_timestamp_us: int | None = None
+
+        @property
+        def frame_duration_us(self) -> int:
+            return 25_000
+
+        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[tuple[bytes, int]]:
+            return [(pcm, 25_000)]
+
+        def flush(self) -> list[tuple[bytes, int]]:
+            return []
+
+        def get_header(self) -> bytes | None:
+            return None
+
+        def reset(self) -> None:
+            return
+
+    group = _DummyGroup(clients=[])
+    live_role = _DummyRole(
+        AudioRequirements(
+            sample_rate=48_000,
+            bit_depth=16,
+            channels=2,
+            transformer=TransformerA(),
+            channel_id=MAIN_CHANNEL,
+            frame_duration_us=25_000,
+        )
+    )
+    group.clients.append(_DummyClient([live_role]))
+
+    loop = asyncio.get_running_loop()
+    clock = ManualClock(now_us_value=0)
+    stream = PushStream(loop=loop, clock=clock, group=group)
+    stream.enable_pcm_cache_for_channel(MAIN_CHANNEL)
+
+    for _ in range(4):
+        stream.prepare_audio(
+            bytes(9600),  # 25ms @ 48kHz stereo f32
+            AudioFormat(sample_rate=48_000, bit_depth=32, channels=2, sample_type="float"),
+        )
+        await stream.commit_audio()
+        clock.advance_us(25_000)
+
+    # Force the guarded branch: pretend a non-passthrough resampler already
+    # exists at the joining role's target shape. Without the opt-out this
+    # short-circuits PCM replay.
+    stream._has_established_resampler_for = lambda *_a, **_k: True  # type: ignore[method-assign]  # noqa: SLF001
+
+    # Analysis-only joiner (no transformer => distinct TransformKey from the
+    # live role) that opts into PCM-cache replay.
+    viz_role = _DummyRole(
+        AudioRequirements(
+            sample_rate=48_000,
+            bit_depth=16,
+            channels=2,
+            channel_id=MAIN_CHANNEL,
+            frame_duration_us=25_000,
+        ),
+        replay_from_pcm_cache=True,
+    )
+    group.clients.append(_DummyClient([viz_role]))
+    stream.on_role_join(viz_role)
+
+    for _ in range(50):
+        if viz_role.received:
+            break
+        await asyncio.sleep(0.01)
+
+    assert viz_role.received, "replay_from_pcm_cache role should receive buffered PCM on late join"
+
+    # Control: same scenario, replay disabled => guard skips replay, no audio.
+    class TransformerB(TransformerA):
+        pass
+
+    plain_role = _DummyRole(
+        AudioRequirements(
+            sample_rate=48_000,
+            bit_depth=16,
+            channels=2,
+            transformer=TransformerB(),
+            channel_id=MAIN_CHANNEL,
+            frame_duration_us=25_000,
+        ),
+        replay_from_pcm_cache=False,
+    )
+    group.clients.append(_DummyClient([plain_role]))
+    stream.on_role_join(plain_role)
+
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+
+    assert not plain_role.received, "replay-disabled role must not get historical replay"
+    assert plain_role.started >= 1, "replay-disabled role should still be started for live audio"
 
 
 def test_noop_resample_bypasses_graph_construction(

--- a/tests/test_client_visualizer_parsing.py
+++ b/tests/test_client_visualizer_parsing.py
@@ -1,62 +1,242 @@
-"""Tests for strict client-side visualizer payload parsing."""
+"""Tests for strict client-side visualizer payload parsing (v1 wire)."""
 
 from __future__ import annotations
 
 import struct
 
+import pytest
+
 from aiosendspin.client.client import SendspinClient
+from aiosendspin.models.types import BinaryMessageType, Roles
+from aiosendspin.models.visualizer import (
+    ClientHelloVisualizerSpectrum,
+    ClientHelloVisualizerSupport,
+    StreamStartVisualizer,
+    VisualizerFrame,
+)
 
 
-def _build_payload(
+def _basic_config(
     *,
-    frame_count: int,
-    timestamp_us: int = 1_000_000,
-    loudness: int = 1000,
-    f_peak: int = 2000,
-) -> bytes:
-    payload = bytearray()
-    payload.append(frame_count)
-    for _ in range(frame_count):
-        payload.extend(struct.pack(">q", timestamp_us))
-        payload.extend(struct.pack(">H", loudness))
-        payload.extend(struct.pack(">H", f_peak))
-    return bytes(payload)
+    types: tuple[str, ...] = ("loudness",),
+    n_disp_bins: int = 8,
+) -> StreamStartVisualizer:
+    spectrum: ClientHelloVisualizerSpectrum | None = None
+    if "spectrum" in types:
+        spectrum = ClientHelloVisualizerSpectrum(
+            n_disp_bins=n_disp_bins, scale="lin", f_min=20, f_max=16_000
+        )
+    # The parser only consults `types` + spectrum metadata to validate frame
+    # widths, so the rest of the config can stay at defaults.
+    return StreamStartVisualizer(types=types, rate_max=30, spectrum=spectrum)  # type: ignore[arg-type]
 
 
-def test_parse_visualization_frames_strict_layout() -> None:
-    """Parses strict payload format [frame_count, frames...]."""
-    payload = _build_payload(frame_count=1)
-    frames = SendspinClient._parse_visualization_frames(  # noqa: SLF001
-        payload, ["loudness", "f_peak"], 0
+# ---------------------------------------------------------------------------
+# loudness (msg 16)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_loudness_frame() -> None:
+    """Parse loudness frame."""
+    payload = struct.pack(">q", 1_234_000) + struct.pack(">H", 12345)
+    cfg = _basic_config()
+    frame = SendspinClient._parse_visualization_frame(  # noqa: SLF001
+        BinaryMessageType.VISUALIZATION_LOUDNESS, payload, cfg
+    )
+    assert frame is not None
+    assert frame.timestamp_us == 1_234_000
+    assert frame.loudness == 12345
+
+
+def test_parse_loudness_frame_rejects_wrong_length() -> None:
+    """Parse loudness frame rejects wrong length."""
+    cfg = _basic_config()
+    bad = struct.pack(">q", 1) + b"\x00"  # only 1 byte of data instead of 2
+    assert (
+        SendspinClient._parse_visualization_frame(  # noqa: SLF001
+            BinaryMessageType.VISUALIZATION_LOUDNESS, bad, cfg
+        )
+        is None
     )
 
-    assert len(frames) == 1
-    assert frames[0].timestamp_us == 1_000_000
-    assert frames[0].loudness == 1000
-    assert frames[0].f_peak == 2000
+
+# ---------------------------------------------------------------------------
+# f_peak (msg 18)
+# ---------------------------------------------------------------------------
 
 
-def test_parse_visualization_frames_rejects_legacy_layout_with_leading_type() -> None:
-    """Legacy payload [16, frame_count, ...] is rejected in strict mode."""
-    strict = _build_payload(frame_count=1)
-    legacy = bytes([16]) + strict
-
-    frames = SendspinClient._parse_visualization_frames(  # noqa: SLF001
-        legacy, ["loudness", "f_peak"], 0
+def test_parse_f_peak_frame() -> None:
+    """Parse f peak frame."""
+    payload = struct.pack(">q", 100) + struct.pack(">HH", 1024, 0x4000)
+    cfg = _basic_config(types=("f_peak",))
+    frame = SendspinClient._parse_visualization_frame(  # noqa: SLF001
+        BinaryMessageType.VISUALIZATION_F_PEAK, payload, cfg
     )
-    assert frames == []
+    assert frame is not None
+    assert frame.f_peak_freq == 1024
+    assert frame.f_peak_amp == 0x4000
 
 
-def test_parse_visualization_frames_rejects_incomplete_payload() -> None:
-    """Incomplete frame payload is rejected."""
-    payload = _build_payload(frame_count=1)[:-1]
-    frames = SendspinClient._parse_visualization_frames(  # noqa: SLF001
-        payload, ["loudness", "f_peak"], 0
+def test_parse_f_peak_rejects_wrong_length() -> None:
+    """Parse f peak rejects wrong length."""
+    cfg = _basic_config(types=("f_peak",))
+    bad = struct.pack(">q", 1) + struct.pack(">H", 100)  # missing amp
+    assert (
+        SendspinClient._parse_visualization_frame(  # noqa: SLF001
+            BinaryMessageType.VISUALIZATION_F_PEAK, bad, cfg
+        )
+        is None
     )
-    assert frames == []
 
 
-def test_parse_visualization_frames_zero_frames_is_empty() -> None:
-    """Zero frame payload parses as empty list."""
-    frames = SendspinClient._parse_visualization_frames(b"\x00", ["loudness", "f_peak"], 0)  # noqa: SLF001
-    assert frames == []
+# ---------------------------------------------------------------------------
+# spectrum (msg 19)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_spectrum_frame() -> None:
+    """Parse spectrum frame."""
+    bins = list(range(8))
+    payload = struct.pack(">q", 42) + struct.pack(">8H", *bins)
+    cfg = _basic_config(types=("spectrum",), n_disp_bins=8)
+    frame = SendspinClient._parse_visualization_frame(  # noqa: SLF001
+        BinaryMessageType.VISUALIZATION_SPECTRUM, payload, cfg
+    )
+    assert frame is not None
+    assert frame.spectrum == bins
+
+
+def test_parse_spectrum_rejects_wrong_bin_count() -> None:
+    """Parse spectrum rejects wrong bin count."""
+    payload = struct.pack(">q", 0) + struct.pack(">4H", 1, 2, 3, 4)
+    cfg = _basic_config(types=("spectrum",), n_disp_bins=8)
+    assert (
+        SendspinClient._parse_visualization_frame(  # noqa: SLF001
+            BinaryMessageType.VISUALIZATION_SPECTRUM, payload, cfg
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# peak (msg 20)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_peak_frame() -> None:
+    """Parse peak frame."""
+    payload = struct.pack(">q", 99) + bytes([0xC8])
+    cfg = _basic_config(types=("peak",))
+    frame = SendspinClient._parse_visualization_frame(  # noqa: SLF001
+        BinaryMessageType.VISUALIZATION_PEAK, payload, cfg
+    )
+    assert frame is not None
+    assert frame.peak_strength == 0xC8
+
+
+# ---------------------------------------------------------------------------
+# pitch (msg 21)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_pitch_frame() -> None:
+    """Parse pitch frame."""
+    # A4 = MIDI 69 → 0x4500. Confidence 200.
+    payload = struct.pack(">q", 1) + struct.pack(">H", 0x4500) + bytes([200])
+    cfg = _basic_config(types=("pitch",))
+    frame = SendspinClient._parse_visualization_frame(  # noqa: SLF001
+        BinaryMessageType.VISUALIZATION_PITCH, payload, cfg
+    )
+    assert frame is not None
+    assert frame.pitch_midi_q88 == 0x4500
+    assert frame.pitch_confidence == 200
+
+
+def test_parse_pitch_rejects_wrong_length() -> None:
+    """Parse pitch rejects wrong length."""
+    cfg = _basic_config(types=("pitch",))
+    bad = struct.pack(">q", 1) + struct.pack(">H", 0x4500)  # missing confidence byte
+    assert (
+        SendspinClient._parse_visualization_frame(  # noqa: SLF001
+            BinaryMessageType.VISUALIZATION_PITCH, bad, cfg
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# beat (msg 17) — delivered through the visualizer callback
+# ---------------------------------------------------------------------------
+
+
+def _client_with_visualizer_callback() -> tuple[SendspinClient, list[VisualizerFrame]]:
+    support = ClientHelloVisualizerSupport(
+        types=["loudness", "beat"], buffer_capacity=65536, rate_max=30
+    )
+    client = SendspinClient(
+        client_id="x",
+        client_name="x",
+        roles=[Roles.VISUALIZER],
+        visualizer_support=support,
+    )
+    received: list[VisualizerFrame] = []
+
+    def _cb(frames: list[VisualizerFrame]) -> None:
+        received.extend(frames)
+
+    client.add_visualizer_listener(_cb)
+    return client, received
+
+
+@pytest.mark.asyncio
+async def test_handle_beat_dispatches_downbeat_frame() -> None:
+    """Downbeat byte sets is_downbeat=True on the dispatched frame."""
+    client, received = _client_with_visualizer_callback()
+    body = struct.pack(">q", 100) + bytes([0b0000_0001])
+    client._handle_visualization_beat(body)  # noqa: SLF001
+    assert len(received) == 1
+    assert received[0].timestamp_us == 100
+    assert received[0].is_downbeat is True
+
+
+@pytest.mark.asyncio
+async def test_handle_beat_dispatches_regular_frame() -> None:
+    """Flags=0 dispatches is_downbeat=False."""
+    client, received = _client_with_visualizer_callback()
+    body = struct.pack(">q", 200) + bytes([0])
+    client._handle_visualization_beat(body)  # noqa: SLF001
+    assert len(received) == 1
+    assert received[0].timestamp_us == 200
+    assert received[0].is_downbeat is False
+
+
+@pytest.mark.asyncio
+async def test_handle_beat_rejects_wrong_length() -> None:
+    """Body without the trailing flag byte is dropped silently."""
+    client, received = _client_with_visualizer_callback()
+    client._handle_visualization_beat(struct.pack(">q", 100))  # noqa: SLF001
+    assert received == []
+
+
+@pytest.mark.asyncio
+async def test_handle_beat_rejects_empty_payload() -> None:
+    """Empty body is dropped silently."""
+    client, received = _client_with_visualizer_callback()
+    client._handle_visualization_beat(b"")  # noqa: SLF001
+    assert received == []
+
+
+# ---------------------------------------------------------------------------
+# Truncated header
+# ---------------------------------------------------------------------------
+
+
+def test_parse_visualization_frame_rejects_truncated_header() -> None:
+    """Parse visualization frame rejects truncated header."""
+    cfg = _basic_config()
+    assert (
+        SendspinClient._parse_visualization_frame(  # noqa: SLF001
+            BinaryMessageType.VISUALIZATION_LOUDNESS, b"\x00\x01", cfg
+        )
+        is None
+    )


### PR DESCRIPTION
Implements the `visualizer@v1` role: the server computes audio features (loudness, spectrum, dominant frequency, onset peaks, pitch, and beats) and streams them to visualizer clients as per-frame binary messages, replacing the batched `_draft_r1` blob. Legacy `visualizer@_draft_r1` clients are still accepted.

Spec:

* https://github.com/Sendspin/spec/pull/86

Beats come from server-fed offline analysis via `append_beat_schedule` and ride the wire interleaved with periodic frames in timestamp order. `beat` is deferred from `stream/start` until the first schedule lands.

### Late join and pacing
A visualizer grouped onto an active stream now receives buffered audio immediately instead of waiting up to the producer-buffer depth (about 30s) for the first FFT frames. While a beat schedule is still computing, periodic frames are not sent too far in advance (only 3s or so). This ensures that all visualizer data keeps having non-decreasing timestamps and still appears as fast as possible for clients.

### Optional `pitch` computation
`SendspinServer.set_visualizer_pitch_enabled(enabled=False)` drops the heaviest feature (YINFFT) server wide for if it turns out to be too computationally intensive. Quality of `pitch` data and algorithm also needs to be tested more.
All other data is rather simple to compute since FFT constants (Hanning window, frequency grid, spectrum bin assignment) are cached so steady per-frame cost stays low.

### Breaking changes

`Roles.VISUALIZER` switches to `"visualizer@v1"` and the exported visualizer models (`VisualizerFrame`, `ClientHelloVisualizerSupport`, `StreamStartVisualizer.from_support`) are updated to the newer spec version. Connected clients stay backwards-compatible. `visualizer@_draft_r1` remains registered and keeps working as before.