### PR TITLE
Fix spec conformance gaps and align time filter with C++ reference

### DIFF
--- a/aiosendspin/client/client.py
+++ b/aiosendspin/client/client.py
@@ -857,14 +857,22 @@ class SendspinClient:
             logger.warning("Unknown binary message type: %s", raw_type)
             return
 
-        if (
-            not self._stream_active
-            and not self._visualizer_stream_active
-            and not self._artwork_stream_active
-        ):
-            logger.debug(
-                "Ignoring binary message of type %s since no stream is active", message_type
-            )
+        role_active = {
+            BinaryMessageType.AUDIO_CHUNK: self._stream_active,
+            BinaryMessageType.ARTWORK_CHANNEL_0: self._artwork_stream_active,
+            BinaryMessageType.ARTWORK_CHANNEL_1: self._artwork_stream_active,
+            BinaryMessageType.ARTWORK_CHANNEL_2: self._artwork_stream_active,
+            BinaryMessageType.ARTWORK_CHANNEL_3: self._artwork_stream_active,
+            BinaryMessageType.VISUALIZATION_LOUDNESS: self._visualizer_stream_active,
+            BinaryMessageType.VISUALIZATION_BEAT: self._visualizer_stream_active,
+            BinaryMessageType.VISUALIZATION_F_PEAK: self._visualizer_stream_active,
+            BinaryMessageType.VISUALIZATION_SPECTRUM: self._visualizer_stream_active,
+            BinaryMessageType.VISUALIZATION_PEAK: self._visualizer_stream_active,
+            BinaryMessageType.VISUALIZATION_PITCH: self._visualizer_stream_active,
+        }.get(message_type, False)
+
+        if not role_active:
+            logger.debug("Ignoring binary message of type %s — role stream inactive", message_type)
             return
 
         if message_type is BinaryMessageType.AUDIO_CHUNK:

--- a/aiosendspin/client/time_sync.py
+++ b/aiosendspin/client/time_sync.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 
-# Residual threshold as fraction of max_error for triggering adaptive forgetting.
+# Residual threshold as multiple of max_error for triggering adaptive forgetting.
 # When residual > CUTOFF * max_error, the filter applies forgetting to recover from outliers.
 ADAPTIVE_FORGETTING_CUTOFF = 3.0
 

--- a/aiosendspin/client/time_sync.py
+++ b/aiosendspin/client/time_sync.py
@@ -255,6 +255,7 @@ class SendspinTimeFilter:
     def reset(self) -> None:
         """Reset the filter state."""
         self._count = 0
+        self._last_update = 0
         self._offset = 0.0
         self._drift = 0.0
         self._offset_covariance = math.inf

--- a/aiosendspin/client/time_sync.py
+++ b/aiosendspin/client/time_sync.py
@@ -14,6 +14,10 @@ from dataclasses import dataclass
 # When residual > CUTOFF * max_error, the filter applies forgetting to recover from outliers.
 ADAPTIVE_FORGETTING_CUTOFF = 0.75
 
+# Scale factor applied to max_error before it is used as the measurement standard deviation.
+# Values < 1 indicate the round-trip half-delay overestimates true measurement noise.
+MAX_ERROR_SCALE = 0.5
+
 
 @dataclass(slots=True)
 class TimeElement:
@@ -95,7 +99,7 @@ class SendspinTimeFilter:
         dt: float = float(time_added - self._last_update)
         self._last_update = time_added
 
-        update_std_dev: float = float(max_error)
+        update_std_dev: float = float(max_error) * MAX_ERROR_SCALE
         measurement_variance: float = update_std_dev * update_std_dev
 
         # Filter initialization: First measurement establishes offset baseline

--- a/aiosendspin/client/time_sync.py
+++ b/aiosendspin/client/time_sync.py
@@ -81,8 +81,8 @@ class SendspinTimeFilter:
             time_added: Client timestamp when this measurement was taken in
                 microseconds.
         """
-        if time_added == self._last_update:
-            # Skip duplicate timestamps to avoid division by zero in drift calculation
+        if time_added <= self._last_update:
+            # Skip non-monotonic timestamps to guard against backwards dt in predict
             return
 
         dt: float = float(time_added - self._last_update)

--- a/aiosendspin/client/time_sync.py
+++ b/aiosendspin/client/time_sync.py
@@ -18,6 +18,10 @@ ADAPTIVE_FORGETTING_CUTOFF = 0.75
 # Values < 1 indicate the round-trip half-delay overestimates true measurement noise.
 MAX_ERROR_SCALE = 0.5
 
+# SNR threshold for applying drift compensation in time conversions.
+# Drift is only used when drift^2 > threshold^2 * drift_covariance.
+DRIFT_SIGNIFICANCE_THRESHOLD_SQUARED = 2.0 * 2.0
+
 
 @dataclass(slots=True)
 class TimeElement:
@@ -26,6 +30,7 @@ class TimeElement:
     last_update: int = 0
     offset: float = 0.0
     drift: float = 0.0
+    use_drift: bool = False
 
 
 class SendspinTimeFilter:
@@ -200,10 +205,17 @@ class SendspinTimeFilter:
         )
         self._offset_covariance = new_offset_covariance - offset_gain * new_offset_covariance
 
+        # SNR gate: only apply drift when statistically significant
+        use_drift: bool = (
+            self._drift * self._drift
+            > DRIFT_SIGNIFICANCE_THRESHOLD_SQUARED * self._drift_covariance
+        )
+
         self._current_time_element = TimeElement(
             last_update=self._last_update,
             offset=self._offset,
             drift=self._drift,
+            use_drift=use_drift,
         )
 
     def compute_server_time(self, client_time: int) -> int:
@@ -228,9 +240,11 @@ class SendspinTimeFilter:
         # offset(t) = offset_base + drift * (t - t_last_update)
 
         # Retrieve latest time transformation parameters
+        element = self._current_time_element
+        effective_drift = element.drift if element.use_drift else 0.0
 
-        dt = float(client_time - self._current_time_element.last_update)
-        offset = round(self._current_time_element.offset + self._current_time_element.drift * dt)
+        dt = float(client_time - element.last_update)
+        offset = round(element.offset + effective_drift * dt)
         return client_time + offset
 
     def compute_client_time(self, server_time: int) -> int:
@@ -254,14 +268,12 @@ class SendspinTimeFilter:
         # T_server = T_client + offset + drift * (T_client - T_last_update)
         # T_server = (1 + drift) * T_client + offset - drift * T_last_update
         # T_client = (T_server - offset + drift * T_last_update) / (1 + drift)
+        element = self._current_time_element
+        effective_drift = element.drift if element.use_drift else 0.0
 
         return round(
-            (
-                float(server_time)
-                - self._current_time_element.offset
-                + self._current_time_element.drift * self._current_time_element.last_update
-            )
-            / (1.0 + self._current_time_element.drift)
+            (float(server_time) - element.offset + effective_drift * element.last_update)
+            / (1.0 + effective_drift)
         )
 
     def reset(self) -> None:

--- a/aiosendspin/client/time_sync.py
+++ b/aiosendspin/client/time_sync.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 
 # Residual threshold as fraction of max_error for triggering adaptive forgetting.
 # When residual > CUTOFF * max_error, the filter applies forgetting to recover from outliers.
-ADAPTIVE_FORGETTING_CUTOFF = 0.75
+ADAPTIVE_FORGETTING_CUTOFF = 3.0
 
 # Scale factor applied to max_error before it is used as the measurement standard deviation.
 # Values < 1 indicate the round-trip half-delay overestimates true measurement noise.
@@ -66,8 +66,8 @@ class SendspinTimeFilter:
 
     def __init__(
         self,
-        process_std_dev: float = 0.01,
-        forget_factor: float = 1.001,
+        process_std_dev: float = 0.0,
+        forget_factor: float = 2.0,
         drift_process_std_dev: float = 1e-11,
     ) -> None:
         """Initialise the Kalman filter with noise and forgetting parameters."""

--- a/aiosendspin/client/time_sync.py
+++ b/aiosendspin/client/time_sync.py
@@ -50,13 +50,20 @@ class SendspinTimeFilter:
     _drift_covariance: float = 0.0
 
     _process_variance: float
+    _drift_process_variance: float
     _forget_variance_factor: float
 
     _current_time_element: TimeElement
 
-    def __init__(self, process_std_dev: float = 0.01, forget_factor: float = 1.001) -> None:
+    def __init__(
+        self,
+        process_std_dev: float = 0.01,
+        forget_factor: float = 1.001,
+        drift_process_std_dev: float = 1e-11,
+    ) -> None:
         """Initialise the Kalman filter with noise and forgetting parameters."""
         self._process_variance = process_std_dev * process_std_dev
+        self._drift_process_variance = drift_process_std_dev * drift_process_std_dev
         self._forget_variance_factor = forget_factor * forget_factor
         self._current_time_element = TimeElement()
 
@@ -135,8 +142,9 @@ class SendspinTimeFilter:
         # State transition matrix F = [1, dt; 0, 1]
         dt_squared: float = dt * dt
 
-        # Process noise only applied to offset (modeling clock jitter/wander)
-        drift_process_variance: float = 0.0  # Drift assumed stable
+        # Process noise for both offset and drift (full random walk model).
+        # Independent clock jitter (offset noise) and wander (drift noise).
+        drift_process_variance: float = dt * self._drift_process_variance
         new_drift_covariance: float = self._drift_covariance + drift_process_variance
 
         offset_drift_process_variance: float = 0.0

--- a/aiosendspin/models/__init__.py
+++ b/aiosendspin/models/__init__.py
@@ -62,7 +62,7 @@ class BinaryHeader(NamedTuple):
     """Header structure for binary messages."""
 
     message_type: int  # message type identifier (B - unsigned char)
-    timestamp_us: int  # timestamp in microseconds (Q - unsigned long long)
+    timestamp_us: int  # timestamp in microseconds (q - signed long long)
 
 
 def unpack_binary_header(data: bytes) -> BinaryHeader:

--- a/aiosendspin/models/core.py
+++ b/aiosendspin/models/core.py
@@ -534,14 +534,19 @@ class StreamClearPayload(DataClassORJSONMixin):
     """Roles to clear: player, visualizer, or both. If omitted, clears both roles."""
 
     def __post_init__(self) -> None:
-        """Validate that only player and visualizer role families are specified."""
+        """Validate role names. Permits known families and `_`-prefixed app roles."""
         if self.roles is not None:
-            invalid_roles = set(self.roles) - STREAM_CLEAR_ROLE_FAMILIES
+            invalid_roles = {
+                role
+                for role in self.roles
+                if role not in STREAM_CLEAR_ROLE_FAMILIES and not role.startswith("_")
+            }
             if invalid_roles:
                 supported = sorted(STREAM_CLEAR_ROLE_FAMILIES)
                 invalid = sorted(invalid_roles)
                 raise ValueError(
-                    f"stream/clear only supports roles {supported}, got invalid roles: {invalid}"
+                    f"stream/clear only supports roles {supported} or `_`-prefixed "
+                    f"application roles, got invalid roles: {invalid}"
                 )
 
     class Config(BaseConfig):
@@ -593,14 +598,19 @@ class StreamEndPayload(DataClassORJSONMixin):
     """Roles to end streams for. If omitted, ends all active streams."""
 
     def __post_init__(self) -> None:
-        """Validate that only known role families are specified."""
+        """Validate role names. Permits known families and `_`-prefixed app roles."""
         if self.roles is not None:
-            invalid_roles = set(self.roles) - STREAM_END_ROLE_FAMILIES
+            invalid_roles = {
+                role
+                for role in self.roles
+                if role not in STREAM_END_ROLE_FAMILIES and not role.startswith("_")
+            }
             if invalid_roles:
                 supported = sorted(STREAM_END_ROLE_FAMILIES)
                 invalid = sorted(invalid_roles)
                 raise ValueError(
-                    f"stream/end only supports roles {supported}, got invalid roles: {invalid}"
+                    f"stream/end only supports roles {supported} or `_`-prefixed "
+                    f"application roles, got invalid roles: {invalid}"
                 )
 
     class Config(BaseConfig):

--- a/aiosendspin/models/player.py
+++ b/aiosendspin/models/player.py
@@ -86,18 +86,16 @@ class PlayerStatePayload(DataClassORJSONMixin):
     """Volume range 0-100, only included if 'volume' in supported_commands."""
     muted: bool | None = None
     """Mute state, only included if 'mute' in supported_commands."""
-    static_delay_ms: int = 0
+    static_delay_ms: int | None = None
     """Static delay in milliseconds (0-5000), always present for players."""
-    # TODO: drop default once all clients report this field per spec.
-    required_lead_time_ms: int = 250
+    required_lead_time_ms: int | None = None
     """Minimum startup lead time in milliseconds (0-30000), always present for players.
 
     Measured from the server transmit time of the start/restart trigger (stream/start
     or stream/clear) to the timestamp of the first subsequent audio chunk. Covers codec
     init, decode warmup, audio backend buffering, and DAC latency. Excludes static_delay_ms.
     """
-    # TODO: drop default once all clients report this field per spec.
-    min_buffer_ms: int = 250
+    min_buffer_ms: int | None = None
     """Requested minimum ongoing buffer duration in milliseconds (0-30000).
 
     Maintained during playback (primarily for live streams) to absorb network jitter and
@@ -110,13 +108,13 @@ class PlayerStatePayload(DataClassORJSONMixin):
         """Validate field values."""
         if self.volume is not None and not 0 <= self.volume <= 100:
             raise ValueError(f"Volume must be in range 0-100, got {self.volume}")
-        if not 0 <= self.static_delay_ms <= 5000:
+        if self.static_delay_ms is not None and not 0 <= self.static_delay_ms <= 5000:
             raise ValueError(f"static_delay_ms must be in range 0-5000, got {self.static_delay_ms}")
-        if not 0 <= self.required_lead_time_ms <= 30000:
+        if self.required_lead_time_ms is not None and not 0 <= self.required_lead_time_ms <= 30000:
             raise ValueError(
                 f"required_lead_time_ms must be in range 0-30000, got {self.required_lead_time_ms}"
             )
-        if not 0 <= self.min_buffer_ms <= 30000:
+        if self.min_buffer_ms is not None and not 0 <= self.min_buffer_ms <= 30000:
             raise ValueError(f"min_buffer_ms must be in range 0-30000, got {self.min_buffer_ms}")
         VALID_STATE_COMMANDS = {PlayerCommand.SET_STATIC_DELAY}  # noqa: N806
         if self.supported_commands:

--- a/aiosendspin/models/player.py
+++ b/aiosendspin/models/player.py
@@ -87,16 +87,19 @@ class PlayerStatePayload(DataClassORJSONMixin):
     muted: bool | None = None
     """Mute state, only included if 'mute' in supported_commands."""
     static_delay_ms: int | None = None
-    """Static delay in milliseconds (0-5000), always present for players."""
+    """Static delay in milliseconds (0-5000). Required on the initial state message;
+    omitted in incremental updates means unchanged."""
     required_lead_time_ms: int | None = None
-    """Minimum startup lead time in milliseconds (0-30000), always present for players.
+    """Minimum startup lead time in milliseconds (0-30000). Required on the initial state
+    message; omitted in incremental updates means unchanged.
 
     Measured from the server transmit time of the start/restart trigger (stream/start
     or stream/clear) to the timestamp of the first subsequent audio chunk. Covers codec
     init, decode warmup, audio backend buffering, and DAC latency. Excludes static_delay_ms.
     """
     min_buffer_ms: int | None = None
-    """Requested minimum ongoing buffer duration in milliseconds (0-30000).
+    """Requested minimum ongoing buffer duration in milliseconds (0-30000). Required on
+    the initial state message; omitted in incremental updates means unchanged.
 
     Maintained during playback (primarily for live streams) to absorb network jitter and
     decode/playback timing variance. Excludes static_delay_ms.

--- a/aiosendspin/server/audio.py
+++ b/aiosendspin/server/audio.py
@@ -184,14 +184,15 @@ class BufferTracker:
         if bytes_needed <= 0:
             return True
         if bytes_needed >= self.capacity_bytes:
-            # Chunk exceeds capacity, but allow it through
             logger.warning(
-                "Chunk size %s exceeds reported buffer capacity %s for client %s",
+                "Chunk size %s exceeds reported buffer capacity %s for client %s "
+                "— blocking until buffer drains",
                 bytes_needed,
                 self.capacity_bytes,
                 self.client_id,
             )
-            return True
+            self.prune_consumed()
+            return self.buffered_bytes == 0
 
         self.prune_consumed()
         projected_usage = self.buffered_bytes + bytes_needed
@@ -276,20 +277,25 @@ class BufferTracker:
         """
         Calculate time in microseconds until the buffer can accept bytes_needed more bytes.
 
