### PR TITLE
Allow multi-channel

### DIFF
--- a/aiosendspin/server/audio.py
+++ b/aiosendspin/server/audio.py
@@ -109,10 +109,9 @@ class AudioFormat:
             layout = "6.1"
         elif self.channels == 8:
             layout = "7.1"             
+        elif self.channels == 10:
+            layout = "9.1"
         else:
-            # 9 and 10 channels (e.g. "9.1") have no single
-            # layout alike 5.1/7.1 / FFmpeg raises
-            # "Error parsing channel layout: 9.1")
             raise ValueError(f"Unsupported channel count: {self.channels}")
 
         return wire_bytes_per_sample, av_format, layout, av_bytes_per_sample

--- a/aiosendspin/server/audio.py
+++ b/aiosendspin/server/audio.py
@@ -97,8 +97,22 @@ class AudioFormat:
             layout = "mono"
         elif self.channels == 2:
             layout = "stereo"
+        elif self.channels == 3:
+            layout = "2.1"
+        elif self.channels == 4:
+            layout = "quad"
+        elif self.channels == 5:
+            layout = "4.1"
+        elif self.channels == 6:
+            layout = "5.1"
+        elif self.channels == 7:
+            layout = "6.1"
+        elif self.channels == 8:
+            layout = "7.1"
+        elif self.channels == 10:
+            layout = "9.1"
         else:
-            raise ValueError("Only mono and stereo layouts are supported")
+            raise ValueError(f"Unsupported channel count: {self.channels}")
 
         return wire_bytes_per_sample, av_format, layout, av_bytes_per_sample
 

--- a/aiosendspin/server/audio.py
+++ b/aiosendspin/server/audio.py
@@ -108,7 +108,7 @@ class AudioFormat:
         elif self.channels == 7:
             layout = "6.1"
         elif self.channels == 8:
-            layout = "7.1"             
+            layout = "7.1"
         elif self.channels == 10:
             layout = "9.1"
         else:

--- a/aiosendspin/server/audio.py
+++ b/aiosendspin/server/audio.py
@@ -108,10 +108,11 @@ class AudioFormat:
         elif self.channels == 7:
             layout = "6.1"
         elif self.channels == 8:
-            layout = "7.1"
-        elif self.channels == 10:
-            layout = "9.1"
+            layout = "7.1"             
         else:
+            # 9 and 10 channels (e.g. "9.1") have no single
+            # layout alike 5.1/7.1 / FFmpeg raises
+            # "Error parsing channel layout: 9.1")
             raise ValueError(f"Unsupported channel count: {self.channels}")
 
         return wire_bytes_per_sample, av_format, layout, av_bytes_per_sample

--- a/aiosendspin/server/roles/player/audio_transformers.py
+++ b/aiosendspin/server/roles/player/audio_transformers.py
@@ -415,10 +415,6 @@ class OpusEncoder:
             valid = sorted(self.VALID_SAMPLE_RATES)
             msg = f"Opus only supports sample rates {valid}, got {sample_rate}"
             raise ValueError(msg)
-        # Opus multichannel requires libopus multistream (RFC 7845) — not yet implemented.
-        if channels not in {1, 2}:
-            msg = f"Opus only supports 1 or 2 channels, got {channels}"
-            raise ValueError(msg)
 
         self._sample_rate = sample_rate
         self._channels = channels

--- a/aiosendspin/server/roles/player/audio_transformers.py
+++ b/aiosendspin/server/roles/player/audio_transformers.py
@@ -415,6 +415,10 @@ class OpusEncoder:
             valid = sorted(self.VALID_SAMPLE_RATES)
             msg = f"Opus only supports sample rates {valid}, got {sample_rate}"
             raise ValueError(msg)
+        # Opus multichannel requires libopus multistream (RFC 7845) — not yet implemented.
+        if channels not in {1, 2}:
+            msg = f"Opus only supports 1 or 2 channels, got {channels}"
+            raise ValueError(msg)
 
         self._sample_rate = sample_rate
         self._channels = channels

--- a/aiosendspin/server/roles/player/capabilities.py
+++ b/aiosendspin/server/roles/player/capabilities.py
@@ -24,7 +24,7 @@ def can_encode_format(fmt: SupportedAudioFormat) -> bool:
     Validates against server encoding constraints:
     - PCM bit depth: 16, 24, or 32; channels: 1-8 or 10 (up to 9.1)
     - FLAC bit depth: 16, 24, or 32; channels: 1-8 or 10 (up to 9.1)
-    - Opus bit depth: 16 only; channels: 1 or 2 only, as multichannel Opus requires libopus multistream, RFC 7845 — not yet implemented;
+    - Opus bit depth: 16 only; channels: 1 or 2 only, as multichannel not yet implemented
     - Opus: sample rate must be one of 8k, 12k, 16k, 24k, 48k
     - FLAC/PCM: any sample rate
 

