### PR TITLE
Correctness and performance fixes

### DIFF
--- a/aiosendspin/client/client.py
+++ b/aiosendspin/client/client.py
@@ -34,10 +34,21 @@ from aiosendspin.noise.keys import Identity
 from aiosendspin.noise.pairing import PairingError
 from aiosendspin.noise.trust_store import ClientPairingStore, ResolvedPsk
 
-from .connection import UNSYNCED_PLAY_LEAD_US, SendspinConnection
+from .connection import DECODABLE_CODECS, UNSYNCED_PLAY_LEAD_US, SendspinConnection
 from .models import AudioFormat, ServerInfo
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_decodable_formats(player_support: ClientHelloPlayerSupport) -> None:
+    """Reject advertised codecs the SDK cannot decode."""
+    undecodable = {f.codec for f in player_support.supported_formats}.difference(DECODABLE_CODECS)
+    if undecodable:
+        names = ", ".join(sorted(c.value for c in undecodable))
+        raise ValueError(
+            f"player_support advertises codecs the SDK cannot decode ({names}); "
+            "only PCM and FLAC are supported"
+        )
 
 
 # Callback invoked when server state metadata updates are received.
@@ -202,6 +213,7 @@ class SendspinClient:
         if Roles.PLAYER in self._roles:
             if player_support is None:
                 raise ValueError("player_support is required when PLAYER role is specified")
+            _validate_decodable_formats(player_support)
             self._player_support = player_support
         else:
             self._player_support = None

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -113,6 +113,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Codecs the SDK can decode. Anything else would be silently dropped.
+DECODABLE_CODECS = (AudioCodec.PCM, AudioCodec.FLAC)
+
 _ManagementRequest = (
     ManagementListRecordsMessage
     | ManagementAddRecordMessage
@@ -1035,7 +1038,7 @@ class SendspinConnection:
                 logger.debug("Stream start message without player payload")
             return
 
-        if player.codec not in (AudioCodec.PCM, AudioCodec.FLAC):
+        if player.codec not in DECODABLE_CODECS:
             logger.error(
                 "Unsupported codec '%s' - only PCM and FLAC are supported", player.codec.value
             )

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -844,9 +844,10 @@ class SendspinConnection:
         await self._send_message(message.to_json())
 
     async def _send_message(self, payload: str) -> None:
-        if self._ws is None:
-            raise RuntimeError("WebSocket is not connected")
         async with self._send_lock:
+            # Re-check under the lock: disconnect() can null _ws while we await it.
+            if self._ws is None:
+                raise RuntimeError("WebSocket is not connected")
             if self._exchange_in_progress:
                 return
             await self._ws.send_str(payload)

--- a/aiosendspin/client/time_sync.py
+++ b/aiosendspin/client/time_sync.py
@@ -187,7 +187,8 @@ class SendspinTimeFilter:
 
         ### Kalman Update Step ###
         # Innovation covariance: S = H * P * H^T + R, where H = [1, 0]
-        uncertainty: float = 1.0 / (new_offset_covariance + measurement_variance)
+        # Floor the denominator so zero-error loopback can't divide by zero.
+        uncertainty: float = 1.0 / max(new_offset_covariance + measurement_variance, 1e-9)
 
         # Kalman gain: K = P * H^T * S^(-1)
         offset_gain: float = new_offset_covariance * uncertainty

--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -99,6 +99,8 @@ class SendspinClient:
         self._info: ClientHelloPayload | None = None
         self._negotiated_role_ids: list[str] = []
         self._roles: dict[str, Role] = {}
+        # Cached tuple of active roles, rebuilt when the role set changes.
+        self._active_roles: tuple[Role, ...] | None = None
         self._group: SendspinGroup | None = None
 
         self._connection: SendspinConnection | None = None
@@ -167,9 +169,11 @@ class SendspinClient:
         return self._negotiated_role_ids
 
     @property
-    def active_roles(self) -> list[Role]:
+    def active_roles(self) -> tuple[Role, ...]:
         """All active role instances for iteration."""
-        return list(self._roles.values())
+        if self._active_roles is None:
+            self._active_roles = tuple(self._roles.values())
+        return self._active_roles
 
     @property
     def active_role_ids(self) -> list[str]:
@@ -695,6 +699,7 @@ class SendspinClient:
             for role in self._roles.values():
                 role.on_disconnect()
         self._roles.clear()
+        self._active_roles = None
         self._binary_handling_cache.clear()
         self._roles_cold_preinitialized = False
         self._roles_attached = False
@@ -715,6 +720,7 @@ class SendspinClient:
 
     def _rebuild_binary_handling_cache(self) -> None:
         """Build binary handling cache for fast lookup."""
+        self._active_roles = None
         self._binary_handling_cache.clear()
         for msg_type in BinaryMessageType:
             for role in self._roles.values():

--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -267,7 +267,8 @@ class SendspinClient:
         old_available = self._available
         self._available = available
 
-        for role in self._roles.values():
+        # Snapshot: an awaited hook can trigger a cold reconnect that rebuilds _roles.
+        for role in list(self._roles.values()):
             coro = role.on_availability_changed(old_available, available)
             if coro is not None:
                 await coro

--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -631,11 +631,11 @@ class SendspinClient:
         self._roles_attached = False
 
     async def _handle_takeover_disconnect(self) -> None:
-        """Handle ANOTHER_SERVER disconnect by ungrouping first, then stopping."""
+        """Handle ANOTHER_SERVER disconnect by ungrouping the client from its group."""
         old_group_id = self.group.group_id
         try:
+            # ungroup() already leaves the client in a fresh stopped solo group.
             await self.ungroup()
-            await self.group.stop()
         except Exception:
             self._logger.exception(
                 "Takeover disconnect sequence failed for %s (old_group=%s)",

--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -441,10 +441,7 @@ class SendspinClient:
     ) -> None:
         """Attach a new WebSocket connection to this client."""
         # Cancel pending cleanup if client reconnected before cleanup fired
-        if self._cleanup_handle is not None:
-            self._logger.debug("Cancelling pending cleanup due to reconnect")
-            self._cleanup_handle.cancel()
-            self._cleanup_handle = None
+        self._cancel_cleanup()
 
         if self._connection is not None and self._connection is not connection:
             # Replace an existing connection for the same device.
@@ -574,6 +571,8 @@ class SendspinClient:
                 f"Cannot cold-preinitialize roles for {self._client_id!r} while connected"
             )
 
+        # Disarm a pending cleanup so a just-registered client isn't removed.
+        self._cancel_cleanup()
         self._hard_detach_roles(call_disconnect_hooks=self._roles_attached)
         self._set_identity_from_hello(client_info)
         self._roles_warm_disconnected = False
@@ -642,6 +641,13 @@ class SendspinClient:
                 self._client_id,
                 old_group_id,
             )