-        Returns 0 if bytes_needed <= 0 (immediate capacity) or bytes_needed >= capacity_bytes
-        (chunk exceeds capacity but is allowed through anyway).
+        Returns 0 if bytes_needed <= 0 (immediate capacity). When bytes_needed exceeds
+        capacity_bytes, returns the time needed for the buffer to fully drain so the
+        oversize chunk can be admitted alone; returns 0 only if the buffer is already empty.
         """
         if bytes_needed <= 0:
             return 0
         if bytes_needed >= self.capacity_bytes:
-            # TODO: raise exception instead?
             logger.warning(
-                "Chunk size %s exceeds reported buffer capacity %s for client %s",
+                "Chunk size %s exceeds reported buffer capacity %s for client %s "
+                "— blocking until buffer drains",
                 bytes_needed,
                 self.capacity_bytes,
                 self.client_id,
             )
-            return 0
+            cursor_time_us = self.prune_consumed()
+            if self.buffered_bytes == 0:
+                return 0
+            latest_end_us = self.buffered_chunks[-1].end_time_us
+            return max(latest_end_us - cursor_time_us, 0)
 
         # Prune consumed chunks once at the start
         cursor_time_us = self.prune_consumed()

--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -717,15 +717,4 @@ class SendspinClient:
         """Remove the client from its current group, placing it in a fresh solo group."""
         if self._group is None:
             return
-        old_group = self._group
-        if len(old_group.clients) > 1:
-            await old_group.remove_client(self)
-            return
-        # Solo source: evict directly and finalize the now-empty group. The new
-        # SendspinGroup() below triggers _set_group on us, which unregisters
-        # events from old_group.
-        from .group import SendspinGroup  # noqa: PLC0415  # avoid circular import
-
-        old_group._clients.remove(self)  # noqa: SLF001
-        old_group._finalize_empty_group()  # noqa: SLF001
-        SendspinGroup(self._server, self)
+        await self._group.remove_client(self)

--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -22,8 +22,10 @@ from aiosendspin.models.types import (
     BinaryMessageType,
     ClientStateType,
     GoodbyeReason,
+    PlaybackStateType,
     Roles,
     has_role,
+    has_role_family,
 )
 from aiosendspin.util import create_task
 
@@ -100,6 +102,13 @@ class SendspinClient:
 
         # Client-level state (reported by client/state). Persists across reconnects until updated.
         self._client_state: ClientStateType = ClientStateType.SYNCHRONIZED
+
+        # External-source recovery state (persists across reconnects).
+        self._previous_group_id: str | None = None
+        """Group ID to rejoin after external_source ends."""
+        self._external_source_solo_group_id: str | None = None
+        """Solo group ID created when entering external_source."""
+        self._switch_lock: asyncio.Lock = asyncio.Lock()
 
         # Role-owned persistent state (per role family).
         self._role_state: dict[str, object] = {}
@@ -211,6 +220,166 @@ class SendspinClient:
             coro = role.on_state_transition(old_state, new_state)
             if coro is not None:
                 await coro
+
+        if new_state == ClientStateType.EXTERNAL_SOURCE:
+            await self._handle_external_source_transition()
+
+    async def _handle_external_source_transition(self) -> None:
+        """Move the client out of any shared group when it switches to external_source.
+
+        - Multi-client group: remember the previous group and move to a solo group.
+        - Solo group: stop playback so the client is no longer streaming.
+        """
+        if len(self.group.clients) > 1:
+            self._previous_group_id = self.group.group_id
+            self._logger.debug(
+                "Storing previous group %s for external_source client",
+                self._previous_group_id,
+            )
+            await self.group.remove_client(self)
+            self._external_source_solo_group_id = self.group.group_id
+            return
+
+        self._logger.debug("Client already in solo group, stopping playback for external_source")
+        await self.group.stop()
+
+    async def handle_switch_command(self) -> None:
+        """Cycle this client through available groups (spec §561-605)."""
+        if self._switch_lock.locked():
+            self._logger.debug("Ignoring switch command; switch already in progress")
+            return
+        async with self._switch_lock:
+            await self._handle_switch_command_locked()
+
+    async def _handle_switch_command_locked(self) -> None:
+        # Clients in external_source can't participate in playback.
+        if self._client_state == ClientStateType.EXTERNAL_SOURCE:
+            self._logger.debug("Ignoring switch command while client is in external_source state")
+            return
+
+        # External-source recovery takes priority over the normal cycle.
+        if await self._try_rejoin_previous_group():
+            return
+
+        current_group = self.group
+        all_groups = self._get_all_groups()
+        has_player_role = has_role_family("player", self._negotiated_roles)
+        cycle_groups = self._build_group_cycle(all_groups, current_group, has_player_role)
+
+        if not cycle_groups:
+            self._logger.debug("No groups available to switch to")
+            return
+
+        try:
+            current_index = cycle_groups.index(current_group)
+            next_index = (current_index + 1) % len(cycle_groups)
+        except ValueError:
+            next_index = 0
+
+        next_group = cycle_groups[next_index]
+
+        if next_group is None:
+            self._logger.info("Switching client %s to solo group", self._client_id)
+            await current_group.remove_client(self)
+        elif next_group != current_group:
+            self._logger.info(
+                "Switching client %s to group %s", self._client_id, next_group.group_id
+            )
+            await current_group.remove_client(self)
+            await next_group.add_client(self)
+
+    def _get_all_groups(self) -> list[SendspinGroup]:
+        """Return all unique groups across currently connected clients."""
+        groups_seen: set[str] = set()
+        unique_groups: list[SendspinGroup] = []
+        for client in self._server.connected_clients:
+            group = client.group
+            if group.group_id not in groups_seen:
+                groups_seen.add(group.group_id)
+                unique_groups.append(group)
+        return unique_groups
+
+    def _build_group_cycle(
+        self,
+        all_groups: list[SendspinGroup],
+        current_group: SendspinGroup,
+        has_player_role: bool,  # noqa: FBT001
+    ) -> list[SendspinGroup | None]:
+        """Build the switch cycle list (spec README:597-605).
+
+        ``None`` in the list represents "switch to a new solo group" for clients
+        that hold the player role.
+        """
+        multi_client_playing: list[SendspinGroup] = []
+        single_client: list[SendspinGroup] = []
+
+        for group in all_groups:
+            client_count = len(group.clients)
+            is_playing = group.state == PlaybackStateType.PLAYING
+            if client_count > 1 and is_playing:
+                if any(has_role_family("player", c.negotiated_roles) for c in group.clients):
+                    multi_client_playing.append(group)
+            elif client_count == 1 and is_playing:
+                single_client_obj = group.clients[0]
+                if group != current_group and has_role_family(
+                    "player", single_client_obj.negotiated_roles
+                ):
+                    single_client.append(group)
+
+        multi_client_playing.sort(key=lambda g: g.group_id)
+        single_client.sort(key=lambda g: g.group_id)
+
+        if has_player_role:
+            current_is_solo = len(current_group.clients) == 1
+            solo_option: list[SendspinGroup | None] = [current_group] if current_is_solo else [None]
+            return multi_client_playing + single_client + solo_option
+        return [*multi_client_playing, *single_client]
+
+    def _should_rejoin_previous_group(self) -> bool:
+        """Return True when switch should rejoin the pre-external-source group.
+
+        Per spec: if the client is still in the solo group created by its
+        ``external_source`` transition, switch prioritizes rejoining that group.
+        """
+        return (
+            self._previous_group_id is not None
+            and self._client_state != ClientStateType.EXTERNAL_SOURCE
+            and self._external_source_solo_group_id == self.group.group_id
+            and len(self.group.clients) == 1
+        )
+
+    async def _try_rejoin_previous_group(self) -> bool:
+        if not self._should_rejoin_previous_group():
+            return False
+
+        previous_group_id = self._previous_group_id
+        # Clear external_source tracking after attempt, regardless of outcome.
+        self._previous_group_id = None
+        self._external_source_solo_group_id = None
+
+        previous_group = self._find_group_by_id(previous_group_id)
+        if previous_group is not None and previous_group != self.group:
+            self._logger.info(
+                "Rejoining previous group %s after external_source", previous_group_id
+            )
+            await self.group.remove_client(self)
+            await previous_group.add_client(self)
+            return True
+
+        self._logger.debug(
+            "Previous group %s no longer exists or is current group, "
+            "falling back to normal switch cycle",
+            previous_group_id,
+        )
+        return False
+
+    def _find_group_by_id(self, group_id: str | None) -> SendspinGroup | None:
+        if group_id is None:
+            return None
+        for client in self._server.connected_clients:
+            if client.group.group_id == group_id:
+                return client.group
+        return None
 
     def check_role(self, role: Roles) -> bool:
         """Check if the client has a role active (by role family)."""

--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -545,6 +545,18 @@ class SendspinClient:
             role.on_group_changed(group)
 
     async def ungroup(self) -> None:
-        """Remove the client from the group (no-op if already solo)."""
-        if len(self.group.clients) > 1:
-            await self.group.remove_client(self)
+        """Remove the client from its current group, placing it in a fresh solo group."""
+        if self._group is None:
+            return
+        old_group = self._group
+        if len(old_group.clients) > 1:
+            await old_group.remove_client(self)
+            return
+        # Solo source: evict directly and finalize the now-empty group. The new
+        # SendspinGroup() below triggers _set_group on us, which unregisters
+        # events from old_group.
+        from .group import SendspinGroup  # noqa: PLC0415  # avoid circular import
+
+        old_group._clients.remove(self)  # noqa: SLF001
+        old_group._finalize_empty_group()  # noqa: SLF001
+        SendspinGroup(self._server, self)

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -366,7 +366,7 @@ class SendspinConnection:
 
     def send_priority_message(self, message: ServerMessage) -> None:
         """Enqueue a high-priority message (processed before regular queue)."""
-        if self._queue_size >= MAX_PENDING_MSG:
+        if len(self._priority_messages) >= MAX_PENDING_MSG:
             self._disconnect_due_to_queue_overflow("Priority message queue full, client too slow")
             return
         self._queue_sequence += 1

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -457,10 +457,33 @@ class SendspinConnection:
         for family in ROLE_SUPPORT_SPECS:
             selected_role = cls._first_registered_role_id_in_family(supported_roles, family=family)
             if selected_role is None:
-                # No registered role for this family — check if client advertises
-                # any custom role in the family so we still parse its support key.
-                selected_role = next((r for r in supported_roles if role_family(r) == family), None)
+                # Restrict the fallback to spec-custom versions (those starting
+                # with `_`). Unknown spec-versioned IDs like `v2` may carry a
+                # schema-incompatible support payload, so parsing against the
+                # family's registered schema would crash on field drift.
+                selected_role = next(
+                    (
+                        r
+                        for r in supported_roles
+                        if role_family(r) == family and r.partition("@")[2].startswith("_")
+                    ),
+                    None,
+                )
             if selected_role is None:
+                # Log unknown spec-versioned roles per spec README "Detecting
+                # Outdated Servers" so operators can spot a client running a
+                # newer protocol revision.
+                unknown_versions = [
+                    r
+                    for r in supported_roles
+                    if role_family(r) == family and not r.partition("@")[2].startswith("_")
+                ]
+                if unknown_versions:
+                    logger.info(
+                        "Client offered unknown spec role versions in family '%s': %s",
+                        family,
+                        unknown_versions,
+                    )
                 continue
             primary_role_id = cls._primary_role_id_for_family(family)
             if selected_role == primary_role_id:

--- a/aiosendspin/server/group.py
+++ b/aiosendspin/server/group.py
@@ -366,8 +366,7 @@ class SendspinGroup:
                 if self._push_stream is not None and not self._push_stream.is_stopped:
                     self._push_stream.on_role_leave(role)
         if not self._clients:
-            # Emit event for group deletion, no clients left
-            self._signal_event(GroupDeletedEvent())
+            self._finalize_empty_group()
         else:
             # Emit event for client removal
             self._signal_event(GroupMemberRemovedEvent(client.client_id))
@@ -375,6 +374,10 @@ class SendspinGroup:
         new_group = SendspinGroup(self._server, client)
         # Send group update to notify client of their new solo group
         new_group.on_client_connected(client)
+
+    def _finalize_empty_group(self) -> None:
+        """Tear down a group with no remaining clients."""
+        self._signal_event(GroupDeletedEvent())
 
     async def add_client(self, client: SendspinClient) -> None:
         """

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -1001,7 +1001,10 @@ class PushStream:
         """Return a safe minimum playback timestamp for late-join replay."""
         now_us = self._clock.now_us()
         delay_us = role.get_static_delay_us() if role is not None else 0
-        target_us = now_us + max(0, min_lead_us) + delay_us
+        effective_lead_us = max(0, min_lead_us)
+        if role is not None:
+            effective_lead_us = max(effective_lead_us, role.get_required_lead_time_us())
+        target_us = now_us + effective_lead_us + delay_us
         if align_to_channel_tail and channel_id is not None and channel_id in self._channel_timing:
             # For channels that currently have no other subscribers, anchor catch-up
             # to that channel's own live tail when it is near real time. If that tail

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -2135,8 +2135,8 @@ class PushStream:
     ) -> list[CachedChunk]:
         """Resample PCM chunks to the target format and encode them sequentially.
 
-        Pass `resamplers`/`quantizers` to share state across calls (single resampler,
-        drainable via `_drain_catchup_resamplers`).
+        Pass `resamplers`/`quantizers` to share state across calls (single resampler
+        instance per key reused between batches).
         """
         tkey = self._build_transform_key(req, channel_id)
         cached: list[CachedChunk] = []
@@ -2322,29 +2322,6 @@ class PushStream:
             )
             for data, ts, dur in encoded_frames
         ]
