### PR TITLE
Keep retry loop alive on mDNS withdrawal for persistent clients

### DIFF
--- a/aiosendspin/server/server.py
+++ b/aiosendspin/server/server.py
@@ -906,9 +906,24 @@ class SendspinServer:
 
     def _handle_service_removed(self, name: str) -> None:
         url = self._mdns_client_urls.pop(name, None)
-        if url is not None:
+        if url is None:
+            return
+        # Keep the retry loop alive if a normal client still wants to be reached.
+        # mDNS can drop ahead of the device coming back, and the device may not
+        # re-announce until something else nudges it (router-side delay, ESP
+        # firmware that announces only on cold boot).
+        if not self._has_persistent_client_for_url(url):
             self.disconnect_from_client(url)
-            create_task(self._cleanup_retained_clients_for_removed_mdns_url(url))
+        create_task(self._cleanup_retained_clients_for_removed_mdns_url(url))
+
+    def _has_persistent_client_for_url(self, url: str) -> bool:
+        for client_id, known_url in self._client_urls.items():
+            if known_url != url:
+                continue
+            client = self._clients.get(client_id)
+            if client is not None and not client.cleanup_on_mdns_removal:
+                return True
+        return False
 
     async def _cleanup_retained_clients_for_removed_mdns_url(self, url: str) -> None:
         """Remove retained ANOTHER_SERVER clients when their mDNS URL disappears."""
@@ -916,7 +931,11 @@ class SendspinServer:
             client_id for client_id, known_url in self._client_urls.items() if known_url == url
         ]
         for client_id in client_ids:
-            self._client_urls.pop(client_id, None)
+            client = self._clients.get(client_id)
+            # Only forget the URL for clients we're about to remove. Persistent
+            # clients keep the URL so the still-running retry task can reconnect.
+            if client is None or client.cleanup_on_mdns_removal:
+                self._client_urls.pop(client_id, None)
 
         for client_id in client_ids:
             client = self._clients.get(client_id)

--- a/tests/server/test_server_initial_connect.py
+++ b/tests/server/test_server_initial_connect.py
@@ -502,6 +502,66 @@ async def test_mdns_removal_keeps_non_retained_client() -> None:
     server.remove_client.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_mdns_removal_keeps_connection_task_for_persistent_client() -> None:
+    """A persistent client must keep its retry task alive after mDNS withdrawal.
+
+    Without this guarantee, a transient mDNS drop (network blip while the
+    device is still alive) silently cancels the reconnect loop and the device
+    stays unavailable until MA restart.
+    """
+    session = _PersistentSuccessfulSession()
+    server = _make_server(session)
+    url = "ws://127.0.0.1:9999/sendspin"
+
+    persistent_client = MagicMock()
+    persistent_client.is_connected = False
+    persistent_client.cleanup_on_mdns_removal = False
+
+    server.connect_to_client(url)
+    task = server._connection_tasks.get(url)  # noqa: SLF001
+    assert task is not None
+
+    server._clients = {"client-1": persistent_client}  # noqa: SLF001
+    server._client_urls = {"client-1": url}  # noqa: SLF001
+    server._mdns_client_urls = {"service._sendspin._tcp.local.": url}  # noqa: SLF001
+
+    server._handle_service_removed("service._sendspin._tcp.local.")  # noqa: SLF001
+    await asyncio.sleep(0)
+
+    assert server._connection_tasks.get(url) is task  # noqa: SLF001
+    assert task.cancelling() == 0
+    assert server._client_urls.get("client-1") == url  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_mdns_removal_cancels_connection_when_no_persistent_client() -> None:
+    """With no persistent client (or only an ANOTHER_SERVER retainer), tear the retry task down."""
+    session = _PersistentSuccessfulSession()
+    server = _make_server(session)
+    url = "ws://127.0.0.1:9999/sendspin"
+
+    retained_client = MagicMock()
+    retained_client.is_connected = False
+    retained_client.cleanup_on_mdns_removal = True
+
+    server.connect_to_client(url)
+    task = server._connection_tasks.get(url)  # noqa: SLF001
+    assert task is not None
+
+    server._clients = {"client-1": retained_client}  # noqa: SLF001
+    server._client_urls = {"client-1": url}  # noqa: SLF001
+    server._mdns_client_urls = {"service._sendspin._tcp.local.": url}  # noqa: SLF001
+    server.remove_client = AsyncMock()  # type: ignore[method-assign]
+
+    server._handle_service_removed("service._sendspin._tcp.local.")  # noqa: SLF001
+    await asyncio.sleep(0)
+
+    assert url not in server._connection_tasks  # noqa: SLF001
+    assert task.cancelling() > 0
+    assert "client-1" not in server._client_urls  # noqa: SLF001
+
+
 @pytest.mark.parametrize(
     ("addresses", "port", "path", "has_task", "expected_url", "expect_reconnect"),
     [


### PR DESCRIPTION
A transient mDNS drop while the device is still on the network (network blip, ESP firmware that announces only on cold boot) caused the connection retry task to be cancelled, so the client stayed unavailable until a server restart.

`_handle_service_removed` now only cancels the retry task when no non-`ANOTHER_SERVER` client wants the URL kept reachable. The `_client_urls` mapping for those persistent clients is preserved so the still-running retry task can land the reconnect when the device comes back.