### PR TITLE
Fix late-joining player not catching up to the group

### DIFF
--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -1970,12 +1970,10 @@ class PushStream:
                     and self._has_established_resampler_for(req, channel_id)
                     and self._skip_replay_keeps_join_near_playhead(channel_id, role)
                 ):
-                    # A live role drives this resampler shape, so replaying through
-                    # it would shift the live role's audio across the hand-off. Skip
-                    # replay and pick up live audio, but only when it lands near the
-                    # playhead. Behind a deep producer buffer the shared tail sits far
-                    # ahead and cannot be clamped, so fall through to isolated-resampler
-                    # catch-up rather than strand the joiner until the tail.
+                    # A live role drives this resampler shape, so replaying through it
+                    # would shift the live role's audio across the hand-off. Skip replay
+                    # only when live audio lands near the playhead, else fall through to
+                    # catch-up so the joiner is not stranded waiting at a far-ahead tail.
                     self._rebase_far_ahead_join_tail(channel_id, role)
                     if self._channel_timing:
                         self._ensure_role_started(role)
@@ -2114,11 +2112,9 @@ class PushStream:
     def _skip_replay_keeps_join_near_playhead(self, channel_id: UUID, role: Role) -> bool:
         """Whether skipping PCM replay still lands the joiner near the playhead.
 
-        Skipping replay relies on live audio arriving soon. That holds when the
-        channel tail is already within a normal buffer of now, or when
-        _rebase_far_ahead_join_tail can clamp a far-ahead tail. Behind a deep
-        producer buffer with other roles holding the shared timeline, the tail
-        sits far ahead and cannot be clamped, so the joiner must replay instead.
+        True when the tail is within a normal buffer of now, or far ahead but
+        clampable. A far-ahead tail that cannot be clamped means the joiner must
+        replay instead of waiting for live audio at the tail.
         """
         tail_us = self._channel_timing.get(channel_id)
         if tail_us is None:
@@ -2126,21 +2122,20 @@ class PushStream:
         now_us = self._clock.now_us()
         if tail_us <= now_us + self._role_send_ahead_us(role):
             return True