-
-    def _drain_catchup_resamplers(
-        self,
-        resamplers: dict[_ResamplerKey, _ResamplerState],
-        quantizers: dict[_ResamplerKey, _ResamplerState],
-        encoder: AudioTransformer | None,
-        req: AudioRequirements,
-        channel_id: UUID,
-    ) -> list[CachedChunk]:
-        """Flush each catchup resampler's FIR tail and encode the drained PCM.
-
-        Without draining, the resampler's FIR holds samples past the catchup
-        tail, leaving a content gap before the first live chunk. Drain emits
-        those held samples on the live timeline so live picks up seamlessly.
-        """
-        cached: list[CachedChunk] = []
-        for resampler_state in resamplers.values():
-            cached.extend(
-                self._flush_resampler_to_chunks(
-                    resampler_state, quantizers, encoder, req, channel_id
-                )
-            )
-        return cached
 
     async def _start_catchup_encoding(  # noqa: PLR0915
         self,

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -1183,12 +1183,12 @@ class PushStream:
         channel_play_start: dict[UUID, int] = {}
 
         if play_start_us is not None:
-            # Explicit timestamp mode: use provided timestamp directly.
+            # Explicit timestamp mode: caller-provided value is authoritative
+            # across mode switches, so overwrite any stale advanced timing.
             for channel_id in prepared:
                 channel_play_start[channel_id] = play_start_us
-                if channel_id not in self._channel_timing:
-                    self._channel_timing[channel_id] = play_start_us
-                    self._channel_timing_residue[channel_id] = 0
+                self._channel_timing[channel_id] = play_start_us
+                self._channel_timing_residue[channel_id] = 0
             return channel_play_start
 
         # Auto-calculate mode (existing behavior).

--- a/aiosendspin/server/roles/artwork/v1.py
+++ b/aiosendspin/server/roles/artwork/v1.py
@@ -65,13 +65,11 @@ class ArtworkV1Role(Role):
     def on_connect(self) -> None:
         """Initialize channel configs from client hello and subscribe to group."""
         self._init_channel_configs()
-        self._subscribe_to_group_role()
         if self._channel_configs:
             # Reannounce stream config first so follow-up artwork snapshot is interpretable.
             self._send_stream_start()
-        if isinstance(self._group_role, ArtworkGroupRole):
-            # Push current artwork immediately on (re)connect; do not wait for next change.
-            self._group_role._send_artwork_to_role(self)  # noqa: SLF001
+        # Subscribe after stream/start so the on_member_join artwork snapshot lands second.
+        self._subscribe_to_group_role()
 
     def on_disconnect(self) -> None:
         """Unsubscribe from ArtworkGroupRole."""

--- a/aiosendspin/server/roles/controller/v1.py
+++ b/aiosendspin/server/roles/controller/v1.py
@@ -7,48 +7,31 @@ This role handles bidirectional communication:
 
 from __future__ import annotations
 
-import asyncio
 import logging
-from collections.abc import Coroutine
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from aiosendspin.models.controller import ControllerCommandPayload
-from aiosendspin.models.types import (
-    ClientStateType,
-    MediaCommand,
-    PlaybackStateType,
-    has_role_family,
-)
+from aiosendspin.models.types import MediaCommand
 from aiosendspin.server.roles.base import Role
 from aiosendspin.util import create_task
 
 if TYPE_CHECKING:
     from aiosendspin.models.core import ClientCommandPayload
     from aiosendspin.server.client import SendspinClient
-    from aiosendspin.server.group import SendspinGroup
     from aiosendspin.server.roles.controller.group import ControllerGroupRole
 
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class ControllerRoleState:
-    """Persistent state for ControllerV1Role across reconnects."""
-
-    previous_group_id: str | None = None
-    """Group ID to rejoin after external_source ends."""
-
-    external_source_solo_group_id: str | None = None
-    """Solo group ID created when entering external_source."""
-
-
 class ControllerV1Role(Role):
     """Role implementation for controller clients.
 
     Receives controller state from ControllerGroupRole and forwards commands
-    from the client to the group.
+    from the client to the group. State-machine concerns that span all roles
+    (external_source, switch cycling, previous-group rejoin) live on
+    :class:`SendspinClient` because they apply even to clients without the
+    controller role.
     """
 
     def __init__(self, client: SendspinClient | None = None) -> None:
@@ -64,7 +47,6 @@ class ControllerV1Role(Role):
         self._stream_started = False
         self._buffer_tracker = None
         self._group_role: ControllerGroupRole | None = None
-        self._switch_lock = asyncio.Lock()
         self._logger = logger.getChild(str(client.client_id))
 
     @property
@@ -85,40 +67,6 @@ class ControllerV1Role(Role):
         """Unsubscribe from ControllerGroupRole."""
         self._unsubscribe_from_group_role()
 
-    def on_state_transition(
-        self,
-        old_state: ClientStateType,  # noqa: ARG002
-        new_state: ClientStateType,
-    ) -> Coroutine[Any, Any, None] | None:
-        """Handle external_source transitions by moving client to solo group."""
-        if new_state != ClientStateType.EXTERNAL_SOURCE:
-            return None
-        return self._handle_external_source_transition()
-
-    async def _handle_external_source_transition(self) -> None:
-        """Handle transition to external_source state.
-
-        When transitioning to external_source:
-        - If in multi-client group: remember previous group, move to solo group
-        - If already in solo group: stop playback
-        """
-        is_multi_client_group = len(self._client.group.clients) > 1
-
-        if is_multi_client_group:
-            # Store previous group in controller role state (persists across reconnects)
-            state = self._get_state()
-            state.previous_group_id = self._client.group.group_id
-            self._logger.debug(
-                "Storing previous group %s for external_source client",
-                state.previous_group_id,
-            )
-            await self._client.group.remove_client(self._client)
-            state.external_source_solo_group_id = self._client.group.group_id
-            return
-
-        self._logger.debug("Client already in solo group, stopping playback for external_source")
-        await self._client.group.stop()
-
     def on_command(self, payload: ClientCommandPayload) -> None:
         """Handle client/command payload."""
         controller_cmd = payload.controller
@@ -126,7 +74,7 @@ class ControllerV1Role(Role):
             return
 
         if controller_cmd.command == MediaCommand.SWITCH:
-            create_task(self._handle_switch_command())
+            create_task(self._client.handle_switch_command())
             return
 
         # Forward other commands to group role
@@ -141,183 +89,3 @@ class ControllerV1Role(Role):
         """
         if self._group_role is not None:
             self._group_role.handle_command(cmd)
-
-    # --- Switch command handling ---
-
-    def _get_state(self) -> ControllerRoleState:
-        """Get or create persistent state for this role."""
-        return self._client.get_or_create_role_state(self.role_family, ControllerRoleState)
-
-    async def _handle_switch_command(self) -> None:
-        """Handle the switch command to cycle through groups."""
-        if self._switch_lock.locked():
-            self._logger.debug("Ignoring switch command; switch already in progress")
-            return
-        async with self._switch_lock:
-            await self._handle_switch_command_locked()
-
-    async def _handle_switch_command_locked(self) -> None:
-        """Handle the switch command to cycle through groups (locked)."""
-        # Clients in external_source can't participate in playback
-        if self._client.client_state == ClientStateType.EXTERNAL_SOURCE:
-            self._logger.debug("Ignoring switch command while client is in external_source state")
-            return
-
-        # Check if client should rejoin previous group (external_source recovery priority)
-        if await self._try_rejoin_previous_group():
-            return
-
-        current_group = self._client.group
-
-        # Get all unique groups from all connected clients
-        all_groups = self._get_all_groups()
-
-        # Build the cycle list based on client's player role
-        has_player_role = has_role_family("player", self._client.negotiated_roles)
-        cycle_groups = self._build_group_cycle(all_groups, current_group, has_player_role)
-
-        if not cycle_groups:
-            self._logger.debug("No groups available to switch to")
-            return
-
-        # Find current position in cycle and move to next
-        try:
-            current_index = cycle_groups.index(current_group)
-            next_index = (current_index + 1) % len(cycle_groups)
-        except ValueError:
-            # Current group not in cycle, start from beginning
-            next_index = 0
-
-        next_group = cycle_groups[next_index]
-
-        # Move client to the next group
-        if next_group is None:
-            # The group.remove_client will create a new solo group for the client
-            self._logger.info(
-                "Switching client %s to solo group",
-                self._client.client_id,
-            )
-            await current_group.remove_client(self._client)
-        elif next_group != current_group:
-            self._logger.info(
-                "Switching client %s to group %s",
-                self._client.client_id,
-                next_group.group_id,
-            )
-            await current_group.remove_client(self._client)
-            await next_group.add_client(self._client)
-
-    def _get_all_groups(self) -> list[SendspinGroup]:
-        """Get all unique groups from all connected clients."""
-        groups_seen: set[str] = set()
-        unique_groups: list[SendspinGroup] = []
-
-        for client in self._client._server.connected_clients:  # noqa: SLF001
-            group = client.group
-            group_id = group.group_id
-            if group_id not in groups_seen:
-                groups_seen.add(group_id)
-                unique_groups.append(group)
-
-        return unique_groups
-
-    def _build_group_cycle(
-        self,
-        all_groups: list[SendspinGroup],
-        current_group: SendspinGroup,
-        has_player_role: bool,  # noqa: FBT001
-    ) -> list[SendspinGroup | None]:
-        """Build the cycle of groups based on the spec.
-
-        Returns a list of groups to cycle through. For player clients, the list
-        may contain None indicating to "go to a new solo group".
-        """
-        # Separate groups into categories
-        multi_client_playing: list[SendspinGroup] = []
-        single_client: list[SendspinGroup] = []
-
-        for group in all_groups:
-            client_count = len(group.clients)
-            is_playing = group.state == PlaybackStateType.PLAYING
-
-            if client_count > 1 and is_playing:
-                # Verify the group has at least one player
-                has_player = any(
-                    has_role_family("player", c.negotiated_roles) for c in group.clients
-                )
-                if has_player:
-                    multi_client_playing.append(group)
-            elif client_count == 1 and is_playing:
-                # Get the single client in this group
-                single_client_obj = group.clients[0]
-                # Skip current group, it will be handled as solo option for player clients
-                if group != current_group and has_role_family(
-                    "player", single_client_obj.negotiated_roles
-                ):
-                    single_client.append(group)
-
-        # Sort for stable ordering (by group ID)
-        multi_client_playing.sort(key=lambda g: g.group_id)
-        single_client.sort(key=lambda g: g.group_id)
-
-        # Build cycle based on client's player role
-        if has_player_role:
-            # With player role: multi-client playing -> single-client -> own solo
-            current_is_solo = len(current_group.clients) == 1
-            # Use current group if solo, otherwise switch to new solo group (None)
-            solo_option: list[SendspinGroup | None] = [current_group] if current_is_solo else [None]
-            return multi_client_playing + single_client + solo_option
-        # Without player role: multi-client playing -> single-client (no own solo)
-        return [*multi_client_playing, *single_client]
-
-    def _should_rejoin_previous_group(self) -> bool:
-        """Check if client should rejoin previous group (external_source recovery).
-
-        Per spec: "If the client is still in the solo group from its 'external_source'
-        transition, the switch command prioritizes rejoining the previous group."
-        """
-        state = self._get_state()
-        return (
-            state.previous_group_id is not None
-            and self._client.client_state != ClientStateType.EXTERNAL_SOURCE
-            and state.external_source_solo_group_id == self._client.group.group_id
-            and len(self._client.group.clients) == 1  # Still in the solo group
-        )
-
-    async def _try_rejoin_previous_group(self) -> bool:
-        """Try to rejoin the previous group after external_source ended."""
-        if not self._should_rejoin_previous_group():
-            return False
-
-        state = self._get_state()
-        previous_group_id = state.previous_group_id
-        # Clear external_source tracking after attempt (regardless of success)
-        state.previous_group_id = None
-        state.external_source_solo_group_id = None
-
-        previous_group = self._find_group_by_id(previous_group_id)
-
-        if previous_group is not None and previous_group != self._client.group:
-            self._logger.info(
-                "Rejoining previous group %s after external_source",
-                previous_group_id,
-            )
-            await self._client.group.remove_client(self._client)
-            await previous_group.add_client(self._client)
-            return True
-        self._logger.debug(
-            "Previous group %s no longer exists or is current group, "
-            "falling back to normal switch cycle",
-            previous_group_id,
-        )
-        return False
-
-    def _find_group_by_id(self, group_id: str | None) -> SendspinGroup | None:
-        """Find a group by its ID from all connected clients."""
-        if group_id is None:
-            return None
-
-        for client in self._client._server.connected_clients:  # noqa: SLF001
-            if client.group.group_id == group_id:
-                return client.group
-        return None

--- a/aiosendspin/server/roles/metadata/state.py
+++ b/aiosendspin/server/roles/metadata/state.py
@@ -8,6 +8,14 @@ from aiosendspin.models.metadata import Progress, SessionUpdateMetadata
 from aiosendspin.models.types import RepeatMode
 
 
+def _progress_fields_changed(last: Metadata, current: Metadata) -> bool:
+    return (
+        last.track_progress != current.track_progress
+        or last.track_duration != current.track_duration
+        or last.playback_speed != current.playback_speed
+    )
+
+
 @dataclass
 class Metadata:
     """Metadata for media playback."""
@@ -128,25 +136,23 @@ class Metadata:
         if last is None or last.shuffle != self.shuffle:
             metadata_update.shuffle = self.shuffle
 
-        # Send progress object if any progress field changed or if track_progress is set
-        # (clients need fresh timestamp for progress calculation)
-        progress_changed = (
-            last is None
-            or last.track_duration != self.track_duration
-            or last.playback_speed != self.playback_speed
-            or self.track_progress is not None
-        )
+        # Emit progress=null to clear when the previous state had progress and the new state
+        # doesn't (spec: omitted = unchanged, null = clear). Emit a full Progress object on the
+        # first update or when any progress field changed.
+        last_had_progress = last is not None and last.track_progress is not None
         if (
-            progress_changed
-            and self.track_progress is not None
+            self.track_progress is not None
             and self.track_duration is not None
             and self.playback_speed is not None
         ):
-            metadata_update.progress = Progress(
-                track_progress=self.track_progress,
-                track_duration=self.track_duration,
-                playback_speed=self.playback_speed,
-            )
+            if last is None or _progress_fields_changed(last, self):
+                metadata_update.progress = Progress(
+                    track_progress=self.track_progress,
+                    track_duration=self.track_duration,
+                    playback_speed=self.playback_speed,
+                )
+        elif last_had_progress:
+            metadata_update.progress = None
 
         return metadata_update
 

--- a/aiosendspin/server/roles/metadata/v1.py
+++ b/aiosendspin/server/roles/metadata/v1.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from aiosendspin.server.roles.base import Role
-from aiosendspin.server.roles.metadata.group import MetadataGroupRole
 
 if TYPE_CHECKING:
     from aiosendspin.server.client import SendspinClient
@@ -48,8 +47,6 @@ class MetadataV1Role(Role):
     def on_connect(self) -> None:
         """Subscribe to MetadataGroupRole for state updates."""
         self._subscribe_to_group_role()
-        if isinstance(self._group_role, MetadataGroupRole):
-            self._group_role._send_state_to_role(self)  # noqa: SLF001
 
     def on_disconnect(self) -> None:
         """Unsubscribe from MetadataGroupRole."""

--- a/aiosendspin/server/roles/player/group.py
+++ b/aiosendspin/server/roles/player/group.py
@@ -2,23 +2,35 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import TYPE_CHECKING, cast
 
+from aiosendspin.models.types import has_role_family
+from aiosendspin.server.events import ClientEvent
 from aiosendspin.server.roles.base import GroupRole
 from aiosendspin.server.roles.player.events import (
     PlayerGroupMuteChangedEvent,
     PlayerGroupVolumeChangedEvent,
+    VolumeChangedEvent,
 )
 from aiosendspin.server.roles.player.types import PlayerRoleProtocol
 
 if TYPE_CHECKING:
     from aiosendspin.server.client import SendspinClient
+    from aiosendspin.server.group import SendspinGroup
 
 
 class PlayerGroupRole(GroupRole):
     """Coordinate player roles across a group."""
 
     role_family = "player"
+
+    def __init__(self, group: SendspinGroup) -> None:
+        """Initialize PlayerGroupRole."""
+        super().__init__(group)
+        self._last_emitted_volume: int | None = None
+        self._last_emitted_muted: bool | None = None
+        self._player_client_unsubs: dict[SendspinClient, Callable[[], None]] = {}
 
     def _player_roles(self) -> list[PlayerRoleProtocol]:
         """Return player role members.
@@ -59,7 +71,6 @@ class PlayerGroupRole(GroupRole):
         players = self._player_roles()
         if not players:
             return True
-        previous_volume = self.get_group_volume()
 
         # Build mapping of player -> current volume (only players with volume support)
         player_volumes: dict[PlayerRoleProtocol, float] = {}
@@ -106,26 +117,12 @@ class PlayerGroupRole(GroupRole):
         # Apply to players
         for player, final_vol in player_volumes.items():
             player.set_player_volume(round(final_vol))
-        new_volume = self.get_group_volume()
-        if previous_volume is not None and new_volume is not None and previous_volume != new_volume:
-            self.emit_group_event(
-                PlayerGroupVolumeChangedEvent(
-                    previous_volume=previous_volume,
-                    volume=new_volume,
-                )
-            )
         return True
 
     def set_group_muted(self, muted: bool) -> bool | None:  # noqa: FBT001
         """Set mute state on all players."""
-        previous_muted = bool(self.get_group_muted())
         for player in self._player_roles():
             player.set_player_mute(muted)
-        new_muted = bool(self.get_group_muted())
-        if previous_muted != new_muted:
-            self.emit_group_event(
-                PlayerGroupMuteChangedEvent(previous_muted=previous_muted, muted=new_muted)
-            )
         return True
 
     @property
@@ -153,3 +150,53 @@ class PlayerGroupRole(GroupRole):
             Clients with player roles.
         """
         return [role._client for role in self._player_roles()]  # noqa: SLF001
+
+    # --- Client added/removed hooks ---
+
+    def on_client_added(self, client: SendspinClient) -> None:
+        """Subscribe to per-client volume events to aggregate group transitions."""
+        if client in self._player_client_unsubs:
+            return
+        if not has_role_family("player", client.negotiated_roles):
+            return
+
+        def on_client_event(_client: SendspinClient, event: ClientEvent) -> None:
+            if isinstance(event, VolumeChangedEvent):
+                self._recompute_and_emit()
+
+        unsub = client.add_event_listener(on_client_event)
+        self._player_client_unsubs[client] = unsub
+        # Prime cached state so the first real echo emits against a known baseline.
+        if self._last_emitted_volume is None:
+            self._last_emitted_volume = self.get_group_volume()
+        if self._last_emitted_muted is None:
+            self._last_emitted_muted = self.get_group_muted()
+
+    def on_client_removed(self, client: SendspinClient) -> None:
+        """Unsubscribe from per-client volume events and re-aggregate."""
+        if client in self._player_client_unsubs:
+            self._player_client_unsubs[client]()
+            del self._player_client_unsubs[client]
+
+    def _recompute_and_emit(self) -> None:
+        """Recompute group volume/mute and emit on integer-average / bool transitions."""
+        new_volume = self.get_group_volume()
+        if new_volume is not None:
+            previous_volume = self._last_emitted_volume
+            self._last_emitted_volume = new_volume
+            if previous_volume is not None and previous_volume != new_volume:
+                self.emit_group_event(
+                    PlayerGroupVolumeChangedEvent(
+                        previous_volume=previous_volume,
+                        volume=new_volume,
+                    )
+                )
+
+        new_muted = self.get_group_muted()
+        if new_muted is not None:
+            previous_muted = self._last_emitted_muted
+            self._last_emitted_muted = new_muted
+            if previous_muted is not None and previous_muted != new_muted:
+                self.emit_group_event(
+                    PlayerGroupMuteChangedEvent(previous_muted=previous_muted, muted=new_muted)
+                )

--- a/aiosendspin/server/roles/player/group.py
+++ b/aiosendspin/server/roles/player/group.py
@@ -173,7 +173,11 @@ class PlayerGroupRole(GroupRole):
             self._last_emitted_muted = self.get_group_muted()
 
     def on_client_removed(self, client: SendspinClient) -> None:
-        """Unsubscribe from per-client volume events and re-aggregate."""
+        """Unsubscribe from per-client volume events.
+
+        Membership still includes the leaver here (role unsubscribe runs later),
+        so emission is left to the per-client VolumeChangedEvent echo.
+        """
         if client in self._player_client_unsubs:
             self._player_client_unsubs[client]()
             del self._player_client_unsubs[client]

--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -672,19 +672,22 @@ class PlayerV1Role(Role):
         if state.supported_commands is not None:
             self.state_supported_commands = state.supported_commands
 
-        if self.static_delay_ms != state.static_delay_ms:
+        if state.static_delay_ms is not None and self.static_delay_ms != state.static_delay_ms:
             self.static_delay_ms = state.static_delay_ms
             self._client._signal_event(  # noqa: SLF001
                 StaticDelayChangedEvent(static_delay_ms=state.static_delay_ms)
             )
 
-        if self.required_lead_time_ms != state.required_lead_time_ms:
+        if (
+            state.required_lead_time_ms is not None
+            and self.required_lead_time_ms != state.required_lead_time_ms
+        ):
             self.required_lead_time_ms = state.required_lead_time_ms
             self._client._signal_event(  # noqa: SLF001
                 RequiredLeadTimeChangedEvent(required_lead_time_ms=state.required_lead_time_ms)
             )
 
-        if self.min_buffer_ms != state.min_buffer_ms:
+        if state.min_buffer_ms is not None and self.min_buffer_ms != state.min_buffer_ms:
             self.min_buffer_ms = state.min_buffer_ms
             self._client._signal_event(  # noqa: SLF001
                 MinBufferChangedEvent(min_buffer_ms=state.min_buffer_ms)

--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -55,6 +55,9 @@ if TYPE_CHECKING:
     from aiosendspin.server.client import SendspinClient
 
 
+BUFFER_TRACKER_RESET_DELAY_S = 2.0
+
+
 @dataclass
 class PlayerPersistentState:
     """Persistent player state stored on the SendspinClient."""
@@ -233,11 +236,10 @@ class PlayerV1Role(Role):
                 return
             state.buffer_tracker.reset()
 
-        reset_after_s = 2.0
         if state.buffer_reset_handle is not None:
             state.buffer_reset_handle.cancel()
         state.buffer_reset_handle = self._client._server.loop.call_later(  # noqa: SLF001
-            reset_after_s, _maybe_reset
+            BUFFER_TRACKER_RESET_DELAY_S, _maybe_reset
         )
 
     def requires_initial_state(self) -> bool:

--- a/scripts/compare_time_filter.py
+++ b/scripts/compare_time_filter.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Parity vector harness for SendspinTimeFilter vs the C++ reference.
+
+NOT RUN IN CI. Invoke manually after touching aiosendspin/client/time_sync.py
+or bumping the C++ reference SHA in scripts/cpp_reference_sha.txt.
+
+Pipeline:
+
+1. Clone https://github.com/Sendspin-Protocol/time-filter into /tmp/time-filter-ref
+   (or pass --cpp-ref-dir). The SHA pinned in scripts/cpp_reference_sha.txt is
+   what the Python port was last reconciled against.
+2. Compile a tiny C++ harness around sendspin_time_filter.cpp that reads
+   ``measurement,max_error,time_added`` lines on stdin and prints
+   ``offset,drift,offset_covariance,drift_covariance,server_time(sample_t)``
+   per step.
+3. Feed the same deterministic seeded sequence through the Python filter and
+   diff per-step state. PASS if max divergence < eps, else FAIL with the first
+   diverging row.
+
+Run with ``./scripts/run-in-env.sh python scripts/compare_time_filter.py``.
+"""
+
+# ruff: noqa: D101, D103, S108, S311, S603, SLF001, T201, PERF401  Manual dev script
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import math
+import random
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from aiosendspin.client.time_sync import SendspinTimeFilter  # noqa: E402
+
+DEFAULT_CPP_REF_DIR = Path("/tmp/time-filter-ref")
+DEFAULT_SAMPLE_T_OFFSET_US = 500_000
+DEFAULT_TOLERANCE_US = 2
+
+# Minimal C++ harness wrapping the reference filter. Reads CSV from stdin and
+# emits state per update on stdout.
+CPP_HARNESS = r"""
+#include "sendspin_time_filter.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::fprintf(stderr, "usage: harness <sample_t_offset_us>\n");
+        return 2;
+    }
+    const int64_t sample_t_offset = std::stoll(argv[1]);
+
+    SendspinTimeFilter filter{SendspinTimeFilter::Config{}};
+
+    std::string line;
+    std::printf("offset,drift,offset_covariance,drift_covariance,server_time\n");
+    while (std::getline(std::cin, line)) {
+        if (line.empty()) continue;
+        std::istringstream parts(line);
+        std::string tok;
+        int64_t measurement = 0, max_error = 0, time_added = 0;
+        std::getline(parts, tok, ','); measurement = std::stoll(tok);
+        std::getline(parts, tok, ','); max_error = std::stoll(tok);
+        std::getline(parts, tok, ','); time_added = std::stoll(tok);
+
+        filter.update(measurement, max_error, time_added);
+
+        const int64_t sample_client_time = time_added + sample_t_offset;
+        const int64_t sample_server_time = filter.compute_server_time(sample_client_time);
+
+        // Reach into protected state via a friend shim. Re-derive what we can
+        // from the public API: offset/drift covariance are not exported, so
+        // print get_covariance() for offset and the get_error() squared shape
+        // for drift_covariance is unavailable. We only diff offset & server_time.
+        std::printf("%.6f,%.12e,%lld,%.12e,%lld\n",
+                    0.0,  // offset placeholder (not exposed by reference)
+                    0.0,  // drift placeholder
+                    static_cast<long long>(filter.get_covariance()),
+                    0.0,
+                    static_cast<long long>(sample_server_time));
+    }
+    return 0;
+}
+"""
+
+
+@dataclass
+class Measurement:
+    measurement: int
+    max_error: int
+    time_added: int
+
+
+@dataclass
+class StepRow:
+    offset_covariance: int
+    server_time: int
+
+
+def generate_sequence(seed: int = 1729, count: int = 200) -> list[Measurement]:
+    """Synthetic but realistic sequence with constant offset, small drift, noisy RTT."""
+    rng = random.Random(seed)
+    true_offset = 250_000
+    true_drift = 5e-8
+    t = 1_000_000
+    out: list[Measurement] = []
+    for _ in range(count):
+        noise = rng.gauss(0.0, 50.0)
+        meas = round(true_offset + true_drift * t + noise)
+        max_err = rng.randint(200, 800)
+        out.append(Measurement(meas, max_err, t))
+        t += rng.randint(900_000, 1_100_000)
+    return out
+
+
+def run_python(seq: list[Measurement], sample_t_offset: int) -> list[StepRow]:
+    f = SendspinTimeFilter()
+    rows: list[StepRow] = []
+    for m in seq:
+        f.update(m.measurement, m.max_error, m.time_added)
+        rows.append(
+            StepRow(
+                offset_covariance=round(f._offset_covariance)
+                if math.isfinite(f._offset_covariance)
+                else -1,
+                server_time=f.compute_server_time(m.time_added + sample_t_offset),
+            )
+        )
+    return rows
+
+
+def build_cpp_harness(cpp_ref_dir: Path, build_dir: Path) -> Path:
+    """Compile the C++ reference + harness into a single binary."""
+    src_cpp = cpp_ref_dir / "cpp" / "sendspin_time_filter.cpp"
+    src_h = cpp_ref_dir / "cpp" / "sendspin_time_filter.h"
+    if not src_cpp.exists() or not src_h.exists():
+        raise SystemExit(
+            f"C++ reference not found under {cpp_ref_dir}/cpp. "
+            "Clone https://github.com/Sendspin-Protocol/time-filter into "
+            f"{cpp_ref_dir} or pass --cpp-ref-dir."
+        )
+
+    build_dir.mkdir(parents=True, exist_ok=True)
+    harness_src = build_dir / "harness.cpp"
+    harness_src.write_text(CPP_HARNESS)
+
+    binary = build_dir / "harness"
+    cxx = shutil.which("c++") or shutil.which("g++") or shutil.which("clang++")
+    if not cxx:
+        raise SystemExit("No C++ compiler found in PATH.")
+
+    cmd = [
+        cxx,
+        "-std=c++17",
+        "-O2",
+        f"-I{src_cpp.parent}",
+        str(src_cpp),
+        str(harness_src),
+        "-o",
+        str(binary),
+        "-pthread",
+    ]
+    subprocess.run(cmd, check=True)
+    return binary
+
+
+def run_cpp(binary: Path, seq: list[Measurement], sample_t_offset: int) -> list[StepRow]:
+    stdin_text = io.StringIO()
+    for m in seq:
+        stdin_text.write(f"{m.measurement},{m.max_error},{m.time_added}\n")
+
+    result = subprocess.run(
+        [str(binary), str(sample_t_offset)],
+        input=stdin_text.getvalue(),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    rows: list[StepRow] = []
+    reader = csv.DictReader(io.StringIO(result.stdout))
+    for row in reader:
+        rows.append(
+            StepRow(
+                offset_covariance=int(row["offset_covariance"]),
+                server_time=int(row["server_time"]),
+            )
+        )
+    return rows
+
+
+def diff_rows(py: list[StepRow], cpp: list[StepRow], tolerance_us: int) -> tuple[bool, str]:
+    if len(py) != len(cpp):
+        return False, f"row count mismatch: py={len(py)} cpp={len(cpp)}"
+    for i, (p, c) in enumerate(zip(py, cpp, strict=True)):
+        if abs(p.server_time - c.server_time) > tolerance_us:
+            return False, (
+                f"row {i}: server_time diverged "
+                f"py={p.server_time} cpp={c.server_time} "
+                f"delta={p.server_time - c.server_time} us"
+            )
+    return True, ""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cpp-ref-dir",
+        type=Path,
+        default=DEFAULT_CPP_REF_DIR,
+        help="Directory containing the cloned Sendspin-Protocol/time-filter repo.",
+    )
+    parser.add_argument(
+        "--build-dir",
+        type=Path,
+        default=Path("/tmp/sendspin_time_filter_parity_build"),
+    )
+    parser.add_argument("--seed", type=int, default=1729)
+    parser.add_argument("--count", type=int, default=200)
+    parser.add_argument(
+        "--sample-offset",
+        type=int,
+        default=DEFAULT_SAMPLE_T_OFFSET_US,
+        help="Microseconds past each update's time_added at which to evaluate "
+        "compute_server_time for the diff.",
+    )
+    parser.add_argument(
+        "--tolerance",
+        type=int,
+        default=DEFAULT_TOLERANCE_US,
+        help="Maximum tolerated divergence in microseconds for compute_server_time.",
+    )
+    parser.add_argument("--csv", type=Path, help="Write per-step CSV (py vs cpp) to this path.")
+    args = parser.parse_args()
+
+    seq = generate_sequence(args.seed, args.count)
+    py_rows = run_python(seq, args.sample_offset)
+    binary = build_cpp_harness(args.cpp_ref_dir, args.build_dir)
+    cpp_rows = run_cpp(binary, seq, args.sample_offset)
+
+    if args.csv:
+        with args.csv.open("w", newline="") as fp:
+            w = csv.writer(fp)
+            w.writerow(["step", "py_server_time", "cpp_server_time", "delta_us"])
+            for i, (p, c) in enumerate(zip(py_rows, cpp_rows, strict=True)):
+                w.writerow([i, p.server_time, c.server_time, p.server_time - c.server_time])
+
+    ok, msg = diff_rows(py_rows, cpp_rows, args.tolerance)
+    if ok:
+        print(f"PASS — {len(py_rows)} steps within {args.tolerance} us of C++ reference")
+        return 0
+    print(f"FAIL — {msg}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/compare_time_filter.py
+++ b/scripts/compare_time_filter.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 """Parity vector harness for SendspinTimeFilter vs the C++ reference.
 
-NOT RUN IN CI. Invoke manually after touching aiosendspin/client/time_sync.py
-or bumping the C++ reference SHA in scripts/cpp_reference_sha.txt.
+This script is not run in CI since it needs a checkout of the C++ reference
+and a working C++ toolchain. Invoke manually after touching
+aiosendspin/client/time_sync.py or bumping the C++ reference SHA in
+scripts/cpp_reference_sha.txt.
 
 Pipeline:
 

--- a/scripts/cpp_reference_sha.txt
+++ b/scripts/cpp_reference_sha.txt
@@ -1,0 +1,1 @@
+39dd3f4a7c37bcd63d8e2ee3885bf4d76fcaa61a

--- a/tests/integration/sync_assertions.py
+++ b/tests/integration/sync_assertions.py
@@ -524,13 +524,13 @@ def assert_audible_sync(
         reference_samples = window_samples_by_player[chosen_reference]
         reference_rate = sample_rate_by_player[chosen_reference]
 
-    lag_us_by_player: dict[str, float] = {}
+    signed_lag_us_by_player: dict[str, float] = {}
     for player_id, segments in segments_by_player.items():
         seg = segments[-1]
         received = window_samples_by_player[player_id]
         if compare_to == "reference":
             if player_id == chosen_reference:
-                lag_us_by_player[player_id] = 0.0
+                signed_lag_us_by_player[player_id] = 0.0
                 continue
             expected = resample_mono_s16(
                 reference_samples,
@@ -551,12 +551,13 @@ def assert_audible_sync(
             expected,
             max_lag_samples=max_lag_samples,
         )
-        lag_us = abs(lag_samples) * 1_000_000 / seg.sample_rate
+        signed_lag_us = lag_samples * 1_000_000 / seg.sample_rate
+        lag_us = abs(signed_lag_us)
 
         assert lag_us <= max_skew_us, f"{player_id} lag {lag_us:.2f}us > {max_skew_us}us"
         if enforce_corr:
             assert score >= min_corr, f"{player_id} correlation {score:.3f} < {min_corr}"
-        lag_us_by_player[player_id] = lag_us
+        signed_lag_us_by_player[player_id] = signed_lag_us
 
-    spread = max(lag_us_by_player.values()) - min(lag_us_by_player.values())
-    assert spread <= max_skew_us, f"player lag spread {spread:.2f}us > {max_skew_us}us"
+    spread = max(signed_lag_us_by_player.values()) - min(signed_lag_us_by_player.values())
+    assert spread <= max_skew_us, f"player signed lag spread {spread:.2f}us > {max_skew_us}us"

--- a/tests/integration/sync_assertions.py
+++ b/tests/integration/sync_assertions.py
@@ -475,7 +475,7 @@ def assert_pcm_chunks_continuous(events: Sequence[Any], *, max_gap_us: int) -> N
 
         if last_end_us is not None:
             gap_us = header.timestamp_us - last_end_us
-            assert gap_us <= max_gap_us
+            assert 0 <= gap_us <= max_gap_us
         last_end_us = header.timestamp_us + dur_us
 
 

--- a/tests/integration/test_audible_sync_fuzz.py
+++ b/tests/integration/test_audible_sync_fuzz.py
@@ -250,7 +250,7 @@ async def _run_seeded_fuzz(seed: int) -> None:  # noqa: PLR0915
     assert_audible_sync(
         segments_by_player,
         max_skew_us=5_000,
-        min_corr=0.35,
+        min_corr=0.85,
         enforce_corr=True,
         window_duration_us=250_000,
         warmup_us=0,

--- a/tests/integration/test_late_joiner_codec.py
+++ b/tests/integration/test_late_joiner_codec.py
@@ -50,7 +50,7 @@ class _DummyGroup:
 class _CaptureConnection:
     def __init__(self) -> None:
         self.sent_json: list[object] = []
-        self.sent_binary: list[bytes] = []
+        self.sent_binary: list[tuple[int, bytes]] = []
         self.buffer_tracker = None
 
     async def disconnect(self, *, retry_connection: bool = True) -> None:  # noqa: ARG002
@@ -67,13 +67,13 @@ class _CaptureConnection:
         data: bytes,
         *,
         role: str,  # noqa: ARG002
-        timestamp_us: int,  # noqa: ARG002
+        timestamp_us: int,
         message_type: int,  # noqa: ARG002
         buffer_end_time_us: int | None = None,
         buffer_byte_count: int | None = None,
         duration_us: int | None = None,
     ) -> bool:
-        self.sent_binary.append(data)
+        self.sent_binary.append((timestamp_us, data))
         if (
             self.buffer_tracker is not None
             and buffer_end_time_us is not None
@@ -183,3 +183,8 @@ async def test_late_joiner_receives_catchup_for_uncached_codec() -> None:
 
     assert any(isinstance(m, StreamStartMessage) for m in conn2.sent_json)
     assert conn2.sent_binary, "expected PCM catch-up audio for late joiner"
+    first_ts, _ = conn2.sent_binary[0]
+    assert first_ts >= clock.now_us(), (
+        f"late joiner first chunk ts {first_ts} < now {clock.now_us()} "
+        "(spec README:177 mandates future-only timestamps)"
+    )

--- a/tests/integration/test_multi_player_timing_integration.py
+++ b/tests/integration/test_multi_player_timing_integration.py
@@ -542,7 +542,7 @@ def _assert_pcm_chunks_continuous(events: list[_Event], *, max_gap_us: int) -> N
         dur_us = int(frame_count * 1_000_000 / fmt.sample_rate)
         if last_end_us is not None:
             gap_us = header.timestamp_us - last_end_us
-            assert gap_us <= max_gap_us
+            assert 0 <= gap_us <= max_gap_us
         last_end_us = header.timestamp_us + dur_us
 
 

--- a/tests/models/test_player.py
+++ b/tests/models/test_player.py
@@ -8,12 +8,19 @@ from aiosendspin.models.player import PlayerCommandPayload, PlayerStatePayload
 from aiosendspin.models.types import PlayerCommand
 
 
-def test_player_state_static_delay_serializes_at_zero() -> None:
-    """static_delay_ms=0 is always serialized (not omitted by omit_none)."""
-    payload = PlayerStatePayload()
+def test_player_state_static_delay_serializes_when_set() -> None:
+    """static_delay_ms is serialized when explicitly set."""
+    payload = PlayerStatePayload(static_delay_ms=0)
     data = payload.to_dict()
     assert "static_delay_ms" in data
     assert data["static_delay_ms"] == 0
+
+
+def test_player_state_static_delay_omitted_when_unset() -> None:
+    """static_delay_ms is omitted when not provided so partial deltas don't reset it."""
+    payload = PlayerStatePayload()
+    data = payload.to_dict()
+    assert "static_delay_ms" not in data
 
 
 def test_player_state_static_delay_range_valid() -> None:
@@ -42,17 +49,17 @@ def test_player_state_supported_commands_serializes() -> None:
 
 
 def test_player_state_backward_compat_no_delay() -> None:
-    """Old clients that don't send static_delay_ms get default 0."""
+    """Omitted static_delay_ms parses as None so server treats it as 'unchanged'."""
     data = '{"volume": 50}'
     payload = PlayerStatePayload.from_json(data)
-    assert payload.static_delay_ms == 0
+    assert payload.static_delay_ms is None
 
 
-def test_player_state_timing_defaults() -> None:
-    """Clients that omit timing fields get the 250 ms defaults."""
+def test_player_state_timing_defaults_to_none() -> None:
+    """Omitted timing fields parse as None so server treats them as 'unchanged'."""
     payload = PlayerStatePayload.from_json('{"volume": 50}')
-    assert payload.required_lead_time_ms == 250
-    assert payload.min_buffer_ms == 250
+    assert payload.required_lead_time_ms is None
+    assert payload.min_buffer_ms is None
 
 
 def test_player_state_timing_serializes() -> None:

--- a/tests/models/test_stream_role_validators.py
+++ b/tests/models/test_stream_role_validators.py
@@ -1,0 +1,46 @@
+"""Validators for `stream/clear` and `stream/end` `roles` lists.
+
+Spec README:394,415 explicitly permit `_`-prefixed application role names.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aiosendspin.models.core import StreamClearPayload, StreamEndPayload
+
+
+def test_stream_clear_accepts_underscore_prefixed_role() -> None:
+    """`_`-prefixed names are reserved for application-specific roles."""
+    payload = StreamClearPayload(roles=["_custom_role"])
+    assert payload.roles == ["_custom_role"]
+
+
+def test_stream_clear_accepts_mixed_known_and_app_roles() -> None:
+    """Known families and `_`-prefixed roles may appear together."""
+    payload = StreamClearPayload(roles=["player", "_my_app"])
+    assert payload.roles == ["player", "_my_app"]
+
+
+def test_stream_clear_rejects_unknown_non_underscore_role() -> None:
+    """Unknown families without `_` prefix are still rejected."""
+    with pytest.raises(ValueError, match="invalid roles"):
+        StreamClearPayload(roles=["controller"])
+
+
+def test_stream_end_accepts_underscore_prefixed_role() -> None:
+    """`_`-prefixed names are reserved for application-specific roles."""
+    payload = StreamEndPayload(roles=["_custom_role"])
+    assert payload.roles == ["_custom_role"]
+
+
+def test_stream_end_accepts_mixed_known_and_app_roles() -> None:
+    """Known families and `_`-prefixed roles may appear together."""
+    payload = StreamEndPayload(roles=["player", "_my_app"])
+    assert payload.roles == ["player", "_my_app"]
+
+
+def test_stream_end_rejects_unknown_non_underscore_role() -> None:
+    """Unknown families without `_` prefix are still rejected."""
+    with pytest.raises(ValueError, match="invalid roles"):
+        StreamEndPayload(roles=["controller"])

--- a/tests/server/roles/artwork/test_v1.py
+++ b/tests/server/roles/artwork/test_v1.py
@@ -6,8 +6,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from aiosendspin.models.artwork import ArtworkChannel
-from aiosendspin.models.core import StreamStartMessage
+from aiosendspin.models.artwork import ArtworkChannel, StreamRequestFormatArtwork
+from aiosendspin.models.core import StreamRequestFormatPayload, StreamStartMessage
 from aiosendspin.models.types import ArtworkSource, PictureFormat
 from aiosendspin.server.roles.artwork.group import ArtworkGroupRole
 from aiosendspin.server.roles.artwork.v1 import ArtworkV1Role
@@ -212,3 +212,32 @@ def test_artwork_role_on_connect_schedules_artwork_once_per_channel() -> None:
 
     channels_sent = [call.args[2] for call in schedule.call_args_list]
     assert sorted(channels_sent) == [0, 1]
+
+
+def test_artwork_partial_format_request_preserves_unchanged_fields() -> None:
+    """A partial stream/request-format only overwrites fields the client included."""
+    client = _make_client_stub()
+    support = MagicMock()
+    support.channels = [
+        ArtworkChannel(
+            source=ArtworkSource.ALBUM,
+            format=PictureFormat.JPEG,
+            media_width=300,
+            media_height=300,
+        ),
+    ]
+    client.info.artwork_support = support
+
+    role = ArtworkV1Role(client=client)
+    role.on_connect()
+
+    payload = StreamRequestFormatPayload(
+        artwork=StreamRequestFormatArtwork(channel=0, format=PictureFormat.PNG),
+    )
+    role.on_stream_request_format(payload)
+
+    configs = role.get_channel_configs()
+    assert configs[0].format == PictureFormat.PNG
+    assert configs[0].source == ArtworkSource.ALBUM
+    assert configs[0].media_width == 300
+    assert configs[0].media_height == 300

--- a/tests/server/roles/artwork/test_v1.py
+++ b/tests/server/roles/artwork/test_v1.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from aiosendspin.models.artwork import ArtworkChannel
 from aiosendspin.models.core import StreamStartMessage
 from aiosendspin.models.types import ArtworkSource, PictureFormat
+from aiosendspin.server.roles.artwork.group import ArtworkGroupRole
 from aiosendspin.server.roles.artwork.v1 import ArtworkV1Role
 
 
@@ -170,3 +171,44 @@ def test_artwork_role_has_no_audio_requirements() -> None:
     client = _make_client_stub()
     role = ArtworkV1Role(client=client)
     assert role.get_audio_requirements() is None
+
+
+def test_artwork_role_on_connect_schedules_artwork_once_per_channel() -> None:
+    """on_connect() schedules a single artwork snapshot per configured channel."""
+    from PIL import Image  # noqa: PLC0415
+
+    client = _make_client_stub()
+    support = MagicMock()
+    support.channels = [
+        ArtworkChannel(
+            source=ArtworkSource.ALBUM,
+            format=PictureFormat.JPEG,
+            media_width=300,
+            media_height=300,
+        ),
+        ArtworkChannel(
+            source=ArtworkSource.ARTIST,
+            format=PictureFormat.PNG,
+            media_width=400,
+            media_height=400,
+        ),
+    ]
+    client.info.artwork_support = support
+    client.connection = MagicMock()
+
+    group = MagicMock()
+    group._server = MagicMock()  # noqa: SLF001
+    group._server.clock.now_us.return_value = 1_000_000  # noqa: SLF001
+    group_role = ArtworkGroupRole(group)
+    group_role._current_artwork = {  # noqa: SLF001
+        ArtworkSource.ALBUM: Image.new("RGB", (10, 10)),
+        ArtworkSource.ARTIST: Image.new("RGB", (10, 10)),
+    }
+    client.group.group_role.return_value = group_role
+
+    role = ArtworkV1Role(client=client)
+    with patch.object(group_role, "_schedule_send_artwork") as schedule:
+        role.on_connect()
+
+    channels_sent = [call.args[2] for call in schedule.call_args_list]
+    assert sorted(channels_sent) == [0, 1]

--- a/tests/server/roles/metadata/test_group.py
+++ b/tests/server/roles/metadata/test_group.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock
 
 from aiosendspin.models.core import ServerStateMessage
+from aiosendspin.models.types import UndefinedField
 from aiosendspin.server.roles.metadata import Metadata, MetadataClearedEvent, MetadataUpdatedEvent
 from aiosendspin.server.roles.metadata.group import MetadataGroupRole
 
@@ -252,3 +253,59 @@ def test_metadata_group_role_member_join_does_not_rewind_after_freeze() -> None:
     assert msg.payload.metadata.progress is not None
     assert msg.payload.metadata.progress.track_progress == 40_000
     assert msg.payload.metadata.progress.playback_speed == 0
+
+
+def test_progress_set_on_first_update() -> None:
+    """diff_update emits a full Progress object on the first update."""
+    current = Metadata(
+        title="Song",
+        track_progress=5_000,
+        track_duration=180_000,
+        playback_speed=1000,
+    )
+
+    update = current.diff_update(None, timestamp=1_000_000)
+
+    assert update.progress is not None
+    assert not isinstance(update.progress, UndefinedField)
+    assert update.progress.track_progress == 5_000
+    assert update.progress.track_duration == 180_000
+    assert update.progress.playback_speed == 1000
+
+
+def test_progress_cleared_when_track_progress_becomes_none() -> None:
+    """diff_update emits progress=null when previous state had progress and new doesn't."""
+    last = Metadata(
+        title="Song",
+        track_progress=12_345,
+        track_duration=180_000,
+        playback_speed=1000,
+    )
+    current = Metadata(title="Loading next track...")
+
+    update = current.diff_update(last, timestamp=2_000_000)
+
+    assert update.progress is None
+    assert update.to_dict()["progress"] is None
+    assert '"progress":null' in update.to_json()
+
+
+def test_progress_omitted_when_unchanged() -> None:
+    """diff_update omits progress when no progress field changed."""
+    last = Metadata(
+        title="Song",
+        track_progress=5_000,
+        track_duration=180_000,
+        playback_speed=1000,
+    )
+    current = Metadata(
+        title="New Title",
+        track_progress=5_000,
+        track_duration=180_000,
+        playback_speed=1000,
+    )
+
+    update = current.diff_update(last, timestamp=2_000_000)
+
+    assert isinstance(update.progress, UndefinedField)
+    assert "progress" not in update.to_json()

--- a/tests/server/roles/metadata/test_v1.py
+++ b/tests/server/roles/metadata/test_v1.py
@@ -6,6 +6,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from aiosendspin.models.core import ServerStateMessage
+from aiosendspin.server.roles.metadata.group import MetadataGroupRole
+from aiosendspin.server.roles.metadata.state import Metadata
 from aiosendspin.server.roles.metadata.v1 import MetadataV1Role
 
 
@@ -75,3 +78,28 @@ def test_metadata_role_has_no_audio_requirements() -> None:
     client = _make_client_stub()
     role = MetadataV1Role(client=client)
     assert role.get_audio_requirements() is None
+
+
+def test_metadata_role_on_connect_sends_state_exactly_once() -> None:
+    """on_connect() emits a single ServerStateMessage via on_member_join."""
+    group = MagicMock()
+    group._server = MagicMock()  # noqa: SLF001
+    group._server.clock.now_us.return_value = 1_000_000  # noqa: SLF001
+    group.has_active_stream = False
+    group_role = MetadataGroupRole(group)
+    group_role.set_metadata(Metadata(title="Test"))
+
+    client = MagicMock()
+    client.connection = MagicMock()
+    client.group.group_role.return_value = group_role
+    client.send_role_message = MagicMock()
+
+    role = MetadataV1Role(client=client)
+    role.on_connect()
+
+    state_calls = [
+        call
+        for call in client.send_role_message.call_args_list
+        if isinstance(call.args[1], ServerStateMessage)
+    ]
+    assert len(state_calls) == 1

--- a/tests/server/roles/player/test_group.py
+++ b/tests/server/roles/player/test_group.py
@@ -2,13 +2,82 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
+from aiosendspin.server.events import ClientEvent
 from aiosendspin.server.roles.player.events import (
     PlayerGroupMuteChangedEvent,
     PlayerGroupVolumeChangedEvent,
+    VolumeChangedEvent,
 )
 from aiosendspin.server.roles.player.group import PlayerGroupRole
+
+if TYPE_CHECKING:
+    from aiosendspin.server.client import SendspinClient
+
+
+class _ClientStub:
+    """Minimal SendspinClient stub with event listener wiring."""
+
+    def __init__(self, *, negotiated_roles: list[str] | None = None) -> None:
+        self.negotiated_roles = negotiated_roles or ["player@v1"]
+        self._cbs: list[Callable[[SendspinClient, ClientEvent], None]] = []
+
+    def add_event_listener(
+        self, callback: Callable[[SendspinClient, ClientEvent], None]
+    ) -> Callable[[], None]:
+        self._cbs.append(callback)
+
+        def _remove() -> None:
+            if callback in self._cbs:
+                self._cbs.remove(callback)
+
+        return _remove
+
+    def signal(self, event: ClientEvent) -> None:
+        for cb in list(self._cbs):
+            cb(self, event)  # type: ignore[arg-type]
+
+
+class _PlayerStub:
+    """Minimal player role with mutable volume/mute used to drive aggregation."""
+
+    def __init__(self, client: _ClientStub, *, volume: int = 100, muted: bool = False) -> None:
+        self._client = client
+        self._volume = volume
+        self._muted = muted
+
+    def get_player_volume(self) -> int | None:
+        return self._volume
+
+    def get_player_muted(self) -> bool | None:
+        return self._muted
+
+    def set_player_volume(self, volume: int) -> None:  # noqa: ARG002
+        # Production set_volume is send-only; the echoed `client/state` is what
+        # mutates the role's volume. Tests drive that echo explicitly below.
+        return
+
+    def set_player_mute(self, muted: bool) -> None:  # noqa: ARG002, FBT001
+        return
+
+    def echo_state(self, *, volume: int | None = None, muted: bool | None = None) -> None:
+        if volume is not None:
+            self._volume = volume
+        if muted is not None:
+            self._muted = muted
+        self._client.signal(VolumeChangedEvent(volume=self._volume, muted=self._muted))
+
+
+def _build(*players: _PlayerStub) -> tuple[PlayerGroupRole, MagicMock]:
+    group = MagicMock()
+    pgr = PlayerGroupRole(group)
+    pgr._members = list(players)  # type: ignore[assignment]  # noqa: SLF001
+    for player in players:
+        pgr.on_client_added(player._client)  # type: ignore[arg-type]  # noqa: SLF001
+    return pgr, group
 
 
 def test_player_group_role_volume_empty() -> None:
@@ -109,31 +178,6 @@ def test_player_group_role_muted_none_returns_false() -> None:
     assert pgr.muted is False
 
 
-def test_player_group_role_set_mute_propagates() -> None:
-    """Propagate mute state to all players."""
-    group = MagicMock()
-    pgr = PlayerGroupRole(group)
-
-    p1 = MagicMock()
-    p2 = MagicMock()
-    muted_state = {"p1": False, "p2": False}
-    p1.get_player_muted.side_effect = lambda: muted_state["p1"]
-    p2.get_player_muted.side_effect = lambda: muted_state["p2"]
-    p1.set_player_mute.side_effect = lambda muted: muted_state.__setitem__("p1", muted)
-    p2.set_player_mute.side_effect = lambda muted: muted_state.__setitem__("p2", muted)
-    pgr._members = [p1, p2]  # noqa: SLF001
-
-    pgr.set_mute(muted=True)
-
-    p1.set_player_mute.assert_called_once_with(True)  # noqa: FBT003
-    p2.set_player_mute.assert_called_once_with(True)  # noqa: FBT003
-    group._signal_event.assert_called_once()  # noqa: SLF001
-    event = group._signal_event.call_args.args[0]  # noqa: SLF001
-    assert isinstance(event, PlayerGroupMuteChangedEvent)
-    assert event.previous_muted is False
-    assert event.muted is True
-
-
 def test_player_group_role_set_volume_empty() -> None:
     """Set volume on empty group is a no-op."""
     group = MagicMock()
@@ -142,25 +186,96 @@ def test_player_group_role_set_volume_empty() -> None:
     pgr.set_volume(50)  # Should not raise
 
 
-def test_player_group_role_set_volume_single_player() -> None:
-    """Set volume on single player sets that player's volume."""
-    group = MagicMock()
-    pgr = PlayerGroupRole(group)
-
-    player = MagicMock()
-    state = {"volume": 100}
-    player.get_player_volume.side_effect = lambda: state["volume"]
-    player.set_player_volume.side_effect = lambda volume: state.__setitem__("volume", volume)
-    pgr._members = [player]  # noqa: SLF001
+def test_player_group_role_set_volume_does_not_emit_synchronously() -> None:
+    """`set_volume` only dispatches commands; events wait for the client echo."""
+    p1 = _PlayerStub(_ClientStub(), volume=100)
+    p2 = _PlayerStub(_ClientStub(), volume=100)
+    pgr, group = _build(p1, p2)
 
     pgr.set_volume(50)
 
-    player.set_player_volume.assert_called_once_with(50)
-    group._signal_event.assert_called_once()  # noqa: SLF001
-    event = group._signal_event.call_args.args[0]  # noqa: SLF001
-    assert isinstance(event, PlayerGroupVolumeChangedEvent)
-    assert event.previous_volume == 100
-    assert event.volume == 50
+    group._signal_event.assert_not_called()  # noqa: SLF001
+
+
+def test_player_group_role_emits_volume_when_clients_echo_state() -> None:
+    """Group event fires when player client/state echoes complete the transition."""
+    p1 = _PlayerStub(_ClientStub(), volume=100)
+    p2 = _PlayerStub(_ClientStub(), volume=100)
+    pgr, group = _build(p1, p2)
+
+    pgr.set_volume(50)
+    p1.echo_state(volume=50)
+    p2.echo_state(volume=50)
+
+    volume_events = [
+        call.args[0]
+        for call in group._signal_event.call_args_list  # noqa: SLF001
+        if isinstance(call.args[0], PlayerGroupVolumeChangedEvent)
+    ]
+    assert len(volume_events) >= 1
+    final = volume_events[-1]
+    assert final.volume == 50
+
+
+def test_player_group_role_volume_event_carries_previous_value() -> None:
+    """`previous_volume` reflects the last emitted group volume."""
+    p1 = _PlayerStub(_ClientStub(), volume=100)
+    p2 = _PlayerStub(_ClientStub(), volume=100)
+    _pgr, group = _build(p1, p2)
+
+    # Seed the cached last-emitted volume with the starting group volume.
+    p1.echo_state(volume=100)
+
+    group._signal_event.reset_mock()  # noqa: SLF001
+    p1.echo_state(volume=60)
+    p2.echo_state(volume=40)
+
+    volume_events = [
+        call.args[0]
+        for call in group._signal_event.call_args_list  # noqa: SLF001
+        if isinstance(call.args[0], PlayerGroupVolumeChangedEvent)
+    ]
+    assert volume_events
+    final = volume_events[-1]
+    assert final.previous_volume != final.volume
+    assert final.volume == 50
+
+
+def test_player_group_role_set_mute_does_not_emit_synchronously() -> None:
+    """`set_mute` only dispatches commands; events wait for the client echo."""
+    p1 = _PlayerStub(_ClientStub(), muted=False)
+    p2 = _PlayerStub(_ClientStub(), muted=False)
+    pgr, group = _build(p1, p2)
+
+    pgr.set_mute(muted=True)
+
+    group._signal_event.assert_not_called()  # noqa: SLF001
+
+
+def test_player_group_role_emits_mute_when_all_clients_echo_state() -> None:
+    """`PlayerGroupMuteChangedEvent` fires only once all players echo muted."""
+    p1 = _PlayerStub(_ClientStub(), muted=False)
+    p2 = _PlayerStub(_ClientStub(), muted=False)
+    pgr, group = _build(p1, p2)
+
+    pgr.set_mute(muted=True)
+    p1.echo_state(muted=True)
+    mute_events = [
+        call.args[0]
+        for call in group._signal_event.call_args_list  # noqa: SLF001
+        if isinstance(call.args[0], PlayerGroupMuteChangedEvent)
+    ]
+    assert mute_events == []  # not yet — group muted only when ALL muted
+
+    p2.echo_state(muted=True)
+    mute_events = [
+        call.args[0]
+        for call in group._signal_event.call_args_list  # noqa: SLF001
+        if isinstance(call.args[0], PlayerGroupMuteChangedEvent)
+    ]
+    assert len(mute_events) == 1
+    assert mute_events[0].previous_muted is False
+    assert mute_events[0].muted is True
 
 
 def test_player_group_role_set_volume_redistributes() -> None:
@@ -227,14 +342,27 @@ def test_player_group_role_set_volume_skips_none() -> None:
 
 
 def test_player_group_role_set_volume_no_change_no_event() -> None:
-    """No event is emitted when effective group volume is unchanged."""
-    group = MagicMock()
-    pgr = PlayerGroupRole(group)
+    """No event is emitted when effective group volume is unchanged across echoes."""
+    p1 = _PlayerStub(_ClientStub(), volume=50)
+    _pgr, group = _build(p1)
 
-    player = MagicMock()
-    player.get_player_volume.return_value = 50
-    pgr._members = [player]  # noqa: SLF001
+    # Prime the last-emitted state to match current.
+    p1.echo_state(volume=50)
+    group._signal_event.reset_mock()  # noqa: SLF001
 
-    pgr.set_volume(50)
+    # Re-echo same volume — no transition.
+    p1.echo_state(volume=50)
+
+    group._signal_event.assert_not_called()  # noqa: SLF001
+
+
+def test_player_group_role_unsubscribes_on_client_removed() -> None:
+    """`on_client_removed` stops aggregating that client's volume echoes."""
+    client = _ClientStub()
+    player = _PlayerStub(client, volume=50)
+    pgr, group = _build(player)
+
+    pgr.on_client_removed(client)  # type: ignore[arg-type]
+    player.echo_state(volume=20)
 
     group._signal_event.assert_not_called()  # noqa: SLF001

--- a/tests/server/roles/player/test_group.py
+++ b/tests/server/roles/player/test_group.py
@@ -296,6 +296,26 @@ def test_player_group_role_set_volume_redistributes() -> None:
     p2.set_player_volume.assert_called_once_with(50)
 
 
+def test_player_group_role_set_volume_redistributes_through_iterative_clamp() -> None:
+    """Asymmetric starting volumes still hit the target after iterative redistribution."""
+    group = MagicMock()
+    pgr = PlayerGroupRole(group)
+
+    p1 = MagicMock()
+    p1.get_player_volume.return_value = 90
+    p2 = MagicMock()
+    p2.get_player_volume.return_value = 70
+    p3 = MagicMock()
+    p3.get_player_volume.return_value = 30
+    pgr._members = [p1, p2, p3]  # noqa: SLF001
+
+    pgr.set_volume(100)
+
+    p1.set_player_volume.assert_called_once_with(100)
+    p2.set_player_volume.assert_called_once_with(100)
+    p3.set_player_volume.assert_called_once_with(100)
+
+
 def test_player_group_role_set_volume_clamps_to_zero() -> None:
     """Set volume clamps player volumes to 0 minimum."""
     group = MagicMock()

--- a/tests/server/roles/test_player_v1.py
+++ b/tests/server/roles/test_player_v1.py
@@ -934,6 +934,24 @@ def test_partial_client_state_does_not_reset_timing_fields() -> None:
     assert VolumeChangedEvent in emitted_types
 
 
+def test_explicit_zero_static_delay_in_delta_updates_field() -> None:
+    """A delta of static_delay_ms=0 sets the field to 0 and fires its event."""
+    client = _make_client_stub()
+    role = PlayerV1Role(client=client)
+
+    role.on_client_state(ClientStatePayload(player=PlayerStatePayload(static_delay_ms=400)))
+    assert role.static_delay_ms == 400
+
+    client._signal_event.reset_mock()  # noqa: SLF001
+
+    role.on_client_state(ClientStatePayload(player=PlayerStatePayload(static_delay_ms=0)))
+
+    assert role.static_delay_ms == 0
+    event = client._signal_event.call_args[0][0]  # noqa: SLF001
+    assert isinstance(event, StaticDelayChangedEvent)
+    assert event.static_delay_ms == 0
+
+
 def test_on_client_state_updates_supported_commands() -> None:
     """on_client_state() updates state_supported_commands."""
     client = _make_client_stub()

--- a/tests/server/roles/test_player_v1.py
+++ b/tests/server/roles/test_player_v1.py
@@ -25,6 +25,8 @@ from aiosendspin.server.roles.player.audio_transformers import FlacEncoder, PcmP
 from aiosendspin.server.roles.player.events import (
     MinBufferChangedEvent,
     RequiredLeadTimeChangedEvent,
+    StaticDelayChangedEvent,
+    VolumeChangedEvent,
 )
 
 # --- Basic properties ---
@@ -891,6 +893,45 @@ def test_on_client_state_updates_min_buffer() -> None:
     event = client._signal_event.call_args[0][0]  # noqa: SLF001
     assert isinstance(event, MinBufferChangedEvent)
     assert event.min_buffer_ms == 1500
+
+
+def test_partial_client_state_does_not_reset_timing_fields() -> None:
+    """A delta carrying only `volume` must leave timing fields and events untouched."""
+    client = _make_client_stub()
+    client.info.player_support = _make_player_support(
+        SupportedAudioFormat(codec=AudioCodec.PCM, channels=2, sample_rate=48000, bit_depth=16),
+    )
+    role = PlayerV1Role(client=client)
+
+    role.on_client_state(
+        ClientStatePayload(
+            player=PlayerStatePayload(
+                volume=80,
+                static_delay_ms=400,
+                required_lead_time_ms=120,
+                min_buffer_ms=600,
+            )
+        )
+    )
+    assert role.static_delay_ms == 400
+    assert role.required_lead_time_ms == 120
+    assert role.min_buffer_ms == 600
+
+    client._signal_event.reset_mock()  # noqa: SLF001
+
+    role.on_client_state(ClientStatePayload(player=PlayerStatePayload(volume=70)))
+
+    assert role.static_delay_ms == 400
+    assert role.required_lead_time_ms == 120
+    assert role.min_buffer_ms == 600
+    emitted_types = [
+        type(call.args[0])
+        for call in client._signal_event.call_args_list  # noqa: SLF001
+    ]
+    assert StaticDelayChangedEvent not in emitted_types
+    assert RequiredLeadTimeChangedEvent not in emitted_types
+    assert MinBufferChangedEvent not in emitted_types
+    assert VolumeChangedEvent in emitted_types
 
 
 def test_on_client_state_updates_supported_commands() -> None:

--- a/tests/server/roles/visualizer/test_v1.py
+++ b/tests/server/roles/visualizer/test_v1.py
@@ -1153,3 +1153,23 @@ async def test_track_change_keeps_parked_periodic_frames() -> None:
     role._run_release_scheduler()  # noqa: SLF001
     assert _periodic_calls(client), "parked frame should release after the track change"
     role._cancel_release_timer()  # noqa: SLF001
+
+
+def test_request_format_partial_preserves_unchanged_fields() -> None:
+    """A partial stream/request-format keeps prior values for omitted fields."""
+    client = _make_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_connect()
+    role.on_stream_start()
+
+    original_types = list(role._stream_config.types)  # noqa: SLF001
+    original_buffer = role._support.buffer_capacity  # noqa: SLF001
+    original_spectrum = role._stream_config.spectrum  # noqa: SLF001
+
+    payload = StreamRequestFormatPayload(visualizer=StreamRequestFormatVisualizer(rate_max=15))
+    role.on_stream_request_format(payload)
+
+    assert role._stream_config.rate_max == 15  # noqa: SLF001
+    assert list(role._stream_config.types) == original_types  # noqa: SLF001
+    assert role._support.buffer_capacity == original_buffer  # noqa: SLF001
+    assert role._stream_config.spectrum == original_spectrum  # noqa: SLF001

--- a/tests/server/test_buffer_tracker.py
+++ b/tests/server/test_buffer_tracker.py
@@ -238,3 +238,55 @@ def test_buffered_horizon_us_tracks_furthest_end_from_now() -> None:
     clock.set_now(250_000)
     # First chunk is pruned; horizon is from now to the second chunk's end.
     assert tracker.buffered_horizon_us() == 250_000
+
+
+def test_has_capacity_now_oversize_blocks_while_buffered() -> None:
+    """Oversize chunk must wait for the buffer to drain before being admitted."""
+    clock = _FakeClock(now_us=0)
+    tracker = BufferTracker(
+        clock=clock,
+        client_id="test",
+        capacity_bytes=1000,
+    )
+
+    tracker.register(end_time_us=100_000, byte_count=500, duration_us=100_000)
+
+    assert tracker.has_capacity_now(1500) is False
+
+
+def test_has_capacity_now_oversize_passes_when_empty() -> None:
+    """Oversize chunk is admitted alone when the buffer is empty."""
+    clock = _FakeClock(now_us=0)
+    tracker = BufferTracker(
+        clock=clock,
+        client_id="test",
+        capacity_bytes=1000,
+    )
+
+    assert tracker.has_capacity_now(1500) is True
+
+
+def test_time_until_capacity_oversize_returns_wait_while_buffered() -> None:
+    """Oversize chunk reports the wait until existing buffered audio fully drains."""
+    clock = _FakeClock(now_us=0)
+    tracker = BufferTracker(
+        clock=clock,
+        client_id="test",
+        capacity_bytes=1000,
+    )
+
+    tracker.register(end_time_us=100_000, byte_count=500, duration_us=100_000)
+
+    assert tracker.time_until_capacity(1500) == 100_000
+
+
+def test_time_until_capacity_oversize_zero_when_empty() -> None:
+    """Oversize chunk waits no time when the buffer is already empty."""
+    clock = _FakeClock(now_us=0)
+    tracker = BufferTracker(
+        clock=clock,
+        client_id="test",
+        capacity_bytes=1000,
+    )
+
+    assert tracker.time_until_capacity(1500) == 0

--- a/tests/server/test_connection_writer.py
+++ b/tests/server/test_connection_writer.py
@@ -21,7 +21,12 @@ from aiosendspin.models.core import (
 from aiosendspin.models.player import StreamStartPlayer
 from aiosendspin.models.types import AudioCodec, BinaryMessageType
 from aiosendspin.server.clock import LoopClock, ManualClock
-from aiosendspin.server.connection import SendspinConnection, _BinaryData, _RoleQueueEntry
+from aiosendspin.server.connection import (
+    MAX_PENDING_MSG,
+    SendspinConnection,
+    _BinaryData,
+    _RoleQueueEntry,
+)
 from aiosendspin.server.roles.base import BinaryHandling
 from aiosendspin.server.roles.player.v1 import PlayerV1Role
 
@@ -466,6 +471,36 @@ async def test_send_binary_disconnects_on_per_role_queue_overflow() -> None:
     await asyncio.sleep(0)
 
     assert conn.disconnect.call_count == 1  # type: ignore[attr-defined]
+
+
+def test_priority_message_queue_cap_uses_own_length() -> None:
+    """Priority queue cap should ignore unrelated role-queue bytes in `_queue_size`."""
+    loop = asyncio.new_event_loop()
+    try:
+        server = _DummyServer(loop=loop, clock=LoopClock(loop))
+        wsock = MagicMock()
+        wsock.closed = False
+        conn = SendspinConnection(server, wsock_client=wsock)
+        conn.disconnect = AsyncMock()  # type: ignore[method-assign]
+
+        # Simulate saturated role queues: aggregate _queue_size above the priority cap
+        # without putting anything into _priority_messages itself.
+        conn._queue_size = MAX_PENDING_MSG * 2  # noqa: SLF001
+
+        conn.send_priority_message(
+            ServerTimeMessage(
+                payload=ServerTimePayload(
+                    client_transmitted=1,
+                    server_received=2,
+                    server_transmitted=0,
+                )
+            )
+        )
+
+        assert conn.disconnect.call_count == 0  # type: ignore[attr-defined]
+        assert len(conn._priority_messages) == 1  # noqa: SLF001
+    finally:
+        loop.close()
 
 
 def test_per_role_queue_limit_is_isolated_between_roles() -> None:

--- a/tests/server/test_connection_writer.py
+++ b/tests/server/test_connection_writer.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from dataclasses import dataclass
 from typing import Any, Never
 from unittest.mock import AsyncMock, MagicMock
@@ -438,6 +439,53 @@ async def test_role_stream_lifecycle_json_is_sent_before_older_binary() -> None:
         await asyncio.sleep(0)
 
     assert send_order[:3] == ["json", "json", "binary"]
+
+    await conn.disconnect(retry_connection=False)
+
+
+@pytest.mark.asyncio
+async def test_writer_rewrites_server_transmitted_at_send_time() -> None:
+    """`server/time` must carry the clock value at actual send, not at enqueue."""
+    loop = asyncio.get_running_loop()
+    clock = ManualClock(now_us_value=1_000_000)
+    server = _DummyServer(loop=loop, clock=clock)
+
+    sent_json: list[str] = []
+
+    async def _record_json(payload: str) -> None:
+        sent_json.append(payload)
+
+    wsock = MagicMock()
+    wsock.closed = False
+    wsock.send_str = AsyncMock(side_effect=_record_json)
+    wsock.send_bytes = AsyncMock()
+
+    conn = SendspinConnection(server, wsock_client=wsock)
+    await conn._setup_connection()  # noqa: SLF001
+
+    conn.send_message(
+        ServerTimeMessage(
+            payload=ServerTimePayload(
+                client_transmitted=11,
+                server_received=22,
+                server_transmitted=0,
+            )
+        )
+    )
+
+    # Simulate enqueue-to-send latency before the writer drains the queue.
+    clock.advance_us(750_000)
+
+    for _ in range(50):
+        if sent_json:
+            break
+        await asyncio.sleep(0)
+
+    assert len(sent_json) == 1
+    payload = json.loads(sent_json[0])["payload"]
+    assert payload["client_transmitted"] == 11
+    assert payload["server_received"] == 22
+    assert payload["server_transmitted"] == 1_750_000
 
     await conn.disconnect(retry_connection=False)
 

--- a/tests/server/test_external_players.py
+++ b/tests/server/test_external_players.py
@@ -574,15 +574,16 @@ async def test_reclaim_timeout_refreshes_on_repeated_requests(
         lambda _url, *, connection_reason: None,  # noqa: ARG005
     )
 
-    assert server.reclaim_client_for_playback("speaker-refresh", timeout_s=0.12)
-    await asyncio.sleep(0.07)
-    assert server.reclaim_client_for_playback("speaker-refresh", timeout_s=0.12)
+    # Inflated to ~5x the timeout to absorb CI scheduler jitter (#28 in REVIEW.md)
+    assert server.reclaim_client_for_playback("speaker-refresh", timeout_s=0.5)
+    await asyncio.sleep(0.3)
+    assert server.reclaim_client_for_playback("speaker-refresh", timeout_s=0.5)
 
-    await asyncio.sleep(0.07)
+    await asyncio.sleep(0.3)
     await _flush_asyncio_callbacks()
     assert server.get_client("speaker-refresh") is not None
 
-    await asyncio.sleep(0.08)
+    await asyncio.sleep(0.7)
     await _flush_asyncio_callbacks()
     assert server.get_client("speaker-refresh") is None
 

--- a/tests/server/test_external_source.py
+++ b/tests/server/test_external_source.py
@@ -1,0 +1,374 @@
+"""Tests for client-level external_source handling and switch cycling.
+
+These cover the state machine that was previously embedded in the controller
+role: any client (regardless of negotiated roles) entering ``external_source``
+must be pulled out of multi-client groups, and the switch command must respect
+the previous-group rejoin priority and the spec's cycle ordering.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+from dataclasses import dataclass
+
+import pytest
+
+from aiosendspin.models.controller import ControllerCommandPayload
+from aiosendspin.models.core import (
+    ClientCommandPayload,
+    ClientHelloPayload,
+    StreamEndMessage,
+)
+from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
+from aiosendspin.models.types import (
+    AudioCodec,
+    ClientStateType,
+    MediaCommand,
+    PlaybackStateType,
+    PlayerCommand,
+    Roles,
+)
+from aiosendspin.server.client import SendspinClient
+from aiosendspin.server.clock import LoopClock
+from aiosendspin.server.group import SendspinGroup
+from aiosendspin.server.roles.controller.v1 import ControllerV1Role
+
+
+@dataclass(slots=True)
+class _DummyServer:
+    loop: asyncio.AbstractEventLoop
+    clock: LoopClock
+    id: str = "srv"
+    name: str = "server"
+    _clients: dict[str, SendspinClient] = dataclasses.field(default_factory=dict)
+
+    def is_external_player(self, client_id: str) -> bool:  # noqa: ARG002
+        return False
+
+    def _signal_client_updated(self, client_id: str) -> None:
+        pass
+
+    def register(self, client: SendspinClient) -> None:
+        self._clients[client.client_id] = client
+
+    @property
+    def connected_clients(self) -> list[SendspinClient]:
+        return [c for c in self._clients.values() if c.is_connected]
+
+    def request_client_playback_connection(self, client_id: str) -> bool:  # noqa: ARG002
+        return False
+
+
+class _DummyConnection:
+    def __init__(self) -> None:
+        self.sent_messages: list[object] = []
+
+    async def disconnect(self, *, retry_connection: bool = True) -> None:  # noqa: ARG002
+        return
+
+    def send_message(self, message: object) -> None:
+        self.sent_messages.append(message)
+
+    def send_role_message(self, role: str, message: object) -> None:  # noqa: ARG002
+        self.sent_messages.append(message)
+
+    def send_binary(
+        self,
+        data: bytes,  # noqa: ARG002
+        *,
+        role: str,  # noqa: ARG002
+        timestamp_us: int,  # noqa: ARG002
+        message_type: int,  # noqa: ARG002
+        buffer_end_time_us: int | None = None,  # noqa: ARG002
+        buffer_byte_count: int | None = None,  # noqa: ARG002
+        duration_us: int | None = None,  # noqa: ARG002
+    ) -> bool:
+        return True
+
+
+def _hello(client_id: str, *, supported_roles: list[str]) -> ClientHelloPayload:
+    player_support: ClientHelloPlayerSupport | None = None
+    if Roles.PLAYER.value in supported_roles:
+        player_support = ClientHelloPlayerSupport(
+            supported_formats=[
+                SupportedAudioFormat(
+                    codec=AudioCodec.PCM,
+                    channels=2,
+                    sample_rate=48000,
+                    bit_depth=16,
+                )
+            ],
+            buffer_capacity=100_000,
+            supported_commands=[PlayerCommand.VOLUME, PlayerCommand.MUTE],
+        )
+    return ClientHelloPayload(
+        client_id=client_id,
+        name=client_id,
+        version=1,
+        supported_roles=supported_roles,
+        player_support=player_support,
+    )
+
+
+def _make_client(
+    server: _DummyServer, client_id: str, *, supported_roles: list[str]
+) -> tuple[SendspinClient, _DummyConnection]:
+    client = SendspinClient(server, client_id=client_id)
+    server.register(client)
+    SendspinGroup(server, client)
+    conn = _DummyConnection()
+    client.attach_connection(
+        conn,
+        client_info=_hello(client_id, supported_roles=supported_roles),
+        active_roles=supported_roles,
+    )
+    client.mark_connected()
+    return client, conn
+
+
+@pytest.mark.asyncio
+async def test_external_source_moves_player_only_client_out_of_multi_group() -> None:
+    """Player-only client entering external_source must leave the shared group."""
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+
+    player_a, conn_a = _make_client(server, "player-a", supported_roles=[Roles.PLAYER.value])
+    player_b, _ = _make_client(server, "player-b", supported_roles=[Roles.PLAYER.value])
+
+    shared_group = player_a.group
+    await shared_group.add_client(player_b)
+    assert player_a.group is player_b.group
+    assert len(shared_group.clients) == 2
+    shared_group_id = shared_group.group_id
+
+    conn_a.sent_messages.clear()
+    await player_a.handle_state_transition(ClientStateType.EXTERNAL_SOURCE)
+
+    # Player A left the shared group, landed in a solo group.
+    assert player_a not in shared_group.clients
+    assert player_a.group is not shared_group
+    assert len(player_a.group.clients) == 1
+
+    # Previous group bookkeeping was recorded for later rejoin.
+    assert player_a._previous_group_id == shared_group_id  # noqa: SLF001
+    assert player_a._external_source_solo_group_id == player_a.group.group_id  # noqa: SLF001
+
+    # The player role's on_stream_end fired stream/end on the connection.
+    assert any(isinstance(msg, StreamEndMessage) for msg in conn_a.sent_messages)
+
+
+@pytest.mark.asyncio
+async def test_external_source_in_solo_group_stops_playback() -> None:
+    """Already-solo client transitioning to external_source stops the group."""
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+
+    player, _ = _make_client(server, "player-solo", supported_roles=[Roles.PLAYER.value])
+    group = player.group
+    group.start_stream()
+    assert group.state == PlaybackStateType.PLAYING
+
+    await player.handle_state_transition(ClientStateType.EXTERNAL_SOURCE)
+
+    # Same solo group, now stopped.
+    assert player.group is group
+    assert group.state == PlaybackStateType.STOPPED
+    # No previous group recorded; we were already solo.
+    assert player._previous_group_id is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_switch_after_external_source_rejoins_previous_group() -> None:
+    """Switch command after leaving external_source rejoins the original group."""
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+
+    client, _ = _make_client(
+        server,
+        "ctrl-player",
+        supported_roles=[Roles.PLAYER.value, Roles.CONTROLLER.value],
+    )
+    other, _ = _make_client(server, "player-other", supported_roles=[Roles.PLAYER.value])
+
+    shared_group = client.group
+    await shared_group.add_client(other)
+    assert client.group is other.group
+    shared_group_id = shared_group.group_id
+
+    # Enter external_source — moved to solo, previous group remembered.
+    await client.handle_state_transition(ClientStateType.EXTERNAL_SOURCE)
+    assert client._previous_group_id == shared_group_id  # noqa: SLF001
+    assert client.group is not shared_group
+
+    # Leave external_source.
+    await client.handle_state_transition(ClientStateType.SYNCHRONIZED)
+
+    # Switch command should rejoin the previous (shared) group.
+    await client.handle_switch_command()
+
+    assert client.group is shared_group
+    # Previous-group tracking is cleared after the rejoin.
+    assert client._previous_group_id is None  # noqa: SLF001
+    assert client._external_source_solo_group_id is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_switch_while_in_external_source_is_ignored() -> None:
+    """Switch must not move a client that is still in external_source."""
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+
+    client, _ = _make_client(
+        server,
+        "ctrl",
+        supported_roles=[Roles.PLAYER.value, Roles.CONTROLLER.value],
+    )
+    other, _ = _make_client(server, "other-player", supported_roles=[Roles.PLAYER.value])
+    other_group = other.group
+    other_group.start_stream()
+
+    await client.handle_state_transition(ClientStateType.EXTERNAL_SOURCE)
+    group_before = client.group
+
+    await client.handle_switch_command()
+
+    assert client.group is group_before
+
+
+@pytest.mark.asyncio
+async def test_switch_cycle_for_player_client_ends_with_solo_option() -> None:
+    """Player clients see multi-client playing -> single playing -> solo option."""
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+
+    # Client under test holds player + controller, starts solo+stopped.
+    client, _ = _make_client(
+        server,
+        "ctrl-player",
+        supported_roles=[Roles.PLAYER.value, Roles.CONTROLLER.value],
+    )
+
+    # Multi-client playing group: alpha + beta.
+    alpha, _ = _make_client(server, "alpha", supported_roles=[Roles.PLAYER.value])
+    beta, _ = _make_client(server, "beta", supported_roles=[Roles.PLAYER.value])
+    multi_group = alpha.group
+    await multi_group.add_client(beta)
+    multi_group.start_stream()
+
+    # Single-player playing group: gamma.
+    gamma, _ = _make_client(server, "gamma", supported_roles=[Roles.PLAYER.value])
+    gamma_group = gamma.group
+    gamma_group.start_stream()
+
+    cycle = client._build_group_cycle(  # noqa: SLF001
+        client._get_all_groups(),  # noqa: SLF001
+        client.group,
+        has_player_role=True,
+    )
+
+    # current_group is solo+stopped, so the cycle ends with that same group as
+    # the "land in solo" option (not None).
+    assert cycle == [multi_group, gamma_group, client.group]
+    # First switch step jumps from the solo current group to the multi group.
+    await client.handle_switch_command()
+    assert client.group is multi_group
+
+
+@pytest.mark.asyncio
+async def test_switch_cycle_from_active_solo_uses_none_solo_marker() -> None:
+    """When the current group is not solo+stopped, the solo option is a new group."""
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+
+    client, _ = _make_client(
+        server,
+        "ctrl-player",
+        supported_roles=[Roles.PLAYER.value, Roles.CONTROLLER.value],
+    )
+    alpha, _ = _make_client(server, "alpha", supported_roles=[Roles.PLAYER.value])
+    beta, _ = _make_client(server, "beta", supported_roles=[Roles.PLAYER.value])
+    multi_group = alpha.group
+    await multi_group.add_client(beta)
+    multi_group.start_stream()
+    await multi_group.add_client(client)
+    assert client.group is multi_group
+
+    cycle = client._build_group_cycle(  # noqa: SLF001
+        client._get_all_groups(),  # noqa: SLF001
+        client.group,
+        has_player_role=True,
+    )
+
+    # Only one group exists now (multi_group with all three clients).
+    assert cycle == [multi_group, None]
+
+
+@pytest.mark.asyncio
+async def test_switch_cycle_for_non_player_client_omits_solo_option() -> None:
+    """Clients without the player role get no solo step in the switch cycle."""
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+
+    # Controller-only client (no player role).
+    client = SendspinClient(server, client_id="remote")
+    server.register(client)
+    SendspinGroup(server, client)
+    client.attach_connection(
+        _DummyConnection(),
+        client_info=ClientHelloPayload(
+            client_id="remote",
+            name="remote",
+            version=1,
+            supported_roles=[Roles.CONTROLLER.value],
+        ),
+        active_roles=[Roles.CONTROLLER.value],
+    )
+    client.mark_connected()
+
+    alpha, _ = _make_client(server, "alpha", supported_roles=[Roles.PLAYER.value])
+    beta, _ = _make_client(server, "beta", supported_roles=[Roles.PLAYER.value])
+    multi_group = alpha.group
+    await multi_group.add_client(beta)
+    multi_group.start_stream()
+
+    gamma, _ = _make_client(server, "gamma", supported_roles=[Roles.PLAYER.value])
+    gamma_group = gamma.group
+    gamma_group.start_stream()
+
+    cycle = client._build_group_cycle(  # noqa: SLF001
+        client._get_all_groups(),  # noqa: SLF001
+        client.group,
+        has_player_role=False,
+    )
+
+    assert cycle == [multi_group, gamma_group]
+
+
+@pytest.mark.asyncio
+async def test_controller_role_delegates_switch_command_to_client() -> None:
+    """ControllerV1Role's on_command must hand SWITCH to the client state machine."""
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+
+    client, _ = _make_client(
+        server,
+        "ctrl",
+        supported_roles=[Roles.PLAYER.value, Roles.CONTROLLER.value],
+    )
+    other, _ = _make_client(server, "other", supported_roles=[Roles.PLAYER.value])
+    other_group = other.group
+    other_group.start_stream()
+
+    controller_role = client.role(Roles.CONTROLLER.value)
+    assert isinstance(controller_role, ControllerV1Role)
+
+    controller_role.on_command(
+        ClientCommandPayload(controller=ControllerCommandPayload(command=MediaCommand.SWITCH))
+    )
+
+    # on_command schedules an eager task; yield twice to let it complete.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert client.group is other_group

--- a/tests/server/test_multi_server.py
+++ b/tests/server/test_multi_server.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 import orjson
 import pytest
 from aiohttp import web
+from mashumaro.exceptions import MissingField
 
 from aiosendspin.models.core import (
     ClientHelloMessage,
@@ -24,6 +25,7 @@ from aiosendspin.server.client import SendspinClient
 from aiosendspin.server.clock import LoopClock
 from aiosendspin.server.connection import SendspinConnection
 from aiosendspin.server.group import SendspinGroup
+from aiosendspin.server.roles.negotiation import negotiate_active_roles
 from aiosendspin.server.roles.registry import ROLE_FACTORIES
 
 if TYPE_CHECKING:
@@ -562,6 +564,253 @@ class TestCustomRoleSupportParsing:
         msg = SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
         assert isinstance(msg, ClientHelloMessage)
         assert msg.payload.visualizer_support is not None
+
+    def test_unknown_future_visualizer_version_ignored_with_schema_drift(self) -> None:
+        """Unregistered spec-versioned roles must not be parsed against the family schema.
+
+        Reproduces the forward-compat trap: a client running a future protocol
+        version sends `visualizer@v99_support` whose schema diverges from the
+        registered v1 spec. The server has no role registered for `v99` so per
+        spec it must ignore the role and proceed. The current implementation
+        greedy-parses against the v1 schema and raises MissingField.
+        """
+        raw = orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "c1",
+                    "name": "Client",
+                    "version": 1,
+                    "supported_roles": ["visualizer@v99"],
+                    "visualizer@v99_support": {
+                        "buffer_capacity": 65536,
+                        "spectrum": {
+                            "n_disp_bins": 48,
+                            "scale": "mel",
+                            "f_min": 20,
+                            "f_max": 20000,
+                            "rate_max": 30,
+                        },
+                    },
+                },
+            }
+        ).decode()
+
+        msg = SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
+        assert isinstance(msg, ClientHelloMessage)
+        assert msg.payload.visualizer_support is None
+
+    def test_unknown_future_player_version_ignored_with_schema_drift(self) -> None:
+        """A future player@vN support payload missing v1's required fields must not crash."""
+        raw = orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "c1",
+                    "name": "Client",
+                    "version": 1,
+                    "supported_roles": ["player@v99"],
+                    "player@v99_support": {"buffer_capacity": 100_000},
+                },
+            }
+        ).decode()
+
+        msg = SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
+        assert isinstance(msg, ClientHelloMessage)
+        assert msg.payload.player_support is None
+
+    def test_unknown_future_artwork_version_ignored_with_schema_drift(self) -> None:
+        """A future artwork@vN support payload missing v1's required fields must not crash."""
+        raw = orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "c1",
+                    "name": "Client",
+                    "version": 1,
+                    "supported_roles": ["artwork@v99"],
+                    "artwork@v99_support": {"some_new_field": "value"},
+                },
+            }
+        ).decode()
+
+        msg = SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
+        assert isinstance(msg, ClientHelloMessage)
+        assert msg.payload.artwork_support is None
+
+    def test_hello_with_draft_r1_only_parses_and_negotiates(self) -> None:
+        """Legacy `visualizer@_draft_r1` clients are still fully supported.
+
+        Wire-format round-trip: deserialize the hello, then run negotiation and
+        confirm the legacy role is the one that gets activated.
+        """
+        raw = orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "c1",
+                    "name": "Client",
+                    "version": 1,
+                    "supported_roles": ["visualizer@_draft_r1"],
+                    "visualizer@_draft_r1_support": {
+                        "types": ["loudness"],
+                        "buffer_capacity": 65_536,
+                        "spectrum": {
+                            "n_disp_bins": 48,
+                            "scale": "mel",
+                            "f_min": 20,
+                            "f_max": 20000,
+                            "rate_max": 30,
+                        },
+                    },
+                },
+            }
+        ).decode()
+
+        msg = SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
+        assert isinstance(msg, ClientHelloMessage)
+        assert msg.payload.visualizer_draft_r1_support is not None
+        assert msg.payload.visualizer_support is None
+        assert "visualizer@_draft_r1" in negotiate_active_roles(msg.payload.supported_roles)
+
+    def test_hello_with_v2_and_v1_mixed_falls_back_to_v1(self) -> None:
+        """When client offers `[v2, v1]` and server knows only v1, v1 is activated.
+
+        Reaches the architecture limit gracefully: client lists a newer protocol
+        version first, but the server picks the highest version it actually
+        registers. The unknown v2 support payload must be ignored, not parsed.
+        """
+        raw = orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "c1",
+                    "name": "Client",
+                    "version": 1,
+                    "supported_roles": ["visualizer@v2", "visualizer@v1"],
+                    "visualizer@v2_support": {"completely": "different schema"},
+                    "visualizer@v1_support": {
+                        "buffer_capacity": 65_536,
+                        "rate_max": 30,
+                        "types": ["loudness"],
+                    },
+                },
+            }
+        ).decode()
+
+        msg = SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
+        assert isinstance(msg, ClientHelloMessage)
+        assert msg.payload.visualizer_support is not None
+        assert negotiate_active_roles(msg.payload.supported_roles) == ["visualizer@v1"]
+
+    def test_hello_with_only_v2_drops_visualizer_role_entirely(self) -> None:
+        """Lone unsupported version → deserialize succeeds and family is inactive.
+
+        Spec: server should ignore unknown roles. Active_roles must reflect this
+        so the client can detect outdated servers and degrade gracefully.
+        """
+        raw = orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "c1",
+                    "name": "Client",
+                    "version": 1,
+                    "supported_roles": ["visualizer@v2"],
+                    "visualizer@v2_support": {"unknown_field": 1},
+                },
+            }
+        ).decode()
+
+        msg = SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
+        assert isinstance(msg, ClientHelloMessage)
+        assert msg.payload.visualizer_support is None
+        assert msg.payload.visualizer_draft_r1_support is None
+        assert negotiate_active_roles(msg.payload.supported_roles) == []
+
+    def test_hello_with_brand_new_family_does_not_crash(self) -> None:
+        """A family the server has never heard of is silently ignored end-to-end.
+
+        Guards against future role additions on the client side that the server
+        doesn't know about yet.
+        """
+        raw = orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "c1",
+                    "name": "Client",
+                    "version": 1,
+                    "supported_roles": ["crystalball@v1"],
+                    "crystalball@v1_support": {"forecast": "cloudy"},
+                },
+            }
+        ).decode()
+
+        msg = SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
+        assert isinstance(msg, ClientHelloMessage)
+        assert negotiate_active_roles(msg.payload.supported_roles) == []
+
+    def test_custom_underscore_player_version_with_v1_compatible_support_parses(self) -> None:
+        """`player@_experimental` (no registered factory) parses against v1 schema.
+
+        Pins the implicit contract: an underscore-prefixed custom version of a
+        spec family keeps its support payload v1-compatible since the family's
+        registered schema is what the deserializer uses. The custom role
+        implementer owns both ends, so this trade-off is intentional.
+        """
+        raw = orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "c1",
+                    "name": "Client",
+                    "version": 1,
+                    "supported_roles": ["player@_experimental"],
+                    "player@_experimental_support": {
+                        "supported_formats": [
+                            {
+                                "codec": "pcm",
+                                "channels": 2,
+                                "sample_rate": 48000,
+                                "bit_depth": 16,
+                            },
+                        ],
+                        "buffer_capacity": 100_000,
+                        "supported_commands": [],
+                    },
+                },
+            }
+        ).decode()
+
+        msg = SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
+        assert isinstance(msg, ClientHelloMessage)
+        assert msg.payload.player_support is not None
+        assert msg.payload.player_support.buffer_capacity == 100_000
+
+    def test_custom_underscore_player_version_with_incompatible_support_raises(self) -> None:
+        """`player@_experimental` with schema-incompatible support raises.
+
+        Documents the implicit contract from the previous test: when an
+        underscore-prefixed custom version is the only role in its family, the
+        family's registered schema gets applied. Diverging from that schema is
+        the implementer's responsibility — the server cannot guess otherwise.
+        """
+        raw = orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "c1",
+                    "name": "Client",
+                    "version": 1,
+                    "supported_roles": ["player@_experimental"],
+                    "player@_experimental_support": {"only": "garbage"},
+                },
+            }
+        ).decode()
+
+        with pytest.raises(MissingField):
+            SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
 
 
 class TestClientUrlRegistration:

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -2939,6 +2939,37 @@ async def test_buffered_source_skips_min_buffer_at_startup() -> None:
 
 
 @pytest.mark.asyncio
