### PR TITLE
Stop delaying the first audio chunk after `stream/start`

### DIFF
--- a/aiosendspin/server/audio.py
+++ b/aiosendspin/server/audio.py
@@ -148,7 +148,6 @@ class BufferTracker:
         self.buffered_chunks: deque[BufferedChunk] = deque()
         self.buffered_bytes = 0
         self.buffered_duration_us = 0
-        self.blocked_until_us: int | None = None
 
     def prune_consumed(self, now_us: int | None = None) -> int:
         """Drop finished chunks and return the timestamp used for the calculation."""
@@ -374,31 +373,6 @@ class BufferTracker:
         self.buffered_chunks.clear()
         self.buffered_bytes = 0
         self.buffered_duration_us = 0
-        self.blocked_until_us = None
-
-    def set_send_blocked(self, delay_us: int) -> None:
-        """Block sending for delay_us microseconds from now.
-
-        Used to give clients time to process stream/start before receiving audio.
-
-        Args:
-            delay_us: Delay in microseconds before sending is allowed.
-        """
-        self.blocked_until_us = self._clock.now_us() + delay_us
-
-    def time_until_unblocked(self) -> int:
-        """Return microseconds until sending is unblocked, or 0 if not blocked.
-
-        Returns:
-            Time in microseconds to wait, or 0 if sending is allowed.
-        """
-        if self.blocked_until_us is None:
-            return 0
-        now_us = self._clock.now_us()
-        if now_us >= self.blocked_until_us:
-            self.blocked_until_us = None
-            return 0
-        return self.blocked_until_us - now_us
 
 
 def _convert_s24_to_s32(data: bytes) -> bytes:

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -1056,7 +1056,6 @@ class SendspinConnection:
                 buffer_tracker = handling_role.get_buffer_tracker()
             if buffer_tracker is not None:
                 buffer_tracker.prune_consumed(now_us)
-                wait_us = max(wait_us, buffer_tracker.time_until_unblocked())
                 bytes_needed = entry.binary.buffer_byte_count or 0
                 duration_needed_us = entry.binary.duration_us or 0
                 wait_us = max(

--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -323,13 +323,8 @@ class PlayerV1Role(Role):
             )
         )
         self.send_message(stream_start)
-        is_initial = not self._stream_started
         self._stream_started = True
         self._last_sent_format = current_format
-
-        # Allow client to process stream/start before first binary audio (initial only).
-        if is_initial and self._buffer_tracker is not None:
-            self._buffer_tracker.set_send_blocked(200_000)
 
     def on_audio_chunk(self, chunk: AudioChunk) -> None:
         """Pack and send binary audio. Late audio is discarded by connection."""

--- a/tests/server/test_connection_writer.py
+++ b/tests/server/test_connection_writer.py
@@ -134,7 +134,6 @@ async def test_writer_registers_buffer_after_send() -> None:
     mock_role = MagicMock()
     mock_buffer_tracker = MagicMock()
     mock_buffer_tracker.time_until_duration_capacity.return_value = 0
-    mock_buffer_tracker.time_until_unblocked.return_value = 0
     mock_buffer_tracker.time_until_ready.return_value = 0
     mock_role.get_buffer_tracker.return_value = mock_buffer_tracker
     mock_role._stream_start_time_us = None  # noqa: SLF001
@@ -193,7 +192,6 @@ async def test_writer_does_not_register_without_metadata() -> None:
     mock_role = MagicMock()
     mock_buffer_tracker = MagicMock()
     mock_buffer_tracker.time_until_duration_capacity.return_value = 0
-    mock_buffer_tracker.time_until_unblocked.return_value = 0
     mock_buffer_tracker.time_until_ready.return_value = 0
     mock_role.get_buffer_tracker.return_value = mock_buffer_tracker
     mock_role._stream_start_time_us = None  # noqa: SLF001
@@ -239,7 +237,6 @@ async def test_writer_blocks_on_buffer_tracker_capacity() -> None:
 
     mock_role = MagicMock()
     mock_buffer_tracker = MagicMock()
-    mock_buffer_tracker.time_until_unblocked.return_value = 0
     mock_buffer_tracker.time_until_ready.return_value = 1_000_000
     mock_role.get_buffer_tracker.return_value = mock_buffer_tracker
     mock_role._stream_start_time_us = None  # noqa: SLF001


### PR DESCRIPTION
The fixed 200 ms hold was a workaround for ESPHome clients that crashed when audio arrived right after `stream/start`. Those clients now handle immediate audio, so the hold is no longer needed. It only delayed delivery anyway, and could push the first chunk past a player's scheduled lead time and get it dropped.
For almost all cases the player timing capabilities (`required_lead_time_ms`/`min_buffer_ms`) now gives clients a configurable warmup delay this was standing in for.