### PR TITLE
Fix stale catch-up task entry after eager completion

### DIFF
--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -1981,9 +1981,11 @@ class PushStream:
 
                 self._catchup_state[cache_key] = "catching_up"
                 self._catchup_roles[cache_key] = {role}
-                self._catchup_tasks[cache_key] = create_task(
-                    self._start_catchup_encoding(role, req, channel_id, cache_key)
-                )
+                task = create_task(self._start_catchup_encoding(role, req, channel_id, cache_key))
+                # An eager task can finish inside create_task, after its own
+                # cleanup already removed the map entry. Don't re-add it.
+                if not task.done():
+                    self._catchup_tasks[cache_key] = task
                 return
 
             if self._channel_timing:


### PR DESCRIPTION
A catch-up task can run to completion inside `create_task` (eager task execution), so its own cleanup removes the `_catchup_tasks` entry before the join assigns it. The finished task then lingers in the map until the role leaves, making every later commit take a spurious yield. Only store the task when it is still running.