+async def test_explicit_play_start_us_overrides_stale_channel_timing() -> None:
+    """Explicit play_start_us is authoritative across mode switches."""
+    loop = asyncio.get_running_loop()
+    clock = ManualClock(now_us_value=1_000_000)
+    group = _DummyGroup(clients=[])
+    role = _make_role(required_lead_time_us=0, min_buffer_us=0, static_delay_us=0)
+    group.clients.append(_DummyClient([role]))
+
+    stream = PushStream(loop=loop, clock=clock, group=group)
+    fmt = AudioFormat(sample_rate=48000, bit_depth=16, channels=2)
+
+    # First commit anchors the channel at an explicit start far ahead of "now".
+    first_play_start_us = 10_000_000
+    stream.prepare_audio(bytes(4800), fmt)
+    returned_first = await stream.commit_audio(play_start_us=first_play_start_us)
+    assert returned_first == first_play_start_us
+
+    # Subsequent commit with a different play_start_us must overwrite the
+    # advanced channel timing, not be ignored because the channel already exists.
+    second_play_start_us = 20_000_000
+    stream.prepare_audio(bytes(4800), fmt)
+    returned_second = await stream.commit_audio(play_start_us=second_play_start_us)
+    assert returned_second == second_play_start_us
+
+    # The channel timing now reflects the second play_start_us plus its chunk
+    # duration (25ms @ 48kHz stereo s16 = 25_000us), not first + 2 * duration.
+    expected_after_advance = second_play_start_us + 25_000
+    assert stream._channel_timing[MAIN_CHANNEL] == expected_after_advance  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_send_ahead_uses_largest_member_budget() -> None:
     """Live grouped players use a common floor: max(lead, min_buffer) + static across members."""
     loop = asyncio.get_running_loop()

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -260,7 +260,26 @@ async def test_late_join_target_includes_player_static_delay() -> None:
 
     stream = PushStream(loop=loop, clock=clock, group=group)
 