+
+    def _cancel_cleanup(self) -> None:
+        """Disarm a pending registry-cleanup timer, if one is armed."""
+        if self._cleanup_handle is not None:
+            self._logger.debug("Cancelling pending cleanup")
+            self._cleanup_handle.cancel()
+            self._cleanup_handle = None
 
     def _schedule_cleanup(self, goodbye_reason: GoodbyeReason | None) -> None:
         """Schedule cleanup from server registry based on disconnect reason."""

--- a/aiosendspin/server/group.py
+++ b/aiosendspin/server/group.py
@@ -418,25 +418,9 @@ class SendspinGroup:
             client: The client to add to this group.
         """
         logger.debug("adding %s to group with members: %s", client.client_id, self._clients)
-        old_group = client.group
-        if logger.isEnabledFor(logging.DEBUG):
-            logger.debug(
-                "add_client(%s): stopping previous group=%s active=%s members=%s",
-                client.client_id,
-                old_group.group_id,
-                old_group.has_active_stream,
-                [c.client_id for c in old_group.clients],
-            )
-        stopped = await old_group.stop()
-        if stopped and logger.isEnabledFor(logging.DEBUG):
-            logger.debug(
-                "add_client(%s): previous group=%s stopped playback",
-                client.client_id,
-                old_group.group_id,
-            )
         if client in self._clients:
             return
-        # Remove it from any existing group first
+        # Remove from the current group first. A remnant with a player keeps playing.
         await client.ungroup()
 
         # Check for and remove any stale client with the same client_id

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -12,6 +12,7 @@ from collections import defaultdict, deque
 from dataclasses import dataclass
 from errno import EAGAIN
 from functools import lru_cache
+from itertools import islice
 from typing import TYPE_CHECKING, Literal, NamedTuple, Protocol, cast
 from uuid import UUID
 
@@ -725,7 +726,7 @@ class PushStream:
         # Inline resamplers for role-based audio delivery
         self._resamplers: dict[_ResamplerKey, _ResamplerState] = {}
         # Role-based chunk cache: TransformKey -> list of cached chunks
-        self._role_chunk_cache: defaultdict[TransformKey, list[CachedChunk]] = defaultdict(list)
+        self._role_chunk_cache: defaultdict[TransformKey, deque[CachedChunk]] = defaultdict(deque)
         # PCM chunk cache: channel_id.int -> deque of cached PCM chunks
         self._pcm_chunk_cache: dict[int, deque[CachedPCMChunk]] = {}
         # Channels with PCM caching enabled
@@ -1751,16 +1752,9 @@ class PushStream:
 
         for key in list(self._role_chunk_cache.keys()):
             chunks = self._role_chunk_cache[key]
-            prune_count = 0
-            for chunk in chunks:
-                if chunk.timestamp_us + chunk.duration_us > now_us:
-                    break
-                prune_count += 1
-
-            if prune_count:
-                self._role_chunk_cache[key] = chunks[prune_count:]
-
-            if not self._role_chunk_cache[key]:
+            while chunks and chunks[0].timestamp_us + chunks[0].duration_us <= now_us:
+                chunks.popleft()
+            if not chunks:
                 del self._role_chunk_cache[key]
 
         for channel_int in list(self._pcm_chunk_cache.keys()):
@@ -1937,7 +1931,7 @@ class PushStream:
 
         # Get cached chunks for this transformer from the role-based cache
         cache_key = self._build_transform_key(req, channel_id, role)
-        cached = self._role_chunk_cache.get(cache_key, [])
+        cached: deque[CachedChunk] = self._role_chunk_cache.get(cache_key, deque())
 
         if not cached:
             if cache_key in self._catchup_state:
@@ -2019,7 +2013,7 @@ class PushStream:
                 last_ts,
             )
 
-        self._send_cached_chunks_to_role(role, cached[start_index:], now_us)
+        self._send_cached_chunks_to_role(role, list(islice(cached, start_index, None)), now_us)
 
     def _other_roles_use_transform_key(self, cache_key: TransformKey, exclude_role: Role) -> bool:
         """Check if any other active pipeline role uses the same TransformKey."""
@@ -2490,9 +2484,10 @@ class PushStream:
                     self._resamplers[qkey] = qstate
 
             now_us = self._clock.now_us()
-            encoded_cache = self._role_chunk_cache.get(cache_key, [])
+            encoded_cache: deque[CachedChunk] = self._role_chunk_cache.get(cache_key, deque())
+            chunks_to_send = list(encoded_cache)
             for r in self._catchup_roles.get(cache_key, {role}):
-                self._send_cached_chunks_to_role(r, encoded_cache, now_us)
+                self._send_cached_chunks_to_role(r, chunks_to_send, now_us)
 
             self._catchup_state[cache_key] = "live"
         finally:

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -1695,21 +1695,24 @@ class PushStream:
 
             # Deliver live chunks directly; connection layer enforces late-drop/backpressure.
             roles = roles_by_transform.get(tkey, [])
+            # Share one AudioChunk across roles so its packed frame is built once.
+            audio_chunks = [
+                AudioChunk(
+                    data=cached_chunk.payload,
+                    timestamp_us=cached_chunk.timestamp_us,
+                    duration_us=cached_chunk.duration_us,
+                    byte_count=cached_chunk.byte_count,
+                )
+                for cached_chunk in cached_for_key
+            ]
             for role in roles:
                 if role not in active_roles:
                     continue
                 self._ensure_role_started(role)
                 if role not in self._started_roles:
                     continue
-                for cached_chunk in cached_for_key:
-                    role.on_audio_chunk(
-                        AudioChunk(
-                            data=cached_chunk.payload,
-                            timestamp_us=cached_chunk.timestamp_us,
-                            duration_us=cached_chunk.duration_us,
-                            byte_count=cached_chunk.byte_count,
-                        )
-                    )
+                for audio_chunk in audio_chunks:
+                    role.on_audio_chunk(audio_chunk)
 
         return cache_results
 

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -202,7 +202,7 @@ def _encode_for_transform_key(
     output_ts: int,
     duration_us: int,
 ) -> list[tuple[bytes, int, int]]:
-    """Encode PCM for a single TransformKey. Thread-safe (no shared state)."""
+    """Encode PCM for a single TransformKey."""
     if transformer is None:
         return [(pcm_data, output_ts, duration_us)]
 
@@ -1597,7 +1597,7 @@ class PushStream:
     ) -> dict[TransformKey, list[CachedChunk]]:
         """Transform PCM, deliver live chunks to roles, and return cache results.
 
