### PR TITLE
Add MAC field to `device_info`

### DIFF
--- a/aiosendspin/client/client.py
+++ b/aiosendspin/client/client.py
@@ -296,7 +296,7 @@ class SendspinClient:
                 if player_support is provided; must include ARTWORK if
                 artwork_support is provided.
             device_info: Optional device information (product name, manufacturer,
-                software version).
+                software version, MAC address).
             player_support: Custom player capabilities. Required if PLAYER role
                 is specified; raises ValueError if missing.
             artwork_support: Custom artwork capabilities. Required if ARTWORK

--- a/aiosendspin/models/core.py
+++ b/aiosendspin/models/core.py
@@ -97,6 +97,8 @@ class DeviceInfo(DataClassORJSONMixin):
     """Device manufacturer name."""
     software_version: str | None = None
     """Software version of the client (not the Sendspin version)."""
+    mac_address: str | None = None
+    """MAC address of the connection's network interface, lowercase colon-separated."""
 
     class Config(BaseConfig):
         """Config for parsing json messages."""

--- a/tests/models/test_client_hello_role_versions.py
+++ b/tests/models/test_client_hello_role_versions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from aiosendspin.models.core import ClientHelloPayload
+from aiosendspin.models.core import ClientHelloPayload, DeviceInfo
 from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
 from aiosendspin.models.types import AudioCodec
 
@@ -71,3 +71,14 @@ def test_player_support_serializes_with_spec_alias_name() -> None:
     serialized = payload.to_dict()
     assert "player@v1_support" in serialized
     assert "player_support" not in serialized
+
+
+def test_device_info_serializes_mac_address_under_spec_key() -> None:
+    """A set mac_address serializes under the spec wire key with its value."""
+    serialized = DeviceInfo(mac_address="aa:bb:cc:dd:ee:ff").to_dict()
+    assert serialized["mac_address"] == "aa:bb:cc:dd:ee:ff"
+
+
+def test_device_info_omits_mac_address_when_unset() -> None:
+    """An unset mac_address is omitted from the wire payload."""
+    assert "mac_address" not in DeviceInfo().to_dict()


### PR DESCRIPTION
Implements:
- https://github.com/Sendspin/spec/pull/87