-    assert stream.get_late_join_target_timestamp_us(role=role) == 6_100_000
+    # now + max(LATE_JOINER_MIN_LEAD_US=100ms, required_lead=250ms) + static_delay=5s
+    assert stream.get_late_join_target_timestamp_us(role=role) == 6_250_000
+
+
+@pytest.mark.asyncio
+async def test_late_join_target_uses_required_lead_time() -> None:
+    """Required lead time bumps the floor when it exceeds the static minimum."""
+    loop = asyncio.get_running_loop()
+    clock = ManualClock(now_us_value=1_000_000)
+    group = _DummyGroup(clients=[])
+    client, _ = _make_connected_player(loop, group, "p1", clock=clock)
+    role = client.role("player@v1")
+    assert role is not None
+    role.static_delay_ms = 5_000
+    role.required_lead_time_ms = 400  # > 100ms default floor
+
+    stream = PushStream(loop=loop, clock=clock, group=group)
+
+    # now + max(100ms, 400ms required_lead) + 5s static_delay
+    assert stream.get_late_join_target_timestamp_us(role=role) == 6_400_000
 
 
 @pytest.mark.asyncio
@@ -2525,6 +2544,7 @@ async def test_replay_from_pcm_cache_overrides_established_resampler_skip() -> N
             frame_duration_us=25_000,
         ),
         replay_from_pcm_cache=True,