-        Encoding is parallelized across unique TransformKeys via a thread pool.
+        Encoding runs sequentially on the event loop, yielding every few keys.
         """
         # Collect unique encoding tasks: tkey -> (transformer, pcm_data, output_ts, duration_us)
         encode_tasks: dict[TransformKey, tuple[AudioTransformer | None, bytes, int, int]] = {}

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -500,8 +500,7 @@ def _resample_pcm_standalone(  # noqa: PLR0915
     output_sample_count = 0
     for out_frame in out_frames:
         expected = resampler_state.target_av_frame_stride * out_frame.samples
-        pcm_bytes = bytes(out_frame.planes[0])[:expected]
-        out_pcm.extend(pcm_bytes)
+        out_pcm.extend(memoryview(out_frame.planes[0])[:expected])
         output_sample_count += out_frame.samples
 
     output_start_ts = resampler_state.pending_timestamp_us
@@ -553,8 +552,7 @@ def _flush_resampler(resampler_state: _ResamplerState) -> _ResampledPCM:
     output_sample_count = 0
     for out_frame in out_frames:
         expected = resampler_state.target_av_frame_stride * out_frame.samples
-        pcm_bytes = bytes(out_frame.planes[0])[:expected]
-        out_pcm.extend(pcm_bytes)
+        out_pcm.extend(memoryview(out_frame.planes[0])[:expected])
         output_sample_count += out_frame.samples
 
     if output_sample_count > 0:

--- a/aiosendspin/server/roles/base.py
+++ b/aiosendspin/server/roles/base.py
@@ -12,8 +12,11 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
 from dataclasses import dataclass
+from functools import cached_property
 from typing import TYPE_CHECKING, Any
 from uuid import UUID
+
+from aiosendspin.models import BinaryMessageType, pack_binary_header_raw
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
@@ -79,6 +82,12 @@ class AudioChunk:
 
     byte_count: int
     """Size of data (for buffer tracking)."""
+
+    @cached_property
+    def packed(self) -> bytes:
+        """Binary AUDIO_CHUNK frame, memoized so subscribers reuse one copy."""
+        header = pack_binary_header_raw(BinaryMessageType.AUDIO_CHUNK.value, self.timestamp_us)
+        return header + self.data
 
 
 class GroupRole(ABC):

--- a/aiosendspin/server/roles/metadata/group.py
+++ b/aiosendspin/server/roles/metadata/group.py
@@ -120,6 +120,8 @@ class MetadataGroupRole(GroupRole):
             else:
                 timestamp = metadata.timestamp_us
 
+        if metadata is None and self._current_metadata is None:
+            return
         if metadata is not None and metadata.equals(self._current_metadata):
             return
 

--- a/aiosendspin/server/roles/metadata/state.py
+++ b/aiosendspin/server/roles/metadata/state.py
@@ -102,7 +102,9 @@ class Metadata:
 
         # Calculate expected progress change based on elapsed time and playback speed
         time_diff_ms = (other.timestamp_us - self.timestamp_us) / 1000
-        playback_speed = (self.playback_speed or 1000) / 1000  # Convert to float multiplier
+        # Only None means unknown. A speed of 0 is a real paused rate.
+        speed = 1000 if self.playback_speed is None else self.playback_speed
+        playback_speed = speed / 1000
         expected_progress_change = time_diff_ms * playback_speed
 
         # Calculate actual progress change

--- a/aiosendspin/server/roles/player/audio_transformers.py
+++ b/aiosendspin/server/roles/player/audio_transformers.py
@@ -109,7 +109,7 @@ class PcmPassthrough:
         frames: list[tuple[bytes, int]] = []
 
         while len(self._buffer) >= self._frame_size:
-            frame = bytes(self._buffer[: self._frame_size])
+            frame = bytes(memoryview(self._buffer)[: self._frame_size])
             del self._buffer[: self._frame_size]
             # Advance pending timestamp using rational arithmetic. Each frame
             # represents exactly `chunk_samples / sample_rate` seconds. Tracking
@@ -318,7 +318,7 @@ class FlacEncoder:
         chunk_size = self._chunk_samples * self._frame_stride
 
         while len(self._buffer) >= chunk_size:
-            chunk_pcm = bytes(self._buffer[:chunk_size])
+            chunk_pcm = bytes(memoryview(self._buffer)[:chunk_size])
             del self._buffer[:chunk_size]
             encoded = self._encode_chunk(chunk_pcm)
             self._chunks_encoded_total += 1
@@ -555,7 +555,7 @@ class OpusEncoder:
         chunk_size = self._chunk_samples * self._frame_stride
 
         while len(self._buffer) >= chunk_size:
-            chunk_pcm = bytes(self._buffer[:chunk_size])
+            chunk_pcm = bytes(memoryview(self._buffer)[:chunk_size])
             del self._buffer[:chunk_size]
             encoded = self._encode_chunk(chunk_pcm)
             self._chunks_encoded_total += 1

--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -14,7 +14,7 @@ import base64
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from aiosendspin.models import AudioCodec, BinaryMessageType, pack_binary_header_raw
+from aiosendspin.models import AudioCodec, BinaryMessageType
 from aiosendspin.models.core import (
     ClientStatePayload,
     ServerCommandMessage,
@@ -348,17 +348,15 @@ class PlayerV1Role(Role):
                 )
             return
 
-        # Pack binary header and send
+        # Reuse the frame packed once and shared across subscribers.
         message_type = BinaryMessageType.AUDIO_CHUNK.value
-        header = pack_binary_header_raw(message_type, chunk.timestamp_us)
-        packed_data = header + chunk.data
         # Compute the wall-clock buffer horizon (effective play time) by shifting
         # the chunk's end time earlier by the configured static delay.
         static_delay_us = self.static_delay_ms * 1_000
         chunk_end_us = chunk.timestamp_us + chunk.duration_us - static_delay_us
 
         self._client.send_binary(
-            packed_data,
+            chunk.packed,
             role_family=self.role_family,
             timestamp_us=chunk.timestamp_us,
             message_type=message_type,

--- a/aiosendspin/server/server.py
+++ b/aiosendspin/server/server.py
@@ -166,6 +166,8 @@ class SendspinServer:
         self._external_stream_start_cbs: dict[str, ExternalStreamStartCallback] = {}
         self._external_registration_timeouts: dict[str, asyncio.Handle] = {}
         self._reclaim_timeouts: dict[str, asyncio.Handle] = {}
+        # Clients whose unregister a one-shot timer deferred to an in-flight reconnect.
+        self._deferred_unregister: set[str] = set()
         self._pending_connections = set()
 
         self._mdns_client_urls: dict[str, str] = {}
@@ -687,8 +689,28 @@ class SendspinServer:
         client = self._clients.get(client_id)
         if client is not None and client.connection is not None:
             return
+        # A reconnect mid-handshake: defer removal until the task settles so a
+        # failed reconnect is still unregistered instead of lingering forever.
+        url = self._client_urls.get(client_id)
+        if url is not None and url in self._connection_tasks:
+            self._deferred_unregister.add(client_id)
+            return
+        self._deferred_unregister.discard(client_id)
         self.unregister_external_player(client_id)
         await self.remove_client(client_id)
+
+    async def _complete_deferred_unregister(
+        self, url: str, *, connection_succeeded: bool, cancelled: bool
+    ) -> None:
+        """Finish an unregister deferred while this URL's reconnect task was in flight."""
+        client_id = self.get_client_id_for_url(url)
+        if client_id is None or client_id not in self._deferred_unregister:
+            return
+        self._deferred_unregister.discard(client_id)
+        # A reconnect that attached (or a shutdown cancellation) is handled elsewhere.
+        if connection_succeeded or cancelled:
+            return
+        await self._full_unregister_disconnected_client(client_id)
 
     def _resolve_initial_connect_waiters(self, url: str, err: BaseException | None = None) -> None:
         """Resolve or fail waiters for an initial connection attempt."""