-        clamp_blocked = (
+        return self._can_clamp_far_ahead_tail(channel_id, role)
+
+    def _can_clamp_far_ahead_tail(self, channel_id: UUID, role: Role) -> bool:
+        """Whether the tail can move, blocked by other roles or committed audio."""
+        return not (
             self._channel_has_other_audio_roles(channel_id, role)
             or channel_id in self._channels_with_committed_audio
         )
-        return not clamp_blocked
 
     def _rebase_far_ahead_join_tail(self, channel_id: UUID, joining_role: Role) -> None:
         """Clamp far-ahead solo-channel timing so a rejoin can resume promptly."""
         if channel_id not in self._channel_timing:
             return
-        if self._channel_has_other_audio_roles(channel_id, joining_role):
-            return
-        if channel_id in self._channels_with_committed_audio:
-            # Do not rebase if the channel already has committed audio, as changing the timing
-            # will de-sync it from other clients.
+        if not self._can_clamp_far_ahead_tail(channel_id, joining_role):
             return
         now_us = self._clock.now_us()
         max_resume_start_us = now_us + self._role_send_ahead_us(joining_role)

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -1965,15 +1965,17 @@ class PushStream:
                             self._ensure_role_started(role)
                         return
 
-                if not role.replay_from_pcm_cache() and self._has_established_resampler_for(
-                    req, channel_id
+                if (
+                    not role.replay_from_pcm_cache()
+                    and self._has_established_resampler_for(req, channel_id)
+                    and self._skip_replay_keeps_join_near_playhead(channel_id, role)
                 ):
-                    # Sharing a resampler key with a live role would shift this
-                    # role's audio across the hand-off; skip historical replay.
-                    # Analysis-only roles opt out: their catch-up uses isolated
-                    # resampler state and an inaudible seam, so replaying the
-                    # buffered PCM now beats waiting for a live commit that may
-                    # sit far ahead behind the producer buffer.
+                    # A live role drives this resampler shape, so replaying through
+                    # it would shift the live role's audio across the hand-off. Skip
+                    # replay and pick up live audio, but only when it lands near the
+                    # playhead. Behind a deep producer buffer the shared tail sits far
+                    # ahead and cannot be clamped, so fall through to isolated-resampler
+                    # catch-up rather than strand the joiner until the tail.
                     self._rebase_far_ahead_join_tail(channel_id, role)
                     if self._channel_timing:
                         self._ensure_role_started(role)
@@ -2108,6 +2110,27 @@ class PushStream:
             self._channel_timing[channel_id], reference_timing_us
         )
         self._channel_timing_residue[channel_id] = 0
+
+    def _skip_replay_keeps_join_near_playhead(self, channel_id: UUID, role: Role) -> bool:
+        """Whether skipping PCM replay still lands the joiner near the playhead.
+
+        Skipping replay relies on live audio arriving soon. That holds when the
+        channel tail is already within a normal buffer of now, or when
+        _rebase_far_ahead_join_tail can clamp a far-ahead tail. Behind a deep
+        producer buffer with other roles holding the shared timeline, the tail
+        sits far ahead and cannot be clamped, so the joiner must replay instead.
+        """
+        tail_us = self._channel_timing.get(channel_id)
+        if tail_us is None:
+            return True
+        now_us = self._clock.now_us()
+        if tail_us <= now_us + self._role_send_ahead_us(role):
+            return True
+        clamp_blocked = (
+            self._channel_has_other_audio_roles(channel_id, role)
+            or channel_id in self._channels_with_committed_audio
+        )
+        return not clamp_blocked
 
     def _rebase_far_ahead_join_tail(self, channel_id: UUID, joining_role: Role) -> None:
         """Clamp far-ahead solo-channel timing so a rejoin can resume promptly."""

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -1015,6 +1015,110 @@ async def test_non_main_pcm_catchup_does_not_anchor_to_far_channel_tail() -> Non
 
 
 @pytest.mark.asyncio
+async def test_main_join_with_established_resampler_backfills_near_now() -> None:
+    """Deeply-buffered main-channel join must backfill near now, not inherit the tail.
+
+    When a live role already drives a non-passthrough resampler at the joiner's
+    target shape and the channel tail sits far ahead (deep producer buffer), the
+    join must still replay buffered PCM from the playhead instead of skipping to
+    live audio that does not arrive until the tail.
+    """
+
+    class TransformerA:
+        pending_timestamp_us: int | None = None
+
+        @property
+        def frame_duration_us(self) -> int:
+            return 25_000
+
+        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[tuple[bytes, int]]:
+            return [(pcm, 25_000)]
+
+        def flush(self) -> list[tuple[bytes, int]]:
+            return []
+
+        def get_header(self) -> bytes | None:
+            return None
+
+        def reset(self) -> None:
+            return
+
+    class TransformerB(TransformerA):
+        pass
+
+    group = _DummyGroup(clients=[])
+    role1 = _DummyRole(
+        AudioRequirements(
+            sample_rate=48000,
+            bit_depth=16,
+            channels=2,
+            transformer=TransformerA(),
+            channel_id=MAIN_CHANNEL,
+            frame_duration_us=25_000,
+        )
+    )
+    group.clients.append(_DummyClient([role1]))
+
+    loop = asyncio.get_running_loop()
+    clock = ManualClock()
+    stream = PushStream(loop=loop, clock=clock, group=group)
+
+    # Commit one 24-bit chunk so role1 establishes a non-passthrough resampler
+    # (source 24-bit to target 16-bit) at the joiner's target shape.
+    stream.prepare_audio(
+        bytes(7200),  # 25ms @ 48kHz stereo 24-bit
+        AudioFormat(sample_rate=48000, bit_depth=24, channels=2),
+    )
+    await stream.commit_audio()
+    role1_req = role1.get_audio_requirements()
+    assert role1_req is not None
+    assert stream._has_established_resampler_for(role1_req, MAIN_CHANNEL)  # noqa: SLF001
+
+    now_us = clock.now_us()
+    frame_duration_us = 25_000
+
+    # ~31s of cached 24-bit PCM spanning near-now into the future, channel tail
+    # parked 30s ahead to model a deep buffered source.
+    pcm_chunks = deque[CachedPCMChunk]()
+    for i in range(1240):
+        ts = now_us - 100_000 + i * frame_duration_us
+        pcm_chunks.append(
+            CachedPCMChunk(
+                timestamp_us=ts,
+                duration_us=frame_duration_us,
+                pcm_data=bytes(7200),
+                sample_rate=48000,
+                bit_depth=24,
+                channels=2,
+            )
+        )
+    stream._pcm_chunk_cache[MAIN_CHANNEL.int] = pcm_chunks  # noqa: SLF001
+    stream._channel_timing[MAIN_CHANNEL] = now_us + 30_000_000  # noqa: SLF001
+
+    role2 = _DummyRole(
+        AudioRequirements(
+            sample_rate=48000,
+            bit_depth=16,
+            channels=2,
+            transformer=TransformerB(),
+            channel_id=MAIN_CHANNEL,
+            frame_duration_us=25_000,
+        )
+    )
+    group.clients.append(_DummyClient([role2]))
+
+    stream.on_role_join(role2)
+    for _ in range(50):
+        if role2.received:
+            break
+        await asyncio.sleep(0)
+
+    assert role2.started == 1
+    assert role2.received
+    assert role2.received[0].timestamp_us - now_us < 500_000
+
+
+@pytest.mark.asyncio
 async def test_non_main_join_without_cache_rebases_far_ahead_tail() -> None:
     """When no catch-up cache exists, non-main rejoin should not wait at a far channel tail."""
 


### PR DESCRIPTION
A player added to an active group could skip catch-up replay and instead wait for live audio at the far end of the timeline, so it stayed silent until that point arrived rather than starting immediately in sync. This happened when a live role already drove a resampler at the joiner's target format and the shared timeline tail could not be moved without de-syncing the other players.

The join now checks whether skipping replay would still start near the current playback position. When the tail sits too far ahead to clamp, it falls through to isolated-resampler catch-up and backfills audio from the playhead, so the new player starts immediately and in sync.