+        required_lead_time_us=100_000,
     )
     group.clients.append(_DummyClient([viz_role]))
     stream.on_role_join(viz_role)
@@ -3359,7 +3379,8 @@ async def test_catchup_drain_advances_encoder_pending_to_live_tip() -> None:
             transformer=joining_transformer,
             channel_id=MAIN_CHANNEL,
             frame_duration_us=25_000,
-        )
+        ),
+        required_lead_time_us=100_000,
     )
     group.clients.append(_DummyClient([role2]))
     stream.on_role_join(role2)
@@ -3457,7 +3478,8 @@ async def test_catchup_mid_pass_format_change_keeps_chunks_ordered() -> None:
             transformer=Transformer(),
             channel_id=MAIN_CHANNEL,
             frame_duration_us=25_000,
-        )
+        ),
+        required_lead_time_us=100_000,
     )
     group.clients.append(_DummyClient([role2]))
     stream.on_role_join(role2)

--- a/tests/server/test_sendspin_client_persistence.py
+++ b/tests/server/test_sendspin_client_persistence.py
@@ -18,6 +18,7 @@ from aiosendspin.server.audio import AudioFormat
 from aiosendspin.server.client import SendspinClient
 from aiosendspin.server.clock import LoopClock
 from aiosendspin.server.connection import SendspinConnection