@@ -809,6 +831,12 @@ class SendspinServer:
             self._initial_connect_succeeded.discard(url)
             self._connection_options.pop(url, None)
             self._connection_reasons.pop(url, None)
+            current = asyncio.current_task()
+            await self._complete_deferred_unregister(
+                url,
+                connection_succeeded=first_connection_succeeded,
+                cancelled=current is not None and current.cancelling() > 0,
+            )
 
     async def start_server(
         self,

--- a/aiosendspin/server/server.py
+++ b/aiosendspin/server/server.py
@@ -658,6 +658,18 @@ class SendspinServer:
         if handle is not None:
             handle.cancel()
 
+    def _cancel_all_timers(self) -> None:
+        """Disarm all pending registry timers."""
+        for handle in (
+            *self._external_registration_timeouts.values(),
+            *self._reclaim_timeouts.values(),
+        ):
+            handle.cancel()
+        self._external_registration_timeouts.clear()
+        self._reclaim_timeouts.clear()
+        for client in self._clients.values():
+            client._cancel_cleanup()  # noqa: SLF001
+
     def _schedule_external_registration_timeout(self, client_id: str, timeout_s: float) -> None:
         """Schedule full unregister if an externally registered client never connects."""
         self._cancel_external_registration_timeout(client_id)
@@ -933,6 +945,9 @@ class SendspinServer:
                     await wsock.close()
             except TimeoutError:
                 logger.debug("Timeout while closing pending client websocket")
+            except RuntimeError:
+                # Not past wsock.prepare() yet, nothing to close.
+                logger.debug("Pending client websocket not prepared, skipping close")
 
         disconnect_tasks: list[asyncio.Task[None]] = []
         for client in self._clients.values():
@@ -943,6 +958,9 @@ class SendspinServer:
             )
         if disconnect_tasks:
             await asyncio.gather(*disconnect_tasks, return_exceptions=True)
+
+        # Disarm timers after disconnect, which re-arms per-client cleanup.
+        self._cancel_all_timers()
 
         await self.stop_server()
         if self._owns_session and not self._client_session.closed:

--- a/aiosendspin/server/server.py
+++ b/aiosendspin/server/server.py
@@ -937,7 +937,8 @@ class SendspinServer:
         # Close pending incoming connections so their handlers can exit promptly.
         for conn in list(self._pending_connections):
             wsock = conn.websocket_connection
-            if wsock.closed:
+            # An incoming socket not past wsock.prepare() has nothing to close.
+            if wsock.closed or (isinstance(wsock, web.WebSocketResponse) and not wsock.prepared):
                 continue
             logger.debug("Closing pending client connection")
             try:
@@ -945,9 +946,6 @@ class SendspinServer:
                     await wsock.close()
             except TimeoutError:
                 logger.debug("Timeout while closing pending client websocket")
-            except RuntimeError:
-                # Not past wsock.prepare() yet, nothing to close.
-                logger.debug("Pending client websocket not prepared, skipping close")
 
         disconnect_tasks: list[asyncio.Task[None]] = []
         for client in self._clients.values():

--- a/aiosendspin/util.py
+++ b/aiosendspin/util.py
@@ -3,15 +3,27 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import socket
 import sys
 from collections.abc import Coroutine
 from typing import Any
 
+_LOGGER = logging.getLogger(__name__)
+
 # Check if eager_start is supported (Python 3.12+)
 _SUPPORTS_EAGER_START = sys.version_info >= (3, 12)
 
 TASKS: set[asyncio.Task[Any]] = set()
