### PR TITLE
Fix audio desync when adding a player to an active group

### DIFF
--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -1141,8 +1141,7 @@ class PushStream:
             if cached_any_pcm:
                 self._signal_pcm_cache_update()
                 if self._catchup_tasks:
-                    # Yield so any active catch-up task gets a chance to consume the new
-                    # PCM and finish before live encoding for its TransformKey resumes.
+                    # Yield so an active catch-up task can consume the new PCM before delivery.
                     await asyncio.sleep(0)
 
             # Role-based audio delivery via hooks
@@ -1591,7 +1590,7 @@ class PushStream:
         self._transform_last_input_end_us[tkey] = output_ts + duration_us
         return encoded
 
-    async def _transform_and_deliver(
+    async def _transform_and_deliver(  # noqa: PLR0915
         self,
         roles_by_pcm: dict[
             tuple[UUID, int, int, int], list[tuple[SendspinClient, Role, AudioRequirements]]
@@ -1645,6 +1644,10 @@ class PushStream:
             for tkey, grouped in grouped_by_key.items():
                 roles_by_transform[tkey].extend(role for _client, role, _req in grouped)
                 if self._catchup_state.get(tkey) == "catching_up":
+                    continue
+                # Skip a chunk catch-up already replayed to avoid a duplicate at the seam.
+                key_cache = self._role_chunk_cache.get(tkey)
+                if key_cache and key_cache[-1].timestamp_us + key_cache[-1].duration_us > output_ts:
                     continue
                 if tkey in encode_tasks:
                     continue
@@ -2457,6 +2460,31 @@ class PushStream:
                 if new_encoded and self._catchup_state.get(cache_key) == "catching_up":
                     self._role_chunk_cache[cache_key].extend(new_encoded)
                     last_encoded_end_us = new_encoded[-1].timestamp_us + new_encoded[-1].duration_us
+
+            # Drain PCM committed after the snapshot (a commit racing the hand-off) so it
+            # is replayed here, not dropped. The final empty check flows into the
+            # synchronous send/flip below with no await between, so a racing commit cannot
+            # slip a chunk past both this replay and the suppressed live delivery.
+            while True:
+                pending = [
+                    chunk
+                    for chunk in self._pcm_chunk_cache.get(channel_int, [])
+                    if chunk.timestamp_us >= last_source_end_us
+                ]
+                if not pending:
+                    break
+                last_source_end_us = pending[-1].timestamp_us + pending[-1].duration_us
+                drained = await self._encode_catchup_sequence(
+                    pending,
+                    encoder,
+                    req,
+                    channel_id,
+                    resamplers=catchup_resamplers,
+                    quantizers=catchup_quantizers,
+                )
+                if drained and self._catchup_state.get(cache_key) == "catching_up":
+                    self._role_chunk_cache[cache_key].extend(drained)
+                    last_encoded_end_us = drained[-1].timestamp_us + drained[-1].duration_us
 
             # Promote FIR-warmed catch-up state, skipping shared live keys.
             for rkey, rstate in catchup_resamplers.items():

--- a/tests/server/test_late_join_scheduling_fuzz.py
+++ b/tests/server/test_late_join_scheduling_fuzz.py
@@ -1,0 +1,178 @@
+"""Seeded yield-injection stress tests for late-join scheduling races.
+
+asyncio is single-threaded, so a slow CPU cannot create data races; it changes
+the order in which coroutines resume at ``await`` points. These tests perturb
+that ordering by injecting randomized ``asyncio.sleep`` jitter into the hot
+late-join paths (``commit_audio``, the catch-up task, encode, delivery), then
+assert the same cross-member sync invariant as
+``test_late_joiner_shares_group_timeline``: a late joiner must land on the
+existing member's exact timeline, with no anchor offset.
+
+The join delay (``get_join_delay_s``) is left at the _DummyRole default of 0.0
+so this isolates SCHEDULING races from the separate, already-known bug that the
+1s join-stabilization delay is never applied in production.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from itertools import pairwise
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from aiosendspin.server.audio import AudioFormat
+from aiosendspin.server.channels import MAIN_CHANNEL
+from aiosendspin.server.clock import ManualClock
+from aiosendspin.server.push_stream import PushStream
+from aiosendspin.server.roles import AudioRequirements
+from tests.server.test_push_stream_behavior import _DummyClient, _DummyGroup, _DummyRole
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+SEEDS = [1, 2, 3, 5, 8, 13, 21, 34]
+
+# Optional ad-hoc deep sweep. Keep at 0 in normal development/CI; set to e.g.
+# 500 locally to crank the interleaving search.
+LARGE_SWEEP_SEED_COUNT = 0
+LARGE_SWEEP_SEEDS = list(range(100, 100 + LARGE_SWEEP_SEED_COUNT))
+
+# Paths wrapped with jitter. Each is awaited from another awaited path, so
+# inserting sleeps here reorders the commit / catch-up / delivery interleaving.
+_JITTER_TARGETS = (
+    "commit_audio",
+    "_start_catchup_encoding",
+    "_encode_catchup_sequence",
+    "_deliver_audio_to_roles",
+)
+
+
+class _TransformerA:
+    pending_timestamp_us: int | None = None
+
+    @property
+    def frame_duration_us(self) -> int:
+        return 25_000
+
+    def process(self, pcm: bytes, _ts: int, _dur: int) -> list[tuple[bytes, int]]:
+        return [(pcm, 25_000)]
+
+    def flush(self) -> list[tuple[bytes, int]]:
+        return []
+
+    def get_header(self) -> bytes | None:
+        return None
+
+    def reset(self) -> None:
+        return
+
+
+class _TransformerB(_TransformerA):
+    """Distinct type so the joiner gets its own TransformKey and a catch-up task."""
+
+
+def _player_requirements(transformer: Any) -> AudioRequirements:
+    return AudioRequirements(
+        sample_rate=48000,
+        bit_depth=16,
+        channels=2,
+        transformer=transformer,
+        channel_id=MAIN_CHANNEL,
+        frame_duration_us=25_000,
+    )
+
+
+def _install_jitter(stream: PushStream, rng: random.Random, jitter_s: float) -> None:
+    """Wrap hot async paths so each yields a random amount at its boundaries."""
+
+    def make(orig: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
+        async def wrapped(*args: Any, **kwargs: Any) -> Any:
+            if jitter_s:
+                await asyncio.sleep(rng.uniform(0, jitter_s))
+            result = await orig(*args, **kwargs)
+            if jitter_s:
+                await asyncio.sleep(rng.uniform(0, jitter_s))
+            return result
+
+        return wrapped
+
+    for name in _JITTER_TARGETS:
+        setattr(stream, name, make(getattr(stream, name)))
+
+
+async def _commit(stream: PushStream) -> None:
+    stream.prepare_audio(
+        bytes(7200),  # 25ms @ 48kHz stereo 24-bit
+        AudioFormat(sample_rate=48000, bit_depth=24, channels=2),
+    )
+    await stream.commit_audio()
+
+
+async def _run_scenario(seed: int) -> None:
+    """Run one seeded late-join scenario under injected scheduling jitter."""
+    rng = random.Random(seed)  # noqa: S311
+    jitter_s = rng.choice([0.0, 0.0001, 0.0005, 0.001])
+    pre_join_commits = rng.randint(1, 4)
+    post_join_commits = rng.randint(1, 4)
+    # How many times to pump the loop right after the join, before firing the
+    # post-join commits: varies whether catch-up partially completes first.
+    post_join_pumps = rng.randint(0, 3)
+
+    group = _DummyGroup(clients=[])
+    role1 = _DummyRole(_player_requirements(_TransformerA()))
+    group.clients.append(_DummyClient([role1]))
+
+    loop = asyncio.get_running_loop()
+    clock = ManualClock()
+    stream = PushStream(loop=loop, clock=clock, group=group)
+    _install_jitter(stream, rng, jitter_s)
+
+    for _ in range(pre_join_commits):
+        await _commit(stream)
+
+    role2 = _DummyRole(_player_requirements(_TransformerB()), replay_from_pcm_cache=True)
+    group.clients.append(_DummyClient([role2]))
+    stream.on_role_join(role2)
+
+    for _ in range(post_join_pumps):
+        await asyncio.sleep(0)
+
+    for _ in range(post_join_commits):
+        await _commit(stream)
+
+    # Drain: let the catch-up task and any jittered deliveries finish.
+    for _ in range(200):
+        if all(t.done() for t in stream._catchup_tasks.values()) and role2.received:  # noqa: SLF001
+            break
+        await asyncio.sleep(0.001)
+
+    ctx = (
+        f"seed={seed} jitter={jitter_s} pre={pre_join_commits} "
+        f"post={post_join_commits} pumps={post_join_pumps}"
+    )
+
+    assert role2.started >= 1, f"joiner never got stream/start ({ctx})"
+    assert role2.received, f"joiner was stranded with no audio ({ctx})"
+
+    role2_chunks = sorted(role2.received, key=lambda c: c.timestamp_us)
+    role2_ts = [c.timestamp_us for c in role2_chunks]
+    role1_ts = {c.timestamp_us for c in role1.received}
+
+    for prev, nxt in pairwise(role2_chunks):
+        assert nxt.timestamp_us == prev.timestamp_us + prev.duration_us, (
+            f"joiner timeline has a gap/overlap: {role2_ts} ({ctx})"
+        )
+
+    assert set(role2_ts) <= role1_ts, (
+        f"joiner desynced from group: role2={role2_ts} "
+        f"not a subset of role1={sorted(role1_ts)} ({ctx})"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("seed", SEEDS + LARGE_SWEEP_SEEDS)
+async def test_late_join_scheduling_race(seed: int) -> None:
+    """Late join stays on the group timeline under perturbed scheduling order."""
+    await _run_scenario(seed)

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -1154,6 +1154,114 @@ async def test_catchup_handoff_delivers_contiguous_audio() -> None:
 
 
 @pytest.mark.asyncio
+async def test_late_joiner_shares_group_timeline() -> None:
+    """A late joiner must land on the same absolute timeline as the existing member.
+
+    Every device schedules playback off the absolute timestamp in each chunk, so
+    two players are in sync only if identical audio reaches them with identical
+    timestamps. This drives a normal (near-now) group: role1 plays, role2 joins
+    mid-stream through the PCM-cache catch-up path, then more live audio commits.
+
+    Invariant: every timestamp role2 receives is also a timestamp role1 receives
+    (a contiguous suffix of the shared timeline), with no anchor offset. A failure
+    here would reproduce the reported "out of sync after grouping" symptom.
+    """
+
+    class TransformerA:
+        pending_timestamp_us: int | None = None
+
+        @property
+        def frame_duration_us(self) -> int:
+            return 25_000
+
+        def process(self, pcm: bytes, _ts: int, _dur: int) -> list[tuple[bytes, int]]:
+            return [(pcm, 25_000)]
+
+        def flush(self) -> list[tuple[bytes, int]]:
+            return []
+
+        def get_header(self) -> bytes | None:
+            return None
+
+        def reset(self) -> None:
+            return
+
+    class TransformerB(TransformerA):
+        pass
+
+    group = _DummyGroup(clients=[])
+    role1 = _DummyRole(
+        AudioRequirements(
+            sample_rate=48000,
+            bit_depth=16,
+            channels=2,
+            transformer=TransformerA(),
+            channel_id=MAIN_CHANNEL,
+            frame_duration_us=25_000,
+        )
+    )
+    group.clients.append(_DummyClient([role1]))
+
+    loop = asyncio.get_running_loop()
+    clock = ManualClock()
+    stream = PushStream(loop=loop, clock=clock, group=group)
+
+    def commit_one() -> None:
+        stream.prepare_audio(
+            bytes(7200),  # 25ms @ 48kHz stereo 24-bit
+            AudioFormat(sample_rate=48000, bit_depth=24, channels=2),
+        )
+
+    # role1 plays two live chunks alone; both are cached as PCM for catch-up.
+    commit_one()
+    await stream.commit_audio()
+    commit_one()
+    await stream.commit_audio()
+
+    # role2 joins mid-stream. replay_from_pcm_cache forces the catch-up path
+    # (its own TransformKey, distinct transformer) rather than skipping replay.
+    role2 = _DummyRole(
+        AudioRequirements(
+            sample_rate=48000,
+            bit_depth=16,
+            channels=2,
+            transformer=TransformerB(),
+            channel_id=MAIN_CHANNEL,
+            frame_duration_us=25_000,
+        ),
+        replay_from_pcm_cache=True,
+    )
+    group.clients.append(_DummyClient([role2]))
+    stream.on_role_join(role2)
+
+    # Two more live chunks land after the join.
+    commit_one()
+    await stream.commit_audio()
+    commit_one()
+    await stream.commit_audio()
+
+    for _ in range(50):
+        if role2.received:
+            break
+        await asyncio.sleep(0)
+
+    assert role2.started >= 1
+    assert role2.received, "joiner was stranded with no audio"
+
+    role2_ts = sorted(c.timestamp_us for c in role2.received)
+    role1_ts = {c.timestamp_us for c in role1.received}
+
+    # role2's timeline is contiguous (no gap that would glitch playback).
+    for prev, nxt in pairwise(sorted(role2.received, key=lambda c: c.timestamp_us)):
+        assert nxt.timestamp_us == prev.timestamp_us + prev.duration_us
+
+    # Core sync invariant: role2 sits on role1's exact timeline, no offset.
+    assert set(role2_ts) <= role1_ts, (
+        f"joiner desynced from group: role2={role2_ts} not a subset of role1={sorted(role1_ts)}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_main_join_with_established_resampler_backfills_near_now() -> None:
     """Deeply-buffered main-channel join must backfill near now, not inherit the tail.
 


### PR DESCRIPTION
Adding a player to a playing group could drop the first audio chunk delivered after the join, leaving the new player out of sync until playback was restarted. The catch-up replay ran to a fixed window while live delivery stayed suppressed during catch-up, so a chunk committed during the hand-off was sent by neither path.

The catch-up task now drains audio that arrives during the hand-off before switching to live, keeping the final check and that switch on one synchronous step so a racing commit cannot slip a chunk past both paths.

A deterministic fuzzer is also added that initially found this race condition.