+from aiosendspin.server.events import GroupDeletedEvent
 from aiosendspin.server.group import SendspinGroup
 from aiosendspin.server.roles.player import v1 as player_v1_module
 from aiosendspin.server.roles.player.v1 import PlayerPersistentState
@@ -510,3 +511,28 @@ async def test_client_updated_event_fires_when_hello_changes() -> None:
     updated = [e for e in server.events if isinstance(e, ClientUpdatedEvent)]
     assert len(updated) == 1
     assert updated[0].client_id == "player-1"
+
+
+@pytest.mark.asyncio
+async def test_add_client_from_solo_group_finalizes_old_group() -> None:
+    """Moving a solo client into another group must drain and delete the old group."""
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+    client_x = SendspinClient(server, client_id="player-x")
+    group_a = SendspinGroup(server, client_x)
+
+    client_y = SendspinClient(server, client_id="player-y")
+    group_b = SendspinGroup(server, client_y)
+
+    deleted_groups: list[SendspinGroup] = []
+    group_a.add_event_listener(
+        lambda g, evt: deleted_groups.append(g) if isinstance(evt, GroupDeletedEvent) else None
+    )
+
+    await group_b.add_client(client_x)
+
+    assert client_x not in group_a.clients
+    assert group_a.clients == []
+    assert client_x.group is group_b
+    assert client_x in group_b.clients
+    assert deleted_groups == [group_a]

--- a/tests/server/test_sendspin_client_persistence.py
+++ b/tests/server/test_sendspin_client_persistence.py
@@ -19,6 +19,7 @@ from aiosendspin.server.client import SendspinClient
 from aiosendspin.server.clock import LoopClock
 from aiosendspin.server.connection import SendspinConnection
 from aiosendspin.server.group import SendspinGroup
+from aiosendspin.server.roles.player import v1 as player_v1_module
 from aiosendspin.server.roles.player.v1 import PlayerPersistentState
 
 
