### PR TITLE
Stop a group when its last player leaves

### DIFF
--- a/aiosendspin/server/group.py
+++ b/aiosendspin/server/group.py
@@ -14,7 +14,7 @@ from aiosendspin.models.core import (
     GroupUpdateServerMessage,
     GroupUpdateServerPayload,
 )
-from aiosendspin.models.types import PlaybackStateType
+from aiosendspin.models.types import PlaybackStateType, has_role_family
 from aiosendspin.server.events import (
     GroupDeletedEvent,
     GroupEvent,
@@ -368,6 +368,9 @@ class SendspinGroup:
         if not self._clients:
             self._finalize_empty_group()
         else:
+            # Stop a remnant with no player-role client left to source audio.
+            if not any(has_role_family("player", c.negotiated_roles) for c in self._clients):
+                await self.stop()
             # Emit event for client removal
             self._signal_event(GroupMemberRemovedEvent(client.client_id))
         # Each client needs to be in a group, add it to a new one

--- a/aiosendspin/server/group.py
+++ b/aiosendspin/server/group.py
@@ -370,7 +370,14 @@ class SendspinGroup:
         else:
             # Stop a remnant with no player-role client left to source audio.
             if not any(has_role_family("player", c.negotiated_roles) for c in self._clients):
+                had_active_stream = self.has_active_stream
                 await self.stop()
+                if not had_active_stream:
+                    # No PushStream to emit stream/end, so signal the surviving
+                    # roles directly to invalidate stale binary.
+                    for remaining in self._clients:
+                        for role in remaining.active_roles:
+                            role.on_stream_end()
             # Emit event for client removal
             self._signal_event(GroupMemberRemovedEvent(client.client_id))
         # Each client needs to be in a group, add it to a new one

--- a/tests/server/test_group_remove_client.py
+++ b/tests/server/test_group_remove_client.py
@@ -1,0 +1,131 @@
+"""Tests for SendspinGroup.remove_client teardown behavior.
+
+A group only makes sense as a playback session while it has a ``player``-role
+client to source audio. When the last such client leaves, any visualizer- or
+metadata-only remnant must not keep "playing" as a phantom-led group.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+from dataclasses import dataclass
+
+import pytest
+
+from aiosendspin.models.core import ClientHelloPayload
+from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
+from aiosendspin.models.types import (
+    AudioCodec,
+    PlaybackStateType,
+    PlayerCommand,
+    Roles,
+)
+from aiosendspin.models.visualizer import ClientHelloVisualizerSupport
+from aiosendspin.server.client import SendspinClient
+from aiosendspin.server.clock import LoopClock
+from aiosendspin.server.group import SendspinGroup
+
+
+@dataclass(slots=True)
+class _DummyServer:
+    loop: asyncio.AbstractEventLoop
+    clock: LoopClock
+    id: str = "srv"
+    name: str = "server"
+    visualizer_pitch_enabled: bool = True
+    _clients: dict[str, SendspinClient] = dataclasses.field(default_factory=dict)
+
+    def is_external_player(self, client_id: str) -> bool:  # noqa: ARG002
+        return False
+
+    def _signal_client_updated(self, client_id: str) -> None:
+        pass
+
+    def register(self, client: SendspinClient) -> None:
+        self._clients[client.client_id] = client
+
+    @property
+    def connected_clients(self) -> list[SendspinClient]:
+        return [c for c in self._clients.values() if c.is_connected]
+
+    def request_client_playback_connection(self, client_id: str) -> bool:  # noqa: ARG002
+        return False
+
+
+class _DummyConnection:
+    async def disconnect(self, *, retry_connection: bool = True) -> None:  # noqa: ARG002
+        return
+
+    def send_message(self, message: object) -> None:
+        pass
+
+    def send_role_message(self, role: str, message: object) -> None:
+        pass
+
+    def send_binary(self, data: bytes, **kwargs: object) -> bool:  # noqa: ARG002
+        return True
+
+
+def _hello(client_id: str, *, supported_roles: list[str]) -> ClientHelloPayload:
+    player_support: ClientHelloPlayerSupport | None = None
+    visualizer_support: ClientHelloVisualizerSupport | None = None
+    if Roles.PLAYER.value in supported_roles:
+        player_support = ClientHelloPlayerSupport(
+            supported_formats=[
+                SupportedAudioFormat(
+                    codec=AudioCodec.PCM, channels=2, sample_rate=48000, bit_depth=16
+                )
+            ],
+            buffer_capacity=100_000,
+            supported_commands=[PlayerCommand.VOLUME, PlayerCommand.MUTE],
+        )
+    if Roles.VISUALIZER.value in supported_roles:
+        visualizer_support = ClientHelloVisualizerSupport(
+            types=["loudness", "beat"], buffer_capacity=65536, rate_max=30
+        )
+    return ClientHelloPayload(
+        client_id=client_id,
+        name=client_id,
+        version=1,
+        supported_roles=supported_roles,
+        player_support=player_support,
+        visualizer_support=visualizer_support,
+    )
+
+
+def _make_client(
+    server: _DummyServer, client_id: str, *, supported_roles: list[str]
+) -> SendspinClient:
+    client = SendspinClient(server, client_id=client_id)
+    server.register(client)
+    SendspinGroup(server, client)
+    client.attach_connection(
+        _DummyConnection(),
+        client_info=_hello(client_id, supported_roles=supported_roles),
+        active_roles=supported_roles,
+    )
+    client.mark_connected()
+    return client
+
+
+@pytest.mark.asyncio
+async def test_group_stops_when_last_player_leaves_visualizer_behind() -> None:
+    """Removing the only player-role client stops a visualizer-only remnant."""
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+
+    player = _make_client(server, "web", supported_roles=[Roles.PLAYER.value])
+    visualizer = _make_client(server, "hue", supported_roles=[Roles.VISUALIZER.value])
+
+    group = player.group
+    await group.add_client(visualizer)
+    group._set_playback_state(PlaybackStateType.PLAYING)  # noqa: SLF001
+    assert group.state == PlaybackStateType.PLAYING
+
+    await group.remove_client(player)
+
+    # The visualizer remnant has no audio source, so the group must go idle
+    # rather than linger as a phantom-led, still-playing group.
+    assert visualizer.group is group
+    assert group.state == PlaybackStateType.STOPPED

--- a/tests/server/test_group_remove_client.py
+++ b/tests/server/test_group_remove_client.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 
 import pytest
 
-from aiosendspin.models.core import ClientHelloPayload
+from aiosendspin.models.core import ClientHelloPayload, StreamEndMessage
 from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
 from aiosendspin.models.types import (
     AudioCodec,
@@ -54,6 +54,9 @@ class _DummyServer:
 
 
 class _DummyConnection:
+    def __init__(self) -> None:
+        self.role_messages: list[tuple[str, object]] = []
+
     async def disconnect(self, *, retry_connection: bool = True) -> None:  # noqa: ARG002
         return
 
@@ -61,7 +64,7 @@ class _DummyConnection:
         pass
 
     def send_role_message(self, role: str, message: object) -> None:
-        pass
+        self.role_messages.append((role, message))
 
     def send_binary(self, data: bytes, **kwargs: object) -> bool:  # noqa: ARG002
         return True
@@ -129,3 +132,29 @@ async def test_group_stops_when_last_player_leaves_visualizer_behind() -> None:
     # rather than linger as a phantom-led, still-playing group.
     assert visualizer.group is group
     assert group.state == PlaybackStateType.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_surviving_visualizer_gets_stream_end_without_active_stream() -> None:
+    """Stopping a stream-less PLAYING remnant signals survivors' roles directly."""
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+
+    player = _make_client(server, "web", supported_roles=[Roles.PLAYER.value])
+    visualizer = _make_client(server, "hue", supported_roles=[Roles.VISUALIZER.value])
+
+    group = player.group
+    await group.add_client(visualizer)
+    # PLAYING with no PushStream mirrors the track-transition window.
+    group._set_playback_state(PlaybackStateType.PLAYING)  # noqa: SLF001
+    assert not group.has_active_stream
+
+    connection = visualizer.connection
+    assert connection is not None
+    connection.role_messages.clear()
+
+    await group.remove_client(player)
+
+    # stop() emits stream/end only via an active PushStream, so the survivor's
+    # role must be signaled directly to invalidate stale binary.
+    assert any(isinstance(msg, StreamEndMessage) for _, msg in connection.role_messages)


### PR DESCRIPTION
When the last player-role client was ungrouped or disconnected, a visualizer- or metadata-only client kept the group alive and "playing" with no audio source behind it, leaving those clients in a useless state. Removing the last player now stops the group so the client goes idle.

This fixes Visualizer clients disappearing from Music Assistant.