+
+
+def _log_task_exception(task: asyncio.Task[Any]) -> None:
+    """Log an unhandled exception from a fire-and-forget task."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        _LOGGER.error("Unhandled exception in background task %r", task.get_name(), exc_info=exc)
 
 
 def create_task[T](
@@ -49,12 +61,12 @@ def create_task[T](
     else:
         task = loop.create_task(coro, name=name)
 
+    task.add_done_callback(_log_task_exception)
     if task.done():
         return task
 
     TASKS.add(task)
     task.add_done_callback(TASKS.discard)
-    task.add_done_callback(lambda t: t.exception() if not t.cancelled() else None)
 
     return task
 

--- a/tests/server/roles/metadata/test_group.py
+++ b/tests/server/roles/metadata/test_group.py
@@ -89,6 +89,20 @@ def test_metadata_group_role_clear_metadata() -> None:
     assert isinstance(event, MetadataClearedEvent)
 
 
+def test_metadata_group_role_clear_when_already_cleared_is_noop() -> None:
+    """Clearing already-cleared metadata sends nothing and emits no event."""
+    group = _make_group_stub()
+    mgr = MetadataGroupRole(group)
+
+    member = MagicMock()
+    mgr._members = [member]  # noqa: SLF001
+
+    mgr.clear()
+
+    member.send_message.assert_not_called()
+    group._signal_event.assert_not_called()  # noqa: SLF001
+
+
 def test_metadata_group_role_update_title() -> None:
     """update() updates only the title field."""
     group = _make_group_stub()

--- a/tests/server/roles/metadata/test_state.py
+++ b/tests/server/roles/metadata/test_state.py
@@ -1,0 +1,21 @@
+"""Tests for Metadata.equals progress-drift handling."""
+
+from __future__ import annotations
+
+from aiosendspin.server.roles.metadata.state import Metadata
+
+
+def test_equals_treats_paused_progress_as_frozen() -> None:
+    """While paused (speed 0), unchanged progress across time stays equal (no phantom drift)."""
+    first = Metadata(track_progress=42_000, playback_speed=0, timestamp_us=0)
+    later = Metadata(track_progress=42_000, playback_speed=0, timestamp_us=2_000_000)
+
+    assert first.equals(later)
+
+
+def test_equals_detects_drift_at_normal_speed() -> None:
+    """At 1x, progress that did not advance with elapsed time is not equal."""
+    first = Metadata(track_progress=42_000, playback_speed=1000, timestamp_us=0)
+    later = Metadata(track_progress=42_000, playback_speed=1000, timestamp_us=2_000_000)
+
+    assert not first.equals(later)

--- a/tests/server/test_client_cleanup.py
+++ b/tests/server/test_client_cleanup.py
@@ -162,37 +162,30 @@ async def test_no_cleanup_on_another_server_disconnect(
 
 
 @pytest.mark.asyncio
-async def test_another_server_disconnect_runs_ungroup_then_stop(
+async def test_another_server_disconnect_ungroups_client(
     mock_server: _MockServer, client: SendspinClient
 ) -> None:
-    """Takeover disconnect runs ungroup before stop."""
+    """Takeover disconnect ungroups the client out of its shared group."""
     other = SendspinClient(mock_server, client_id="player-2")
     SendspinGroup(mock_server, other)
     await client.group.add_client(other)
+    shared_group = client.group
 
-    call_order: list[str] = []
+    ungroup_calls: list[str] = []
+    original_ungroup = client.ungroup
 
     async def _record_ungroup() -> None:
-        call_order.append("ungroup")
+        ungroup_calls.append("ungroup")
         await original_ungroup()
 
-    async def _record_stop(group: SendspinGroup) -> bool:
-        if client in group.clients:
-            call_order.append("stop")
-        return await original_stop(group)
-
-    original_ungroup = client.ungroup
-    original_stop = SendspinGroup.stop
     client.ungroup = _record_ungroup  # type: ignore[method-assign]
-    SendspinGroup.stop = _record_stop  # type: ignore[method-assign]
 
-    try:
-        client.detach_connection(GoodbyeReason.ANOTHER_SERVER)
-        await asyncio.sleep(0)
-    finally:
-        SendspinGroup.stop = original_stop  # type: ignore[method-assign]
+    client.detach_connection(GoodbyeReason.ANOTHER_SERVER)
+    await asyncio.sleep(0)
 
-    assert call_order == ["ungroup", "stop"]
+    assert ungroup_calls == ["ungroup"]
+    assert client.group is not shared_group
+    assert client.group.clients == [client]
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_client_multi_role.py
+++ b/tests/server/test_client_multi_role.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock
 from uuid import UUID
 
 from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
-from aiosendspin.models.types import AudioCodec, PlayerCommand
+from aiosendspin.models.types import AudioCodec, GoodbyeReason, PlayerCommand
 from aiosendspin.server.audio_transformers import TransformerPool
 from aiosendspin.server.channels import MAIN_CHANNEL
 from aiosendspin.server.client import SendspinClient
@@ -165,9 +165,29 @@ class TestClientRoles:
         assert len(roles) == 1
         assert roles[0] is client.role("player@v1")
 
+    def test_active_roles_cache_invalidated_on_hard_detach(self, mock_loop: Any) -> None:
+        """The cached active_roles tuple reflects a hard detach that clears roles."""
+        server = _DummyServer(loop=mock_loop, clock=LoopClock(mock_loop))
+        group = _DummyGroup(clients=[])
+        client = SendspinClient(server, client_id="test")
+        client._group = group  # noqa: SLF001
+        group.clients.append(client)
+
+        client.attach_connection(
+            _FakeConnection(),
+            client_info=_make_client_hello(),
+            negotiated_roles=["player@v1"],
+            active_roles=["player@v1"],
+        )
+        assert len(client.active_roles) == 1  # populate the cache
+
+        client.detach_connection(GoodbyeReason.SHUTDOWN)
+
+        assert client.active_roles == ()
+
     def test_active_roles_empty_when_no_roles(self, mock_loop: Any) -> None:
-        """active_roles returns empty list when no roles active."""
+        """active_roles returns an empty tuple when no roles active."""
         server = _DummyServer(loop=mock_loop, clock=LoopClock(mock_loop))
         client = SendspinClient(server, client_id="test")
 
-        assert client.active_roles == []
+        assert client.active_roles == ()

--- a/tests/server/test_client_state_transition.py
+++ b/tests/server/test_client_state_transition.py
@@ -1,0 +1,46 @@
+"""Tests for SendspinClient.handle_availability_change role iteration."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aiosendspin.noise.keys import Identity
+from aiosendspin.noise.trust_store import InMemoryServerPairingStore
+from aiosendspin.server import SendspinServer
+
+
+def _make_server() -> SendspinServer:
+    loop = asyncio.get_running_loop()
+    client_session = MagicMock()
+    client_session.closed = True
+    client_session.close = AsyncMock()
+    return SendspinServer(
+        loop=loop,
+        identity=Identity.generate(),
+        server_name="server",
+        client_session=client_session,
+        pairing_store=InMemoryServerPairingStore(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_availability_change_survives_role_rebuild_during_hook() -> None:
+    """A hook that rebuilds _roles mid-iteration must not raise dictionary-changed-size."""
+    server = _make_server()
+    client = server.get_or_create_client("dev")
+
+    async def _rebuild() -> None:
+        client._roles["late@v1"] = MagicMock()  # noqa: SLF001
+
+    rebuilder = MagicMock()
+    rebuilder.on_availability_changed.return_value = _rebuild()
+    second = MagicMock()
+    second.on_availability_changed.return_value = None
+    client._roles = {"a@v1": rebuilder, "b@v1": second}  # noqa: SLF001
+
+    await client.handle_availability_change(available=True)
+
+    assert "late@v1" in client._roles  # noqa: SLF001

--- a/tests/server/test_external_players.py
+++ b/tests/server/test_external_players.py
@@ -783,3 +783,29 @@ async def test_info_accessors_before_and_after_hello() -> None:
 
     assert client.info_or_none is hello
     assert client.info is hello
+
+
+@pytest.mark.asyncio
+async def test_register_external_player_cancels_pending_cleanup() -> None:
+    """Registering just after a warm disconnect disarms the pending cleanup timer."""
+    server = _make_server()
+    client = server.get_or_create_client("late-register")
+    client.attach_connection(
+        _DummyConnection(),
+        client_info=_player_hello("late-register"),
+        negotiated_roles=[Roles.PLAYER.value],
+        active_roles=[Roles.PLAYER.value],
+    )
+    client.mark_connected()
+
+    # Warm disconnect arms the delayed registry-cleanup timer.
+    client.detach_connection(goodbye_reason=None)
+    assert client._cleanup_handle is not None  # noqa: SLF001
+
+    server.register_external_player(
+        _player_hello("late-register"),
+        on_stream_start=lambda _req: None,
+    )
+
+    assert client._cleanup_handle is None  # noqa: SLF001
+    assert server.get_client("late-register") is client

--- a/tests/server/test_external_players.py
+++ b/tests/server/test_external_players.py
@@ -569,6 +569,69 @@ async def test_reclaim_timeout_full_unregisters_disconnected_client(
 
 
 @pytest.mark.asyncio
+async def test_full_unregister_skips_client_with_reconnect_in_flight() -> None:
+    """A reconnect handshake in flight keeps the client until it attaches or fails."""
+    server = _make_server()
+    server.get_or_create_client("reconnecting")
+    url = "ws://127.0.0.1:9003/sendspin"
+    server.register_client_url("reconnecting", url)
+
+    async def _never() -> None:
+        await asyncio.Event().wait()
+
+    task = asyncio.get_running_loop().create_task(_never())
+    server._connection_tasks[url] = task  # noqa: SLF001
+    try:
+        await server._full_unregister_disconnected_client("reconnecting")  # noqa: SLF001
+        assert server.get_client("reconnecting") is not None
+    finally:
+        task.cancel()
+
+
+async def _defer_unregister_with_task(server: SendspinServer, client_id: str, url: str) -> None:
+    """Register a client and defer its unregister behind an in-flight reconnect task."""
+    server.get_or_create_client(client_id)
+    server.register_client_url(client_id, url)
+    task = asyncio.get_running_loop().create_task(asyncio.Event().wait())
+    server._connection_tasks[url] = task  # noqa: SLF001
+    try:
+        await server._full_unregister_disconnected_client(client_id)  # noqa: SLF001
+        assert server.get_client(client_id) is not None
+    finally:
+        task.cancel()
+    server._connection_tasks.pop(url, None)  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_deferred_unregister_completes_when_reconnect_gives_up() -> None:
+    """A deferred unregister fires once the reconnect task ends without connecting."""
+    server = _make_server()
+    url = "ws://127.0.0.1:9004/sendspin"
+    await _defer_unregister_with_task(server, "reconnecting", url)
+
+    await server._complete_deferred_unregister(  # noqa: SLF001
+        url, connection_succeeded=False, cancelled=False
+    )
+
+    assert server.get_client("reconnecting") is None
+    assert server.get_client_url("reconnecting") is None
+
+
+@pytest.mark.asyncio
+async def test_deferred_unregister_suppressed_when_reconnect_attaches() -> None:
+    """A deferred unregister is dropped, not fired, when the reconnect established a session."""
+    server = _make_server()
+    url = "ws://127.0.0.1:9005/sendspin"
+    await _defer_unregister_with_task(server, "reconnecting", url)
+
+    await server._complete_deferred_unregister(  # noqa: SLF001
+        url, connection_succeeded=True, cancelled=False
+    )
+
+    assert server.get_client("reconnecting") is not None
+
+
+@pytest.mark.asyncio
 async def test_reclaim_timeout_refreshes_on_repeated_requests(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/server/test_group_add_client.py
+++ b/tests/server/test_group_add_client.py
@@ -1,0 +1,137 @@
+"""Tests for SendspinGroup.add_client membership and playback preservation.
+
+Adding a client must not disturb playback it should leave alone: re-adding an
+existing member is a no-op, and moving one player out of a multi-player group
+leaves the remaining players playing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+from dataclasses import dataclass
+
+import pytest
+
+from aiosendspin.models.core import ClientHelloPayload
+from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
+from aiosendspin.models.types import (
+    AudioCodec,
+    PlaybackStateType,
+    PlayerCommand,
+    Roles,
+)
+from aiosendspin.server.client import SendspinClient
+from aiosendspin.server.clock import LoopClock
+from aiosendspin.server.group import SendspinGroup
+
+
+@dataclass(slots=True)
+class _DummyServer:
+    loop: asyncio.AbstractEventLoop
+    clock: LoopClock
+    id: str = "srv"
+    name: str = "server"
+    visualizer_pitch_enabled: bool = True
+    _clients: dict[str, SendspinClient] = dataclasses.field(default_factory=dict)
+
+    def is_external_player(self, client_id: str) -> bool:  # noqa: ARG002
+        return False
+
+    def _signal_client_updated(self, client_id: str) -> None:
+        pass
+
+    def register(self, client: SendspinClient) -> None:
+        self._clients[client.client_id] = client
+
+    @property
+    def connected_clients(self) -> list[SendspinClient]:
+        return [c for c in self._clients.values() if c.is_connected]
+
+    def request_client_playback_connection(self, client_id: str) -> bool:  # noqa: ARG002
+        return False
+
+
+class _DummyConnection:
+    def __init__(self) -> None:
+        self.role_messages: list[tuple[str, object]] = []
+
+    async def disconnect(self, *, retry_connection: bool = True) -> None:  # noqa: ARG002
+        return
+
+    def send_message(self, message: object) -> None:
+        pass
+
+    def send_role_message(self, role: str, message: object) -> None:
+        self.role_messages.append((role, message))
+
+    def send_binary(self, data: bytes, **kwargs: object) -> bool:  # noqa: ARG002
+        return True
+
+
+def _hello(client_id: str) -> ClientHelloPayload:
+    return ClientHelloPayload(
+        client_id=client_id,
+        name=client_id,
+        version=1,
+        supported_roles=[Roles.PLAYER.value],
+        player_support=ClientHelloPlayerSupport(
+            supported_formats=[
+                SupportedAudioFormat(
+                    codec=AudioCodec.PCM, channels=2, sample_rate=48000, bit_depth=16
+                )
+            ],
+            buffer_capacity=100_000,
+            supported_commands=[PlayerCommand.VOLUME, PlayerCommand.MUTE],
+        ),
+    )
+
+
+def _make_player(server: _DummyServer, client_id: str) -> SendspinClient:
+    client = SendspinClient(server, client_id=client_id)
+    server.register(client)
+    SendspinGroup(server, client)
+    client.attach_connection(
+        _DummyConnection(),
+        client_info=_hello(client_id),
+        negotiated_roles=[Roles.PLAYER.value],
+        active_roles=[Roles.PLAYER.value],
+    )
+    client.mark_connected()
+    return client
+
+
+@pytest.mark.asyncio
+async def test_readding_existing_member_preserves_playback() -> None:
+    """Re-adding a client already in the group is a no-op that leaves it playing."""
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+
+    player = _make_player(server, "web")
+    group = player.group
+    group._set_playback_state(PlaybackStateType.PLAYING)  # noqa: SLF001
+
+    await group.add_client(player)
+
+    assert group.state == PlaybackStateType.PLAYING
+
+
+@pytest.mark.asyncio
+async def test_moving_one_player_leaves_other_players_playing() -> None:
+    """Moving one player out of a multi-player group keeps the remnant playing."""
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+
+    stayer = _make_player(server, "stayer")
+    mover = _make_player(server, "mover")
+    other = _make_player(server, "other")
+
+    group = stayer.group
+    await group.add_client(mover)
+    group._set_playback_state(PlaybackStateType.PLAYING)  # noqa: SLF001
+
+    await other.group.add_client(mover)
+
+    # A player (stayer) still sources audio for the old group, so it keeps playing.
+    assert mover.group is other.group
+    assert group.state == PlaybackStateType.PLAYING

--- a/tests/server/test_sendspin_client_persistence.py
+++ b/tests/server/test_sendspin_client_persistence.py
@@ -406,7 +406,7 @@ async def test_attach_with_empty_active_roles_creates_no_roles() -> None:
         negotiated_roles=[Roles.PLAYER.value],
     )
 
-    assert client.active_roles == []
+    assert client.active_roles == ()
     assert client.role("player@v1") is None
     # Capability set is retained even though no role is activated.
     assert client.negotiated_role_ids == [Roles.PLAYER.value]
@@ -432,7 +432,7 @@ async def test_set_active_roles_activates_then_deactivates() -> None:
 
     client.set_active_roles([])
     assert client.role("player@v1") is None
-    assert client.active_roles == []
+    assert client.active_roles == ()
 
 
 @pytest.mark.asyncio

--- a/tests/server/test_server_close.py
+++ b/tests/server/test_server_close.py
@@ -1,0 +1,98 @@
+"""Tests for SendspinServer.close teardown robustness."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aiosendspin.models.core import ClientHelloPayload
+from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
+from aiosendspin.models.types import AudioCodec, PlayerCommand, Roles
+from aiosendspin.noise.keys import Identity
+from aiosendspin.noise.trust_store import InMemoryServerPairingStore
+from aiosendspin.server import SendspinServer
+
+
+def _make_server() -> SendspinServer:
+    loop = asyncio.get_running_loop()
+    client_session = MagicMock()
+    client_session.closed = True
+    client_session.close = AsyncMock()
+    return SendspinServer(
+        loop=loop,
+        identity=Identity.generate(),
+        server_name="server",
+        client_session=client_session,
+        pairing_store=InMemoryServerPairingStore(),
+    )
+
+
+class _DummyConnection:
+    async def disconnect(self, *, retry_connection: bool = True) -> None:  # noqa: ARG002
+        return
+
+    def send_message(self, message: object) -> None:  # noqa: ARG002
+        return
+
+    def send_role_message(self, role: str, message: object) -> None:  # noqa: ARG002
+        return
+
+    def send_binary(self, data: bytes, **kwargs: object) -> bool:  # noqa: ARG002
+        return True
+
+
+def _player_hello(client_id: str) -> ClientHelloPayload:
+    return ClientHelloPayload(
+        client_id=client_id,
+        name=client_id,
+        version=1,
+        supported_roles=[Roles.PLAYER.value],
+        player_support=ClientHelloPlayerSupport(
+            supported_formats=[
+                SupportedAudioFormat(
+                    codec=AudioCodec.PCM, channels=2, sample_rate=48000, bit_depth=16
+                )
+            ],
+            buffer_capacity=100_000,
+            supported_commands=[PlayerCommand.VOLUME, PlayerCommand.MUTE],
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_close_tolerates_unprepared_pending_connection() -> None:
+    """A pending connection not past wsock.prepare() must not abort close()."""
+    server = _make_server()
+    conn = MagicMock()
+    conn.websocket_connection.closed = False
+    conn.websocket_connection.close = AsyncMock(side_effect=RuntimeError("Call .prepare() first"))
+    server._pending_connections.add(conn)  # noqa: SLF001
+
+    await server.close()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_close_disarms_registry_timers() -> None:
+    """close() cancels reclaim, external-registration, and per-client cleanup timers."""
+    server = _make_server()
+    server._schedule_reclaim_timeout("a", 100.0)  # noqa: SLF001
+    server._schedule_external_registration_timeout("b", 100.0)  # noqa: SLF001
+
+    client = server.get_or_create_client("c")
+    client.attach_connection(
+        _DummyConnection(),
+        client_info=_player_hello("c"),
+        negotiated_roles=[Roles.PLAYER.value],
+        active_roles=[Roles.PLAYER.value],
+    )
+    client.mark_connected()
+    client.detach_connection(goodbye_reason=None)
+    assert client._cleanup_handle is not None  # noqa: SLF001
+
+    await server.close()
+
+    assert not server._reclaim_timeouts  # noqa: SLF001
+    assert not server._external_registration_timeouts  # noqa: SLF001
+    assert client._cleanup_handle is None  # noqa: SLF001

--- a/tests/server/test_server_close.py
+++ b/tests/server/test_server_close.py
@@ -6,6 +6,7 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from aiohttp import web
 
 from aiosendspin.models.core import ClientHelloPayload
 from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
@@ -62,15 +63,19 @@ def _player_hello(client_id: str) -> ClientHelloPayload:
 
 
 @pytest.mark.asyncio
-async def test_close_tolerates_unprepared_pending_connection() -> None:
-    """A pending connection not past wsock.prepare() must not abort close()."""
+async def test_close_skips_unprepared_pending_connection() -> None:
+    """A pending connection not past wsock.prepare() is skipped, not closed."""
     server = _make_server()
     conn = MagicMock()
+    conn.websocket_connection = MagicMock(spec=web.WebSocketResponse)
     conn.websocket_connection.closed = False
-    conn.websocket_connection.close = AsyncMock(side_effect=RuntimeError("Call .prepare() first"))
+    conn.websocket_connection.prepared = False
+    conn.websocket_connection.close = AsyncMock()
     server._pending_connections.add(conn)  # noqa: SLF001
 
     await server.close()  # must not raise
+
+    conn.websocket_connection.close.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_client_audio_format.py
+++ b/tests/test_client_audio_format.py
@@ -34,6 +34,25 @@ def _player_support() -> ClientHelloPlayerSupport:
     )
 
 
+def test_client_rejects_undecodable_advertised_codec() -> None:
+    """Advertising a codec the SDK cannot decode fails fast instead of silent no-audio."""
+    support = ClientHelloPlayerSupport(
+        supported_formats=[
+            SupportedAudioFormat(
+                codec=AudioCodec.OPUS, sample_rate=48_000, bit_depth=16, channels=2
+            ),
+        ],
+        buffer_capacity=100_000,
+        supported_commands=[],
+    )
+    with pytest.raises(ValueError, match="cannot decode"):
+        make_sdk_client(
+            client_name="Test Client",
+            roles=[Roles.PLAYER],
+            player_support=support,
+        )
+
+
 @pytest.mark.asyncio
 async def test_stream_start_flac_decodes_codec_header_and_notifies_audio_callbacks() -> None:
     """Client should expose codec-aware format and decoded FLAC header in callbacks."""

--- a/tests/test_client_send_message.py
+++ b/tests/test_client_send_message.py
@@ -1,0 +1,31 @@
+"""Tests for SendspinConnection._send_message locking."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aiosendspin.client.connection import SendspinConnection
+from aiosendspin.models.types import Roles
+
+from .conftest import make_sdk_client
+
+
+@pytest.mark.asyncio
+async def test_send_message_raises_when_ws_nulled_while_awaiting_lock() -> None:
+    """Disconnecting mid-send raises RuntimeError, not AttributeError on a None ws."""
+    client = make_sdk_client(client_name="c", roles=[Roles.CONTROLLER])
+    conn = SendspinConnection(client)
+    conn._ws = MagicMock(send_str=AsyncMock())  # noqa: SLF001
+
+    await conn._send_lock.acquire()  # noqa: SLF001
+    send = asyncio.ensure_future(conn._send_message("payload"))  # noqa: SLF001
+    await asyncio.sleep(0)  # let the send block on the lock
+
+    conn._ws = None  # noqa: SLF001  # disconnect() nulls the socket
+    conn._send_lock.release()  # noqa: SLF001
+
+    with pytest.raises(RuntimeError, match="not connected"):
+        await send

--- a/tests/test_time_sync.py
+++ b/tests/test_time_sync.py
@@ -47,6 +47,18 @@ def test_count_zero_branch_seeds_offset_from_first_sample() -> None:
     assert filter_._drift == 0.0
 
 
+def test_zero_error_measurements_do_not_divide_by_zero() -> None:
+    """Repeated zero-error loopback measurements must not raise ZeroDivisionError."""
+    filter_ = SendspinTimeFilter()  # default process_std_dev=0.0
+
+    t = 1_000_000
+    for _ in range(5):
+        filter_.update(measurement=0, max_error=0, time_added=t)
+        t += 1_000_000
+
+    assert filter_.count == 5
+
+
 def test_count_one_branch_estimates_drift_from_two_point_slope() -> None:
     """Second update estimates drift from the two-point slope."""
     filter_ = SendspinTimeFilter()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,27 @@
+"""Tests for aiosendspin.util."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from aiosendspin.util import create_task
+
+
+async def test_create_task_logs_fire_and_forget_exception(
+    caplog: object,
+) -> None:
+    """A failing fire-and-forget task logs its exception instead of swallowing it."""
+
+    async def boom() -> None:
+        raise ValueError("boom")
+
+    with caplog.at_level(logging.ERROR, logger="aiosendspin.util"):  # type: ignore[attr-defined]
+        task = create_task(boom(), eager_start=False)
+        await asyncio.sleep(0)  # run the task
+        await asyncio.sleep(0)  # let the done callback fire
+
+    assert task.done()
+    logged = [r for r in caplog.records if r.name == "aiosendspin.util"]  # type: ignore[attr-defined]
+    assert logged, "expected the failing task to be logged"
+    assert logged[0].exc_info is not None


### PR DESCRIPTION
A batch of correctness, client-lifecycle, and performance fixes for the server and the Python client SDK, closing findings from a code audit made by Fable.

This PR doesn't include changes to encryption/authentication since that audit was done on a prior commit.

## Correctness

- **Skip re-broadcast when clearing already-cleared metadata.** `MetadataGroupRole.set_metadata(None)` returns early when metadata is already cleared, so no redundant `server/state` clear goes out. This matches the "only send changed fields" contract and mirrors the existing no-op guard for unchanged non-null metadata.
- **Treat paused `playback_speed` (0) as frozen in `Metadata.equals`.** A paused update no longer compares unequal on progress extrapolation, so pausing does not spuriously re-broadcast metadata.
- **Reject undecodable advertised codecs in the client SDK.** Constructing a player client raises `ValueError` when `player_support` advertises a codec the SDK cannot decode (only PCM and FLAC are supported), instead of surfacing the mismatch later as a per-stream error. The decodable set is shared with the `stream/start` handler so the two cannot drift.
- **Floor the Kalman innovation covariance in the time filter.** The update step divides by `max(offset_covariance + measurement_variance, 1e-9)`, so a zero-error loopback cannot divide by zero. Normal operation is unaffected.
- **Log fire-and-forget task exceptions.** Detached background tasks log their exceptions instead of swallowing them.

## Client lifecycle and concurrency

- **Stop only the departing client's old group in `add_client`.** Removed the blanket `old_group.stop()` that stopped the entire source group (cutting off the remaining members) whenever one client moved between groups. `ungroup()` already ends only the departing client's stream and leaves a player-backed remnant playing.
- **Drop the dead `stop()` after `ungroup()` in takeover disconnect.** After `ungroup()` the client is already in a fresh stopped solo group, so the follow-up `stop()` was a no-op.
- **Snapshot roles before awaiting state hooks.** `handle_availability_change` iterates a `list(...)` snapshot of the roles, so a hook that triggers a cold reconnect (rebuilding `_roles`) cannot raise "dictionary changed size during iteration".
- **Cancel pending cleanup when preinitializing a disconnected client.** Preinitialization disarms any pending registry-cleanup timer (via a shared `_cancel_cleanup` helper) so a just-registered client is not removed out from under itself.
- **Defer client unregister to the end of an in-flight reconnect.** The reclaim and external-registration timeouts defer removal while a connection task for the client's URL is still running, so an in-progress reconnect is not torn down. The deferred removal completes when the task gives up without ever connecting, so a client whose reconnect ultimately fails is not left registered forever. A successful reconnect or a shutdown cancellation drops the deferral instead.
- **Re-check `_ws` under the send lock in the client SDK.** The connected check moved inside the send lock, closing the window where `disconnect()` nulls the socket while a sender awaits the lock (previously an `AttributeError`, now a clean `RuntimeError`).
- **Harden server close against unprepared sockets and armed timers.** Closing a not-yet-prepared pending websocket is tolerated, and all registry timers (external-registration, reclaim, per-client cleanup) are disarmed after disconnect so none fire on a torn-down server.

## Performance

- **Pack each audio frame once per chunk instead of per subscriber.** The binary `AUDIO_CHUNK` frame is built once on the shared `AudioChunk` (memoized) and reused across all subscribing player roles.
- **Use a deque for the role chunk cache.** Late-join catch-up pruning runs on every commit. Backing the cache with a deque makes pruning O(1) per chunk (`popleft`) instead of re-copying the surviving window on each prune.
- **Cache `active_roles` as a tuple**, rebuilt only when the role set changes, instead of allocating a new list on every access.
- **Slice transformer input frames via `memoryview`** to avoid a redundant bytearray copy per encoded chunk.
- **Extend resampler output from a `memoryview`** to drop one intermediate copy per resampled frame.
- **Correct the encoding docstring.** Transform encoding runs sequentially on the event loop (yielding periodically), not on a thread pool. Doc-only.