@@ -96,8 +97,11 @@ def _player_hello(
 
 
 @pytest.mark.asyncio
-async def test_goodbye_disconnect_delays_buffer_tracker_reset() -> None:
+async def test_goodbye_disconnect_delays_buffer_tracker_reset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Goodbye disconnect follows the same delayed reset policy."""
+    monkeypatch.setattr(player_v1_module, "BUFFER_TRACKER_RESET_DELAY_S", 0.05)
     loop = asyncio.get_running_loop()
     server = _DummyServer(loop=loop, clock=LoopClock(loop))
     client = SendspinClient(server, client_id="player-1")
@@ -118,13 +122,16 @@ async def test_goodbye_disconnect_delays_buffer_tracker_reset() -> None:
 
     client.detach_connection(GoodbyeReason.USER_REQUEST)
     assert state.buffer_tracker.buffered_bytes == 1234
-    await asyncio.sleep(2.2)
+    await asyncio.sleep(0.1)
     assert state.buffer_tracker.buffered_bytes == 0
 
 
 @pytest.mark.asyncio
-async def test_ungraceful_disconnect_delays_buffer_tracker_reset() -> None:
+async def test_ungraceful_disconnect_delays_buffer_tracker_reset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Ungraceful disconnect delays BufferTracker reset to tolerate brief blips."""
+    monkeypatch.setattr(player_v1_module, "BUFFER_TRACKER_RESET_DELAY_S", 0.05)
     loop = asyncio.get_running_loop()
     server = _DummyServer(loop=loop, clock=LoopClock(loop))
     client = SendspinClient(server, client_id="player-1")
@@ -144,7 +151,7 @@ async def test_ungraceful_disconnect_delays_buffer_tracker_reset() -> None:
     client.detach_connection(None)
 
     assert state.buffer_tracker.buffered_bytes == 1234
-    await asyncio.sleep(2.2)
+    await asyncio.sleep(0.1)
     assert state.buffer_tracker.buffered_bytes == 0
 
 

--- a/tests/server/test_stream_request_format.py
+++ b/tests/server/test_stream_request_format.py
@@ -209,3 +209,41 @@ def test_player_format_request_uses_client_priority_order_when_codec_missing(
     assert player_role.preferred_format.sample_rate == 44100
     assert player_role.preferred_format.channels == 2
     assert player_role.preferred_format.bit_depth == 32
+
+
+def test_player_partial_format_request_preserves_unchanged_fields(
+    mock_server: MagicMock,
+) -> None:
+    """A partial stream/request-format keeps prior values for omitted fields."""
+    client, _conn = _make_player_client(
+        mock_server,
+        "p1",
+        supported_formats=[
+            SupportedAudioFormat(
+                codec=AudioCodec.FLAC, sample_rate=48000, bit_depth=16, channels=2
+            ),
+            SupportedAudioFormat(
+                codec=AudioCodec.FLAC, sample_rate=44100, bit_depth=16, channels=2
+            ),
+        ],
+    )
+
+    initial = StreamRequestFormatPayload(
+        player=StreamRequestFormatPlayer(
+            codec=AudioCodec.FLAC, sample_rate=48000, channels=2, bit_depth=16
+        )
+    )
+    for role in client.active_roles:
+        role.on_stream_request_format(initial)
+
+    partial = StreamRequestFormatPayload(player=StreamRequestFormatPlayer(sample_rate=44100))
+    for role in client.active_roles:
+        role.on_stream_request_format(partial)
+
+    player_role = client.role("player@v1")
+    assert isinstance(player_role, PlayerV1Role)
+    assert player_role.preferred_codec == AudioCodec.FLAC
+    assert player_role.preferred_format is not None
+    assert player_role.preferred_format.sample_rate == 44100
+    assert player_role.preferred_format.bit_depth == 16
+    assert player_role.preferred_format.channels == 2

--- a/tests/test_client_protocol_callbacks.py
+++ b/tests/test_client_protocol_callbacks.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import struct
+
 import pytest
 
-from aiosendspin.client.client import SendspinClient
+from aiosendspin.client.client import AudioFormat, SendspinClient
 from aiosendspin.models import pack_binary_header_raw
 from aiosendspin.models.artwork import (
     ArtworkChannel,
@@ -13,7 +15,11 @@ from aiosendspin.models.artwork import (
     StreamStartArtwork,
 )
 from aiosendspin.models.core import ServerHelloPayload, StreamStartMessage, StreamStartPayload
-from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
+from aiosendspin.models.player import (
+    ClientHelloPlayerSupport,
+    StreamStartPlayer,
+    SupportedAudioFormat,
+)
 from aiosendspin.models.types import (
     ArtworkSource,
     AudioCodec,
@@ -21,6 +27,10 @@ from aiosendspin.models.types import (
     ConnectionReason,
     PictureFormat,
     Roles,
+)
+from aiosendspin.models.visualizer import (
+    ClientHelloVisualizerSupport,
+    VisualizerFrame,
 )
 
 
@@ -111,3 +121,161 @@ async def test_artwork_listener_receives_binary_frames_after_artwork_stream_star
     )
 
     assert captured == [(0, payload)]
+
+
+def _artwork_support() -> ClientHelloArtworkSupport:
+    return ClientHelloArtworkSupport(
+        channels=[
+            ArtworkChannel(
+                source=ArtworkSource.ALBUM,
+                format=PictureFormat.JPEG,
+                media_width=256,
+                media_height=256,
+            )
+        ]
+    )
+
+
+def _visualizer_support() -> ClientHelloVisualizerSupport:
+    return ClientHelloVisualizerSupport(
+        buffer_capacity=4096,
+        rate_max=30,
+        types=["loudness"],
+    )
+
+
+def _stream_start_player() -> StreamStartPlayer:
+    return StreamStartPlayer(
+        codec=AudioCodec.PCM,
+        sample_rate=48_000,
+        channels=2,
+        bit_depth=16,
+    )
+
+
+@pytest.mark.asyncio
+async def test_artwork_binary_dropped_when_only_player_stream_active() -> None:
+    """Artwork binaries must be rejected when only the player stream is active."""
+    client = SendspinClient(
+        client_id="client-1",
+        client_name="Test Client",
+        roles=[Roles.PLAYER, Roles.ARTWORK],
+        player_support=_player_support(),
+        artwork_support=_artwork_support(),
+    )
+    captured: list[tuple[int, bytes]] = []
+    client.add_artwork_listener(lambda channel, data: captured.append((channel, data)))
+
+    await client._handle_stream_start(  # noqa: SLF001
+        StreamStartMessage(payload=StreamStartPayload(player=_stream_start_player()))
+    )
+
+    client._handle_binary_message(  # noqa: SLF001
+        pack_binary_header_raw(BinaryMessageType.ARTWORK_CHANNEL_0.value, 123_456) + b"art"
+    )
+
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_audio_binary_dropped_when_only_artwork_stream_active() -> None:
+    """Audio binaries must be rejected when only the artwork stream is active."""
+    client = SendspinClient(
+        client_id="client-1",
+        client_name="Test Client",
+        roles=[Roles.PLAYER, Roles.ARTWORK],
+        player_support=_player_support(),
+        artwork_support=_artwork_support(),
+    )
+    captured: list[tuple[int, bytes, AudioFormat]] = []
+    client.add_audio_chunk_listener(
+        lambda ts, data, fmt: captured.append((ts, data, fmt)),
+    )
+
+    await client._handle_stream_start(  # noqa: SLF001
+        StreamStartMessage(
+            payload=StreamStartPayload(
+                artwork=StreamStartArtwork(
+                    channels=[
+                        StreamArtworkChannelConfig(
+                            source=ArtworkSource.ALBUM,
+                            format=PictureFormat.JPEG,
+                            width=512,
+                            height=512,
+                        )
+                    ]
+                )
+            )
+        )
+    )
+
+    client._handle_binary_message(  # noqa: SLF001
+        pack_binary_header_raw(BinaryMessageType.AUDIO_CHUNK.value, 123_456) + b"\x00\x00\x00\x00"
+    )
+
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_visualizer_binary_dropped_when_only_player_stream_active() -> None:
+    """Visualizer binaries must be rejected when only the player stream is active."""
+    client = SendspinClient(
+        client_id="client-1",
+        client_name="Test Client",
+        roles=[Roles.PLAYER, Roles.VISUALIZER],
+        player_support=_player_support(),
+        visualizer_support=_visualizer_support(),
+    )
+    captured: list[list[VisualizerFrame]] = []
+    client.add_visualizer_listener(captured.append)
+
+    await client._handle_stream_start(  # noqa: SLF001
+        StreamStartMessage(payload=StreamStartPayload(player=_stream_start_player()))
+    )
+
+    # Loudness frame: type byte + 8-byte timestamp + 2-byte value.
+    loudness_payload = (
+        bytes([BinaryMessageType.VISUALIZATION_LOUDNESS.value])
+        + struct.pack(">q", 1_000)
+        + struct.pack(">H", 42)
+    )
+    client._handle_binary_message(loudness_payload)  # noqa: SLF001
+
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_artwork_binary_dispatched_when_artwork_stream_active() -> None:
+    """Artwork binaries must reach listeners once artwork stream is active."""
+    client = SendspinClient(
+        client_id="client-1",
+        client_name="Test Client",
+        roles=[Roles.ARTWORK],
+        artwork_support=_artwork_support(),
+    )
+    captured: list[tuple[int, bytes]] = []
+    client.add_artwork_listener(lambda channel, data: captured.append((channel, data)))
+
+    await client._handle_stream_start(  # noqa: SLF001
+        StreamStartMessage(
+            payload=StreamStartPayload(
+                artwork=StreamStartArtwork(
+                    channels=[
+                        StreamArtworkChannelConfig(
+                            source=ArtworkSource.ALBUM,
+                            format=PictureFormat.JPEG,
+                            width=512,
+                            height=512,
+                        )
+                    ]
+                )
+            )
+        )
+    )
+
+    payload = b"artwork-bytes-2"
+    client._handle_binary_message(  # noqa: SLF001
+        pack_binary_header_raw(BinaryMessageType.ARTWORK_CHANNEL_1.value, 234_567) + payload
+    )
+
+    assert captured == [(1, payload)]

--- a/tests/test_time_sync.py
+++ b/tests/test_time_sync.py
@@ -1,0 +1,172 @@
+"""Behavior tests for the SendspinTimeFilter Kalman filter.
+
+These tests assert invariants that hold for any correct Kalman implementation
+of the Sendspin time-sync filter. They deliberately avoid pinning exact float
+outputs; for vector-level parity against the C++ reference see
+``scripts/compare_time_filter.py``.
+"""
+
+# ruff: noqa: SLF001  Tests intentionally probe filter internals
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from aiosendspin.client.time_sync import SendspinTimeFilter, TimeElement
+
+
+def _feed_constant_offset(
+    filter_: SendspinTimeFilter,
+    offset_us: int,
+    count: int,
+    max_error_us: int = 1000,
+    interval_us: int = 1_000_000,
+    start_time_us: int = 1_000_000,
+) -> int:
+    """Feed ``count`` measurements with constant offset and zero drift."""
+    t = start_time_us
+    for _ in range(count):
+        filter_.update(offset_us, max_error_us, t)
+        t += interval_us
+    return t
+
+
+def test_count_zero_branch_seeds_offset_from_first_sample() -> None:
+    """First update seeds offset from the single measurement."""
+    filter_ = SendspinTimeFilter()
+
+    assert filter_.count == 0
+
+    filter_.update(measurement=12_345, max_error=500, time_added=1_000_000)
+
+    assert filter_.count == 1
+    assert filter_.offset == pytest.approx(12_345.0)
+    # Drift unknown after one sample
+    assert filter_._drift == 0.0
+
+
+def test_count_one_branch_estimates_drift_from_two_point_slope() -> None:
+    """Second update estimates drift from the two-point slope."""
+    filter_ = SendspinTimeFilter()
+
+    filter_.update(measurement=1_000, max_error=500, time_added=1_000_000)
+    filter_.update(measurement=2_000, max_error=500, time_added=2_000_000)
+
+    assert filter_.count == 2
+    assert filter_.offset == pytest.approx(2_000.0)
+    # (2000 - 1000) / (2_000_000 - 1_000_000) = 0.001
+    assert filter_._drift == pytest.approx(0.001)
+
+
+def test_late_update_with_non_monotonic_time_is_ignored() -> None:
+    """An update with time_added <= _last_update returns without state changes."""
+    filter_ = SendspinTimeFilter()
+    filter_.update(measurement=1_000, max_error=500, time_added=2_000_000)
+
+    snapshot_count = filter_.count
+    snapshot_offset = filter_.offset
+    snapshot_last_update = filter_._last_update
+
+    # Equal timestamp
+    filter_.update(measurement=9_999, max_error=500, time_added=2_000_000)
+    # Backward timestamp
+    filter_.update(measurement=9_999, max_error=500, time_added=1_500_000)
+
+    assert filter_.count == snapshot_count
+    assert filter_.offset == snapshot_offset
+    assert filter_._last_update == snapshot_last_update
+
+
+def test_reset_returns_filter_to_init_state() -> None:
+    """After reset, all internal state matches a fresh filter."""
+    filter_ = SendspinTimeFilter()
+    _feed_constant_offset(filter_, offset_us=50_000, count=10)
+
+    # Sanity: state advanced.
+    assert filter_.count > 0
+    assert filter_._last_update != 0
+
+    filter_.reset()
+
+    assert filter_.count == 0
+    assert filter_._last_update == 0
+    assert filter_._offset == 0.0
+    assert filter_._drift == 0.0
+    assert math.isinf(filter_._offset_covariance)
+    assert filter_._offset_drift_covariance == 0.0
+    assert filter_._drift_covariance == 0.0
+    assert filter_._current_time_element == TimeElement()
+
+
+def test_converges_to_perfect_offset_zero_drift() -> None:
+    """Perfect constant-offset stream converges within microsecond tolerance.
+
+    After enough samples, ``compute_server_time(t)`` should match ``t + offset``.
+    """
+    filter_ = SendspinTimeFilter()
+    offset = 250_000
+
+    last_t = _feed_constant_offset(filter_, offset_us=offset, count=20)
+
+    # After 20 perfect samples the filter should be well within 1 us.
+    sample_client_time = last_t + 500_000
+    assert abs(filter_.compute_server_time(sample_client_time) - (sample_client_time + offset)) <= 1
+
+
+def test_compute_server_time_monotonic_after_convergence() -> None:
+    """After convergence, increasing client_time produces non-decreasing server_time."""
+    filter_ = SendspinTimeFilter()
+    _feed_constant_offset(filter_, offset_us=10_000, count=20)
+
+    base = 100_000_000
+    prev = filter_.compute_server_time(base)
+    for delta in (1, 10, 100, 1_000, 10_000, 100_000, 1_000_000):
+        current = filter_.compute_server_time(base + delta)
+        assert current >= prev
+        prev = current
+
+
+def test_compute_inverse_consistency_zero_drift() -> None:
+    """compute_client_time(compute_server_time(t)) ~= t after convergence (zero drift)."""
+    filter_ = SendspinTimeFilter()
+    _feed_constant_offset(filter_, offset_us=42_000, count=20)
+
+    for client_time in (500_000, 10_000_000, 999_999_999):
+        server = filter_.compute_server_time(client_time)
+        recovered = filter_.compute_client_time(server)
+        assert abs(recovered - client_time) <= 1
+
+
+def test_compute_inverse_consistency_with_drift() -> None:
+    """Inverse consistency holds even when the SNR gate enables drift compensation."""
+    filter_ = SendspinTimeFilter()
+
+    # Server runs at 1.0e-4 us/us faster than client (i.e. ~100 us per second of skew).
+    drift_rate = 1.0e-4
+    base_offset = 100_000
+
+    t = 1_000_000
+    for _ in range(50):
+        # Measured offset includes accumulated drift since baseline at t=0.
+        measurement = round(base_offset + drift_rate * t)
+        filter_.update(measurement, max_error=200, time_added=t)
+        t += 1_000_000
+
+    # If drift compensation is engaged the inverse must still round-trip.
+    for client_time in (t + 0, t + 500_000, t + 5_000_000):
+        server = filter_.compute_server_time(client_time)
+        recovered = filter_.compute_client_time(server)
+        assert abs(recovered - client_time) <= 1
+
+
+def test_init_branches_do_not_set_use_drift() -> None:
+    """The two warmup branches must not enable drift compensation."""
+    filter_ = SendspinTimeFilter()
+
+    filter_.update(measurement=1_000, max_error=500, time_added=1_000_000)
+    assert filter_._current_time_element.use_drift is False
+
+    filter_.update(measurement=1_000, max_error=500, time_added=2_000_000)
+    assert filter_._current_time_element.use_drift is False


### PR DESCRIPTION
Multi-area fix pass across spec conformance, time sync, role state machines, and forward compatibility. Production code net change is +55 LOC; the bulk is targeted fixes plus new test coverage and a parity harness against the C++ time-filter reference.

## Spec conformance

- `client/state` partial updates no longer reset `static_delay_ms` / `required_lead_time_ms` / `min_buffer_ms` to defaults when omitted, per the spec's delta merge rule. Not yet fully defined in the Spec yet, but this implements the most permissive interpretation. Related issue: Sendspin/spec#98.
- `buffer_capacity` is now actually a hard byte cap. Oversize chunks wait for full buffer drain instead of bypassing the limit.
- Late-joiner first-chunk timestamps honor each player's `required_lead_time_ms` (was hardcoded 100ms, causing startup truncation for default players at 250ms).
- `stream/clear` and `stream/end` validators now permit `_`-prefixed application roles.
- Client binary handler rejects per role rather than via a global OR across stream flags.
- `metadata.progress` can be explicitly cleared via incremental `server/state` update.
- `MetadataV1Role` and `ArtworkV1Role` no longer send duplicate `server/state` / artwork binaries on connect (regression from #254).

## Time filter / Kalman

Time filter reconciled against the C++ reference (commit pinned in `scripts/cpp_reference_sha.txt`). Six material divergences fixed: drift process noise, `max_error_scale`, drift SNR gate, adaptive forgetting cutoff, forget factor, process std dev. Plus `reset()` now clears `_last_update` and non-monotonic `time_added` is rejected. Parity script at `scripts/compare_time_filter.py` confirms bit-exact match over a 500-step synthetic sequence.

## Group and state-machine

`external_source` state handling moved from `ControllerV1Role` to `SendspinClient` so player-only, metadata-only, or artwork-only clients correctly leave their groups when entering external_source per the spec's `External Source Handling` section.

`PlayerGroupRole` now reactively aggregates per-client `VolumeChangedEvent`, so `PlayerGroupVolumeChangedEvent` and `PlayerGroupMuteChangedEvent` actually fire (they were dead code).

`SendspinClient.ungroup()` always evicts the client from its old group, finalizing solo source groups instead of leaving stale members.

## Forward compatibility

Unknown spec-versioned role IDs (e.g. `visualizer@v2` on a server that only knows v1) no longer crash deserialization on schema drift. They are ignored and logged so operators can spot newer-protocol clients.

## Technically breaking changes

Both touch effectively-private surfaces. Music Assistant and sendspin-cli are unaffected.

- `PlayerStatePayload.static_delay_ms` / `required_lead_time_ms` / `min_buffer_ms` are now `int | None = None` (were `int` with defaults `0/250/250`). Constructing without these fields yields `None`; consumers must guard. Required for spec-compliant delta merge.
- `ControllerV1Role.on_state_transition` override and the private `_handle_*` helpers moved to `SendspinClient.handle_switch_command()` and related methods. `ControllerRoleState` (never in `__all__`) removed. Subclasses crossing the private API must migrate.

## Tests

Added behavior tests for the time filter, partial `stream/request-format`, external_source flow, iterative volume clamping, late-joiner future timestamps, and forward-compat schema drift. Existing tests tightened: signed lag for spread, backward-timestamp rejection, fuzz correlation threshold raised from 0.35 to 0.85.