### PR TITLE
Increase default `min_buffer_ms` to 500ms

### DIFF
--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -71,7 +71,7 @@ class PlayerPersistentState:
     buffer_reset_handle: asyncio.TimerHandle | None = None
     static_delay_ms: int = 0
     required_lead_time_ms: int = 250
-    min_buffer_ms: int = 250
+    min_buffer_ms: int = 500
     state_supported_commands: list[PlayerCommand] = field(default_factory=list)
 
 

--- a/tests/server/roles/test_player_v1.py
+++ b/tests/server/roles/test_player_v1.py
@@ -860,13 +860,13 @@ def test_on_client_state_no_event_if_unchanged() -> None:
 
 
 def test_timing_defaults() -> None:
-    """Lead time and min buffer default to 250 ms."""
+    """Lead time defaults to 250 ms and min buffer to 500 ms."""
     client = _make_client_stub()
     role = PlayerV1Role(client=client)
     assert role.required_lead_time_ms == 250
-    assert role.min_buffer_ms == 250
+    assert role.min_buffer_ms == 500
     assert role.get_required_lead_time_us() == 250_000
-    assert role.get_min_buffer_us() == 250_000
+    assert role.get_min_buffer_us() == 500_000
 
 
 def test_on_client_state_updates_required_lead_time() -> None:


### PR DESCRIPTION
While it is mandatory to advertise `min_buffer_ms` in the current version of the spec, older implementations are still supported but fell back to the default value of 250ms.
This was too tight though so live streams weren't playing reliably in some conditions.
This PR bumps the default `min_buffer_ms` to 500ms.