--- a/aiosendspin/server/roles/player/capabilities.py
+++ b/aiosendspin/server/roles/player/capabilities.py
@@ -13,6 +13,8 @@ from aiosendspin.server.roles.player.audio_transformers import OpusEncoder
 PCM_BIT_DEPTHS: frozenset[int] = frozenset({16, 24, 32})
 FLAC_BIT_DEPTHS: frozenset[int] = frozenset({16, 24, 32})
 OPUS_BIT_DEPTHS: frozenset[int] = frozenset({16})
+
+# Supported channel counts — matches the layout map in server/audio.py.
 VALID_CHANNELS: frozenset[int] = frozenset({1, 2, 3, 4, 5, 6, 7, 8, 10})
 
 
@@ -22,7 +24,7 @@ def can_encode_format(fmt: SupportedAudioFormat) -> bool:
     Validates against server encoding constraints:
     - PCM bit depth: 16, 24, or 32; channels: 1-8 or 10 (up to 9.1)
     - FLAC bit depth: 16, 24, or 32; channels: 1-8 or 10 (up to 9.1)
-    - Opus bit depth: 16 only; channels: 1 or 2 (enforced by OpusEncoder)
+    - Opus bit depth: 16 only; channels: 1 or 2 only, as multichannel Opus requires libopus multistream, RFC 7845 — not yet implemented;
     - Opus: sample rate must be one of 8k, 12k, 16k, 24k, 48k
     - FLAC/PCM: any sample rate
 
@@ -38,6 +40,8 @@ def can_encode_format(fmt: SupportedAudioFormat) -> bool:
         return False
     codec = fmt.codec.value
     if codec == AudioCodec.OPUS.value:
+        if fmt.channels not in {1, 2}:
+            return False
         if fmt.bit_depth not in OPUS_BIT_DEPTHS:
             return False
         return fmt.sample_rate in OpusEncoder.VALID_SAMPLE_RATES

--- a/aiosendspin/server/roles/player/capabilities.py
+++ b/aiosendspin/server/roles/player/capabilities.py
@@ -13,17 +13,16 @@ from aiosendspin.server.roles.player.audio_transformers import OpusEncoder
 PCM_BIT_DEPTHS: frozenset[int] = frozenset({16, 24, 32})
 FLAC_BIT_DEPTHS: frozenset[int] = frozenset({16, 24, 32})
 OPUS_BIT_DEPTHS: frozenset[int] = frozenset({16})
-VALID_CHANNELS: frozenset[int] = frozenset({1, 2})
+VALID_CHANNELS: frozenset[int] = frozenset({1, 2, 3, 4, 5, 6, 7, 8, 10})
 
 
 def can_encode_format(fmt: SupportedAudioFormat) -> bool:
     """Check if the server can encode this format.
 
     Validates against server encoding constraints:
-    - PCM bit depth: 16, 24, or 32
-    - FLAC bit depth: 16, 24, or 32
-    - Opus bit depth: 16 only
-    - Channels: 1 or 2
+    - PCM bit depth: 16, 24, or 32; channels: 1-8 or 10 (up to 9.1)
+    - FLAC bit depth: 16, 24, or 32; channels: 1-8 or 10 (up to 9.1)
+    - Opus bit depth: 16 only; channels: 1 or 2 (enforced by OpusEncoder)
     - Opus: sample rate must be one of 8k, 12k, 16k, 24k, 48k
     - FLAC/PCM: any sample rate
 


### PR DESCRIPTION
I am proposing to open aiosendpsin so that it can support multi-channel playback
Context: I am supporting a music-assistant local_audio PR that allows to play via alsa and pulse to hdmi. Ahead of its go live I have created a working concept based on that so that it plays multi-channel too.
This requires changes to both MA as well as aiosendspin

What this PR covers:
Multichannel PCM and FLAC support:
Enables multichannel audio streams (up to 9.1) to pass through aiosendspin.
There are no up/downmix elements as i took the pov that the client (e.g. Music Assistant) should define what the end device supports and then makes sure that the stream is mathcing. Thus aiosendspin should only transport that stream without constraints.
Out of scope: Opus multistream. Why? I currently see no use for a multi-channel Opus, nor can I test this....would need a follow-up PR from someone that requires that.

Changes:

server/audio.py: Extended the channel<>layout map to cover 1–10 channels (up to 9.1). Previously only mono and stereo were mapped.

server/roles/player/capabilities.py: extended VALID_CHANNELS to {1,2,3,4,5,6,7,8,10}, matching the layout map. PCM and FLAC multichannel formats are now accepted by the format gate. Per-codec channel limits are enforced by the encoders themselves.

server/roles/player/audio_transformers.py: with the check on 2ch gone from capabilities, I added a similar channel check to OpusEncoder.__init__. 

Use of AI: Claude/Opus to generate a script to stream multi-channel using alsa using aiosendspin. This identified the required changes above.

Additional info: I have a working end-2-end setup right now using MA with pulse or audio, built with these changes in aiosendspin