### PR TITLE
Encryption follow-up fixes

### DIFF
--- a/aiosendspin/client/client.py
+++ b/aiosendspin/client/client.py
@@ -493,6 +493,10 @@ class SendspinClient:
             self._provisional_connections.discard(connection)
             logger.debug("Incoming connection failed bring-up: %s", exc)
             return
+        except BaseException:
+            # Failures outside the expected set may leave the transport half-open.
+            await connection.disconnect()
+            raise
         finally:
             self._provisional_connections.discard(connection)
 

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -55,6 +55,7 @@ from aiosendspin.models.management import (
 )
 from aiosendspin.models.player import PlayerStatePayload, StreamStartPlayer
 from aiosendspin.models.types import (
+    CLOSING_ABORT_REASONS,
     Activity,
     AudioCodec,
     GoodbyeReason,
@@ -138,12 +139,6 @@ UNSYNCED_PLAY_LEAD_US: int = 500_000
 
 # PIN-pairing method families, subject to lockout and the locked_out descriptor.
 _PIN_METHODS: list[PairMethod] = [PairMethod.DYNAMIC_PIN, PairMethod.STATIC_PIN]
-
-# Abort reasons that close the connection; every other reason keeps it open.
-_CLOSING_ABORT_REASONS: list[PairAbortReason] = [
-    PairAbortReason.CONCURRENT_ATTEMPT,
-    PairAbortReason.METHOD_NOT_SUPPORTED,
-]
 
 # psk_id of the Sentinel PSK — the client matches it during PIN pairing / discovery.
 _SENTINEL_PSK_ID: str = psk_id_for(SENTINEL_PSK)
@@ -493,7 +488,7 @@ class SendspinConnection:
                     leftover = await self._run_pairing_protocol()
                     activate = await self._resolve_pairing_activate(leftover)
             except PairingAbortError as err:
-                if err.reason in _CLOSING_ABORT_REASONS:
+                if err.reason in CLOSING_ABORT_REASONS:
                     await self.disconnect()
                 else:
                     logger.info(

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -1184,12 +1184,11 @@ class SendspinConnection:
             case ManagementAddRecordMessage(payload=request):
                 payload, effect = await handle_add_record(store, request)
             case ManagementRemoveRecordMessage(payload=request):
+                assert self._noise_psk is not None
                 payload, effect = await handle_remove_record(
                     store,
                     request,
-                    requester_psk_id=(
-                        self._noise_psk.psk_id if self._noise_psk is not None else None
-                    ),
+                    requester_psk_id=self._noise_psk.psk_id,
                 )
             case ManagementGetPairingConfigMessage():
                 payload, effect = await handle_get_pairing_config(

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -499,7 +499,7 @@ class SendspinConnection:
         if (reason := await self._apply_activation(activate)) is not None:
             await self._goodbye_and_disconnect(reason)
             return
-        self._time_task = self._client.loop.create_task(self._time_sync_loop())
+        self._resume_time_sync()
         await self._send_full_client_state()
 
     async def _run_pairing_protocol(self) -> str | None:
@@ -1001,6 +1001,7 @@ class SendspinConnection:
         if self.is_pairing:
             await self._pair()
             return
+        self._resume_time_sync()
         if resync or not was_player_active:
             await self._send_full_client_state()
 
@@ -1010,6 +1011,11 @@ class SendspinConnection:
             with suppress(asyncio.CancelledError):
                 await self._time_task
             self._time_task = None
+
+    def _resume_time_sync(self) -> None:
+        """Restart the time-sync loop if it is not running."""
+        if self._time_task is None or self._time_task.done():
+            self._time_task = self._client.loop.create_task(self._time_sync_loop())
 
     def _handle_server_time(self, payload: ServerTimePayload) -> None:
         now_us = self.now_us()

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -1151,7 +1151,11 @@ class SendspinConnection:
                 payload, effect = await handle_add_record(store, request)
             case ManagementRemoveRecordMessage(payload=request):
                 payload, effect = await handle_remove_record(
-                    store, request, requester_server_id=self._server_id
+                    store,
+                    request,
+                    requester_psk_id=(
+                        self._noise_psk.psk_id if self._noise_psk is not None else None
+                    ),
                 )
             case ManagementGetPairingConfigMessage():
                 payload, effect = await handle_get_pairing_config(

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -499,6 +499,10 @@ class SendspinConnection:
         if (reason := await self._apply_activation(activate)) is not None:
             await self._goodbye_and_disconnect(reason)
             return
+        if self.is_pairing:
+            # The leave activate redeclared pairing: it admits the next attempt.
+            await self._pair()
+            return
         self._resume_time_sync()
         await self._send_full_client_state()
 

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -86,7 +86,6 @@ from aiosendspin.noise.models import (
 )
 from aiosendspin.noise.pairing import (
     PairingAbortError,
-    PairingError,
     abort_pairing,
     receive_pairing_abort,
     run_dynamic_pin_client,
@@ -505,11 +504,11 @@ class SendspinConnection:
             await self._send_full_client_state()
             return
 
-    async def _run_pairing_protocol(self) -> str | ServerActivatePayload | None:
+    async def _run_pairing_protocol(self) -> str | None:
         """Run the server-selected method's exchange.
 
         Returns ``None`` on finalize, else the raw ``server/activate`` leave frame
-        (already parsed when the pairing window closed before an attempt started).
+        (from the method run, or from the pairing window closing before an attempt).
         """
         assert self._ws is not None
         assert self._server_id is not None
@@ -564,13 +563,13 @@ class SendspinConnection:
         finally:
             self._pairing_attempt_in_progress = False
 
-    async def _await_pairing_window(self) -> ServerActivatePayload | None:
+    async def _await_pairing_window(self) -> str | None:
         """Wait for the operator gesture without leaving the socket unread.
 
-        Returns the payload of a ``server/activate`` that leaves pairing before an
-        attempt started, else ``None`` once the gesture arrives. Anything else
-        received during the wait - the ``pair/abort`` withdrawing the attempt, an
-        unexpected frame, or a close - raises out of the pending receive.
+        Returns the raw ``server/activate`` frame if the server leaves pairing before
+        an attempt started, else ``None`` once the gesture arrives.
+        Anything else received during the wait - the ``pair/abort`` withdrawing the
+        attempt, an unexpected frame, or a close - raises out of the pending receive.
         """
         assert self._client.pairing_window is not None  # offered only when set
         assert self._ws is not None
@@ -588,23 +587,11 @@ class SendspinConnection:
         if window in done:
             await window
         if receive in done:
-            frame = await receive
-            message = ServerMessage.from_json(frame)
-            if not isinstance(message, ServerActivateMessage):
-                raise PairingError(
-                    f"unexpected frame awaiting the pairing gesture: {type(message).__name__}"
-                )
-            logger.info("Server %s ended the pairing window before an attempt", self._server_id)
-            return message.payload
+            return await receive
         return None
 
-    async def _resolve_pairing_activate(
-        self, leftover: str | ServerActivatePayload | None
-    ) -> ServerActivatePayload:
+    async def _resolve_pairing_activate(self, leftover: str | None) -> ServerActivatePayload:
         """Resolve the server/activate that ends pairing, re-handshaking first if it finalized."""
-        if isinstance(leftover, ServerActivatePayload):
-            # The window closed before an attempt: the leave activate is already parsed.
-            return leftover
         method = self._selected_pair_method
         assert method is not None
         async with asyncio.timeout(POST_PAIRING_ACTIVATE_TIMEOUT_S):
@@ -613,12 +600,12 @@ class SendspinConnection:
                 logger.info("Paired with server %s via %s", self._server_id, method.value)
                 await self._rehandshake()
                 return await self._exchange_hellos()
-            # Server left pairing without finalizing: apply the server/activate it should have sent.
-            logger.info("Verified pairing with server %s via %s", self._server_id, method.value)
+            # Server left pairing without finalizing: apply the leave server/activate.
+            logger.info("Server %s left pairing without finalizing", self._server_id)
             message = ServerMessage.from_json(leftover)
             if not isinstance(message, ServerActivateMessage):
                 raise RuntimeError(  # noqa: TRY004 - protocol violation, not a type error
-                    f"Expected server/activate after pair-finalize, got {type(message).__name__}"
+                    f"Expected server/activate ending pairing, got {type(message).__name__}"
                 )
             return message.payload
 

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -487,25 +487,28 @@ class SendspinConnection:
     async def _pair(self) -> None:
         """Run one pairing attempt; on a non-closing abort stay in pairing for a retry."""
         await self._pause_time_sync()
-        try:
-            async with self._exchange():
-                leftover = await self._run_pairing_protocol()
-                activate = await self._resolve_pairing_activate(leftover)
-        except PairingAbortError as err:
-            if err.reason in _CLOSING_ABORT_REASONS:
-                await self.disconnect()
-            else:
-                logger.info("Pairing attempt with %s ended: %s", self._server_id, err.reason.value)
+        while True:
+            try:
+                async with self._exchange():
+                    leftover = await self._run_pairing_protocol()
+                    activate = await self._resolve_pairing_activate(leftover)
+            except PairingAbortError as err:
+                if err.reason in _CLOSING_ABORT_REASONS:
+                    await self.disconnect()
+                else:
+                    logger.info(
+                        "Pairing attempt with %s ended: %s", self._server_id, err.reason.value
+                    )
+                return
+            if (reason := await self._apply_activation(activate)) is not None:
+                await self._goodbye_and_disconnect(reason)
+                return
+            if self.is_pairing:
+                # The leave activate redeclared pairing: it admits the next attempt.
+                continue
+            self._resume_time_sync()
+            await self._send_full_client_state()
             return
-        if (reason := await self._apply_activation(activate)) is not None:
-            await self._goodbye_and_disconnect(reason)
-            return
-        if self.is_pairing:
-            # The leave activate redeclared pairing: it admits the next attempt.
-            await self._pair()
-            return
-        self._resume_time_sync()
-        await self._send_full_client_state()
 
     async def _run_pairing_protocol(self) -> str | ServerActivatePayload | None:
         """Run the server-selected method's exchange.

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -701,14 +701,16 @@ class SendspinConnection:
         message = ClientGoodbyeMessage(
             payload=ClientGoodbyePayload(reason=reason),
         )
-        await self._send_message(message.to_json())
+        # A goodbye precedes disconnect, so it must reach the wire even mid-exchange.
+        await self._send_message(message.to_json(), force=True)
 
     async def send_pair_abort(self, reason: PairAbortReason) -> None:
         """Send a pair/abort to the server (for a pairing connection lost to arbitration)."""
         if not self.connected:
             return
         message = PairAbortMessage(payload=PairAbortPayload(reason=reason))
-        await self._send_message(message.to_json())
+        # A displaced connection's own exchange flag is still set; send regardless (spec).
+        await self._send_message(message.to_json(), force=True)
 
     @property
     def is_pairing(self) -> bool:
@@ -865,12 +867,13 @@ class SendspinConnection:
         message = ClientTimeMessage(payload=ClientTimePayload(client_transmitted=now_us))
         await self._send_message(message.to_json())
 
-    async def _send_message(self, payload: str) -> None:
+    async def _send_message(self, payload: str, *, force: bool = False) -> None:
+        """Send a JSON frame; ``force`` bypasses the in-band-exchange suppression."""
         async with self._send_lock:
             # Re-check under the lock: disconnect() can null _ws while we await it.
             if self._ws is None:
                 raise RuntimeError("WebSocket is not connected")
-            if self._exchange_in_progress:
+            if self._exchange_in_progress and not force:
                 return
             await self._ws.send_str(payload)
 

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -85,6 +85,7 @@ from aiosendspin.noise.models import (
 )
 from aiosendspin.noise.pairing import (
     PairingAbortError,
+    PairingError,
     abort_pairing,
     receive_pairing_abort,
     run_dynamic_pin_client,
@@ -506,10 +507,11 @@ class SendspinConnection:
         self._resume_time_sync()
         await self._send_full_client_state()
 
-    async def _run_pairing_protocol(self) -> str | None:
+    async def _run_pairing_protocol(self) -> str | ServerActivatePayload | None:
         """Run the server-selected method's exchange.
 
-        Returns ``None`` on finalize, else the raw ``server/activate`` leave frame.
+        Returns ``None`` on finalize, else the raw ``server/activate`` leave frame
+        (already parsed when the pairing window closed before an attempt started).
         """
         assert self._ws is not None
         assert self._server_id is not None
@@ -530,7 +532,8 @@ class SendspinConnection:
         if method is PairMethod.STATIC_PIN:
             static_pin = await store.static_pin()
             assert static_pin is not None  # offered only when configured
-            await self._await_pairing_window()
+            if (leave := await self._await_pairing_window()) is not None:
+                return leave
             with self._attempt_in_progress():
                 return await run_static_pin_client(
                     self._ws,
@@ -563,11 +566,13 @@ class SendspinConnection:
         finally:
             self._pairing_attempt_in_progress = False
 
-    async def _await_pairing_window(self) -> None:
+    async def _await_pairing_window(self) -> ServerActivatePayload | None:
         """Wait for the operator gesture without leaving the socket unread.
 
-        Anything received during the wait - the ``pair/abort`` withdrawing the
-        attempt, an unexpected frame, or a close - raises out of the pending receive.
+        Returns the payload of a ``server/activate`` that leaves pairing before an
+        attempt started, else ``None`` once the gesture arrives. Anything else
+        received during the wait - the ``pair/abort`` withdrawing the attempt, an
+        unexpected frame, or a close - raises out of the pending receive.
         """
         assert self._client.pairing_window is not None  # offered only when set
         assert self._ws is not None
@@ -585,10 +590,23 @@ class SendspinConnection:
         if window in done:
             await window
         if receive in done:
-            await receive
+            frame = await receive
+            message = ServerMessage.from_json(frame)
+            if not isinstance(message, ServerActivateMessage):
+                raise PairingError(
+                    f"unexpected frame awaiting the pairing gesture: {type(message).__name__}"
+                )
+            logger.info("Server %s ended the pairing window before an attempt", self._server_id)
+            return message.payload
+        return None
 
-    async def _resolve_pairing_activate(self, leftover: str | None) -> ServerActivatePayload:
+    async def _resolve_pairing_activate(
+        self, leftover: str | ServerActivatePayload | None
+    ) -> ServerActivatePayload:
         """Resolve the server/activate that ends pairing, re-handshaking first if it finalized."""
+        if isinstance(leftover, ServerActivatePayload):
+            # The window closed before an attempt: the leave activate is already parsed.
+            return leftover
         method = self._selected_pair_method
         assert method is not None
         async with asyncio.timeout(POST_PAIRING_ACTIVATE_TIMEOUT_S):

--- a/aiosendspin/client/management.py
+++ b/aiosendspin/client/management.py
@@ -111,7 +111,7 @@ async def handle_remove_record(
     store: ClientPairingStore,
     payload: ManagementRemoveRecordPayload,
     *,
-    requester_server_id: str | None,
+    requester_psk_id: str | None,
 ) -> tuple[ManagementResultPayload, ManagementEffect]:
     """Remove a record; removing one's own record closes the session."""
     record = await store.record_by_psk_id(payload.psk_id)
@@ -121,7 +121,7 @@ async def handle_remove_record(
         return _result(ManagementResult.INVALID), ManagementEffect.NONE
     effect = (
         ManagementEffect.GOODBYE_UNAUTHORIZED
-        if _is_self(record, requester_server_id)
+        if record.psk_id == requester_psk_id
         else ManagementEffect.NONE
     )
     await store.remove_record(payload.psk_id)
@@ -323,8 +323,3 @@ def _merge_enabled(
     if cfg is None or cfg.enabled is None:
         return current
     return cfg.enabled
-
-
-def _is_self(record: ClientPairingRecord, requester_server_id: str | None) -> bool:
-    """Return whether ``record`` is the requesting server's own stored-pubkey record."""
-    return record.server_id is not None and record.server_id == requester_server_id

--- a/aiosendspin/models/management.py
+++ b/aiosendspin/models/management.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 from mashumaro.config import BaseConfig
@@ -18,17 +18,29 @@ from .types import (
 
 # Server -> Client: server/unpair
 @dataclass
+class ServerUnpairPayload(DataClassORJSONMixin):
+    """Empty ``server/unpair`` payload."""
+
+
+@dataclass
 class ServerUnpairMessage(ServerMessage):
     """Tells the client to drop this server's pairing record and close (no payload fields)."""
 
+    payload: ServerUnpairPayload = field(default_factory=ServerUnpairPayload)
     type: Literal["server/unpair"] = "server/unpair"
 
 
 # Server -> Client: management/list-records
 @dataclass
+class ManagementListRecordsPayload(DataClassORJSONMixin):
+    """Empty ``management/list-records`` payload."""
+
+
+@dataclass
 class ManagementListRecordsMessage(ServerMessage):
     """Requests the client's pairing records (no payload fields)."""
 
+    payload: ManagementListRecordsPayload = field(default_factory=ManagementListRecordsPayload)
     type: Literal["management/list-records"] = "management/list-records"
 
 
@@ -83,9 +95,17 @@ class RecordModeConfig(DataClassORJSONMixin):
 
 # Server -> Client: management/get-pairing-config
 @dataclass
+class ManagementGetPairingConfigPayload(DataClassORJSONMixin):
+    """Empty ``management/get-pairing-config`` payload."""
+
+
+@dataclass
 class ManagementGetPairingConfigMessage(ServerMessage):
     """Requests the client's pairing configuration (no payload fields)."""
 
+    payload: ManagementGetPairingConfigPayload = field(
+        default_factory=ManagementGetPairingConfigPayload
+    )
     type: Literal["management/get-pairing-config"] = "management/get-pairing-config"
 
 

--- a/aiosendspin/models/types.py
+++ b/aiosendspin/models/types.py
@@ -255,6 +255,12 @@ class PairAbortReason(Enum):
     USER_CANCELLED = "user_cancelled"
 
 
+# The sender closes the connection after these abort reasons; every other reason keeps it open.
+CLOSING_ABORT_REASONS: frozenset[PairAbortReason] = frozenset(
+    {PairAbortReason.CONCURRENT_ATTEMPT, PairAbortReason.METHOD_NOT_SUPPORTED}
+)
+
+
 class ManagementResult(Enum):
     """Result code carried by management/result."""
 

--- a/aiosendspin/noise/pairing.py
+++ b/aiosendspin/noise/pairing.py
@@ -411,6 +411,8 @@ async def run_static_pin_server(
         await _receive_pair_init(ws, pairing_index)
     async with asyncio.timeout(_SERVER_ATTEMPT_TIMEOUT_S):
         pin = await pin_provider()
+        if not pin_mod.is_valid_static_pin(pin):
+            raise PairingError("static PIN must be exactly 8 decimal digits")
         try:
             cpace = CPace.start(
                 role=CPaceRole.INITIATOR, prs=pin.encode("ascii"), sid=sid, ad=_PAKE_AD_SERVER

--- a/aiosendspin/noise/pairing.py
+++ b/aiosendspin/noise/pairing.py
@@ -190,7 +190,8 @@ async def run_dynamic_pin_client(
             init = await _receive_pairing(ws, ServerPairInitMessage)
             nonce_a = _decode_field(init.payload.nonce_A, "nonce_A", expect_len=pin_mod.NONCE_SIZE)
             pin_length = init.payload.pin_length
-            min_length = (await store.get_pairing_config()).dynamic_pin_min_length
+            configured_min = (await store.get_pairing_config()).dynamic_pin_min_length
+            min_length = max(configured_min, pin_mod.MIN_PIN_DIGITS)
             if not min_length <= pin_length <= pin_mod.MAX_PIN_DIGITS:
                 await abort_pairing(ws, PairAbortReason.PIN_LENGTH_UNACCEPTABLE)
             pin = pin_mod.derive_pin(handshake_hash, nonce_a, nonce_b, pin_length)

--- a/aiosendspin/noise/pairing.py
+++ b/aiosendspin/noise/pairing.py
@@ -578,9 +578,16 @@ async def _receive_pairing[T: PairingMessage](ws: EncryptedWebSocket, expected: 
     return message
 
 
-async def receive_pairing_abort(ws: EncryptedWebSocket) -> NoReturn:
-    """Receive the ``pair/abort`` ending an unstarted attempt; every outcome raises."""
-    await _receive_pairing(ws, PairAbortMessage)
+async def receive_pairing_abort(ws: EncryptedWebSocket) -> str:
+    """Await the ``pair/abort`` ending an unstarted attempt.
+
+    A ``pair/abort`` (or close, or another pairing frame) raises. A non-pairing
+    JSON frame, such as the ``server/activate`` leaving pairing, is returned raw
+    for the caller to interpret.
+    """
+    frame = await _receive_pairing_frame(ws, PairAbortMessage)
+    if isinstance(frame, str):
+        return frame
     raise AssertionError("unreachable: receiving pair/abort raises")
 
 

--- a/aiosendspin/noise/pairing.py
+++ b/aiosendspin/noise/pairing.py
@@ -586,9 +586,8 @@ async def receive_pairing_abort(ws: EncryptedWebSocket) -> str:
     for the caller to interpret.
     """
     frame = await _receive_pairing_frame(ws, PairAbortMessage)
-    if isinstance(frame, str):
-        return frame
-    raise AssertionError("unreachable: receiving pair/abort raises")
+    assert isinstance(frame, str)
+    return frame
 
 
 async def _receive_pair_init(ws: EncryptedWebSocket, pairing_index: int) -> ClientPairInitMessage:

--- a/aiosendspin/noise/pin.py
+++ b/aiosendspin/noise/pin.py
@@ -14,6 +14,12 @@ COMMIT_SIZE: Final[int] = 32
 MIN_PIN_DIGITS: Final[int] = 4
 MAX_PIN_DIGITS: Final[int] = 12
 DEFAULT_MIN_PIN_DIGITS: Final[int] = 6
+STATIC_PIN_DIGITS: Final[int] = 8
+
+
+def is_valid_static_pin(pin: str) -> bool:
+    """Return whether ``pin`` is exactly 8 ASCII decimal digits (the static-PIN format)."""
+    return len(pin) == STATIC_PIN_DIGITS and pin.isascii() and pin.isdigit()
 
 
 def generate_nonce() -> bytes:

--- a/aiosendspin/noise/trust_store.py
+++ b/aiosendspin/noise/trust_store.py
@@ -21,7 +21,7 @@ from .keys import (
     generate_psk,
     psk_id_for,
 )
-from .pin import DEFAULT_MIN_PIN_DIGITS
+from .pin import DEFAULT_MIN_PIN_DIGITS, is_valid_static_pin
 
 # A PIN-pairing method enters terminal lockout when its failure counter reaches
 # this value.
@@ -676,6 +676,8 @@ class _ClientPairingStoreBase(ClientPairingStore):
 
     async def set_static_pin(self, pin: str) -> None:
         """Set the configured static PIN, replacing any existing one."""
+        if not is_valid_static_pin(pin):
+            raise ValueError("static PIN must be exactly 8 decimal digits")
         self._static_pin = pin
         await self._save()
 

--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -550,6 +550,15 @@ class SendspinClient:
 
         self._rebuild_binary_handling_cache()
 
+    def refresh_identity_from_hello(
+        self, client_info: ClientHelloPayload, *, negotiated_roles: list[str]
+    ) -> None:
+        """Apply a hello re-sent over the existing connection (post re-handshake)."""
+        previous_info = self._info
+        self._set_identity_from_hello(client_info, negotiated_roles=negotiated_roles)
+        if previous_info is not None and previous_info != client_info:
+            self._server._signal_client_updated(self._client_id)  # noqa: SLF001
+
     def preload_hello(self, client_info: ClientHelloPayload) -> None:
         """Seed persistent client identity/capabilities without an active connection."""
         self._set_identity_from_hello(client_info)

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -935,6 +935,11 @@ class SendspinConnection:
             self._client = client
             if self._url is not None:
                 self._server.register_client_url(client_id, self._url)
+        else:
+            # Hello re-sent over the same connection after an in-band re-handshake.
+            self._client.refresh_identity_from_hello(
+                client_info, negotiated_roles=self._negotiated_roles
+            )
         return True
 
     async def _admit_legacy_client_id(self, client_id: str) -> bool:

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -102,6 +102,7 @@ from aiosendspin.noise.driver import (
 from aiosendspin.noise.keys import b64url_encode, psk_id_for
 from aiosendspin.noise.pairing import (
     LocalPairingAbortError,
+    PairingAbortError,
     PairingAttempt,
     PairingError,
     abort_pairing,
@@ -846,8 +847,18 @@ class SendspinConnection:
                 return False
             if self._is_pairing():
                 assert isinstance(transport, EncryptedWebSocket)
-                if not await self._pair(transport):
-                    return False
+                try:
+                    if not await self._pair(transport):
+                        return False
+                except PairingAbortError as exc:
+                    if exc.reason in (
+                        PairAbortReason.CONCURRENT_ATTEMPT,
+                        PairAbortReason.METHOD_NOT_SUPPORTED,
+                    ):
+                        raise
+                    # Non-closing abort reason: the connection stays open for a retry.
+                    self._logger.debug("Initial-connect pairing aborted: %s", exc)
+                    self._pairing_attempt = None
             await self._activate()
 
         if self.requires_initial_state():

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -858,7 +858,12 @@ class SendspinConnection:
 
     async def _ingest_client_hello(self, text: str) -> bool:
         """Validate and record the client/hello, attaching the client; False if rejected."""
-        message = self._deserialize_client_message(text)
+        try:
+            message = self._deserialize_client_message(text)
+        except (LookupError, TypeError, ValueError) as exc:
+            self._logger.error("Malformed client/hello: %s", exc)
+            await self.disconnect(retry_connection=False)
+            return False
         if not isinstance(message, ClientHelloMessage):
             self._logger.error("Expected client/hello, got %s", type(message).__name__)
             await self.disconnect(retry_connection=False)

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -539,6 +539,11 @@ class SendspinConnection:
             self._initial_state_timeout_handle.cancel()
             self._initial_state_timeout_handle = None
 
+        if self._pairing_task and not self._pairing_task.done():
+            # Ends like end_pairing: the attempt aborts instead of waiting out its timeout.
+            self._pairing_task.cancel()
+            with suppress(PairingError, OSError, asyncio.CancelledError):
+                await self._pairing_task
         if self._writer_task and not self._writer_task.done():
             self._writer_task.cancel()
             with suppress(asyncio.CancelledError):

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -823,6 +823,13 @@ class SendspinConnection:
                 if self._url is not None
                 else ConnectionReason.DISCOVERY
             )
+            if connection_reason not in (ConnectionReason.DISCOVERY, ConnectionReason.PLAYBACK):
+                # Legacy clients parse the enum strictly and predate the other reasons.
+                self._logger.debug(
+                    "Clamping connection_reason %s to discovery for a legacy client",
+                    connection_reason.value,
+                )
+                connection_reason = ConnectionReason.DISCOVERY
             await transport.send_str(
                 LegacyServerHelloMessage(
                     payload=LegacyServerHelloPayload(

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -80,6 +80,7 @@ from aiosendspin.models.management import (
     StorageAccounting,
 )
 from aiosendspin.models.types import (
+    CLOSING_ABORT_REASONS,
     Activity,
     ClientMessage,
     ConnectionReason,
@@ -851,10 +852,7 @@ class SendspinConnection:
                     if not await self._pair(transport):
                         return False
                 except PairingAbortError as exc:
-                    if exc.reason in (
-                        PairAbortReason.CONCURRENT_ATTEMPT,
-                        PairAbortReason.METHOD_NOT_SUPPORTED,
-                    ):
+                    if exc.reason in CLOSING_ABORT_REASONS:
                         raise
                     # Non-closing abort reason: the connection stays open for a retry.
                     self._logger.debug("Initial-connect pairing aborted: %s", exc)

--- a/aiosendspin/server/server.py
+++ b/aiosendspin/server/server.py
@@ -162,6 +162,8 @@ class SendspinServer:
         self._initial_connect_succeeded: set[str] = set()
         self._connection_options: dict[str, _ServerInitiatedConnectionOptions] = {}
         self._connection_reasons: dict[str, ConnectionReason] = {}  # url → reason
+        # Pairing intents handed to an already-running dial task, consumed on its next dial.
+        self._pending_pairing_attempts: dict[str, PairingAttempt] = {}
         self._client_urls: dict[str, str] = {}  # client_id → url
         self._external_stream_start_cbs: dict[str, ExternalStreamStartCallback] = {}
         self._external_registration_timeouts: dict[str, asyncio.Handle] = {}
@@ -411,7 +413,8 @@ class SendspinServer:
         from a configured hostname/IP, port, and path, then pass
         retry_initial_connection=True and retry_indefinitely=True.
 
-        ``pairing_attempt`` carries an operator-initiated pairing intent for this dial.
+        ``pairing_attempt`` carries an operator-initiated pairing intent for this dial;
+        when a dial task already exists it is queued for that task's next dial.
         """
         self._set_connection_options(
             url,
@@ -421,6 +424,8 @@ class SendspinServer:
         self._connection_reasons[url] = connection_reason
         prev_task = self._connection_tasks.get(url)
         if prev_task is not None:
+            if pairing_attempt is not None:
+                self._pending_pairing_attempts[url] = pairing_attempt
             if retry_event := self._retry_events.get(url):
                 retry_event.set()
             return
@@ -464,6 +469,8 @@ class SendspinServer:
 
         prev_task = self._connection_tasks.get(url)
         if prev_task is not None:
+            if pairing_attempt is not None:
+                self._pending_pairing_attempts[url] = pairing_attempt
             if retry_event := self._retry_events.get(url):
                 retry_event.set()
         else:
@@ -756,6 +763,8 @@ class SendspinServer:
                             self._initial_connect_succeeded.add(url)
                             self._resolve_initial_connect_waiters(url)
                         connection_started_s = time.monotonic()
+                        if pairing_attempt is None:
+                            pairing_attempt = self._pending_pairing_attempts.pop(url, None)
                         conn = SendspinConnection(
                             self,
                             wsock_client=wsock,
@@ -840,6 +849,7 @@ class SendspinServer:
         finally:
             self._connection_tasks.pop(url, None)
             self._retry_events.pop(url, None)
+            self._pending_pairing_attempts.pop(url, None)
             self._initial_connect_succeeded.discard(url)
             self._connection_options.pop(url, None)
             self._connection_reasons.pop(url, None)

--- a/tests/client/test_attach_bringup.py
+++ b/tests/client/test_attach_bringup.py
@@ -1,0 +1,43 @@
+"""Bring-up failure handling for incoming (server-initiated) connections."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from aiosendspin.client.connection import SendspinConnection
+from aiosendspin.models.types import Roles
+from tests.conftest import make_sdk_client
+
+if TYPE_CHECKING:
+    from aiohttp import web
+
+
+async def test_attach_websocket_unexpected_failure_disconnects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bring-up failure outside the expected set tears the connection down and propagates."""
+    sdk = make_sdk_client(client_name="c", roles=[Roles.CONTROLLER])
+    disconnects: list[SendspinConnection] = []
+
+    async def boom(
+        self: SendspinConnection,  # noqa: ARG001
+        ws: web.WebSocketResponse,  # noqa: ARG001
+        *,
+        expected_server_id: str | None = None,  # noqa: ARG001
+    ) -> None:
+        raise UnicodeDecodeError("utf-8", b"x", 0, 1, "bad")
+
+    async def record_disconnect(self: SendspinConnection) -> None:
+        disconnects.append(self)
+
+    monkeypatch.setattr(SendspinConnection, "attach_websocket", boom)
+    monkeypatch.setattr(SendspinConnection, "disconnect", record_disconnect)
+
+    with pytest.raises(UnicodeDecodeError):
+        await sdk.attach_websocket(MagicMock())
+
+    assert len(disconnects) == 1
+    assert not sdk._provisional_connections  # noqa: SLF001

--- a/tests/client/test_management.py
+++ b/tests/client/test_management.py
@@ -130,7 +130,7 @@ async def test_remove_record_ok() -> None:
     payload, effect = await handle_remove_record(
         store,
         ManagementRemoveRecordPayload(psk_id=record.psk_id),
-        requester_server_id=SERVER_ID,
+        requester_psk_id="other-psk",
     )
     assert payload.result is ManagementResult.OK
     assert effect is ManagementEffect.NONE
@@ -143,7 +143,7 @@ async def test_remove_record_not_found() -> None:
     payload, _ = await handle_remove_record(
         store,
         ManagementRemoveRecordPayload(psk_id="missing"),
-        requester_server_id=SERVER_ID,
+        requester_psk_id="other-psk",
     )
     assert payload.result is ManagementResult.NOT_FOUND
 
@@ -156,7 +156,7 @@ async def test_remove_record_referenced_by_record_mode_is_invalid() -> None:
     payload, _ = await handle_remove_record(
         store,
         ManagementRemoveRecordPayload(psk_id=shared.psk_id),
-        requester_server_id=SERVER_ID,
+        requester_psk_id="other-psk",
     )
     assert payload.result is ManagementResult.INVALID
     assert await store.record_by_psk_id(shared.psk_id) is not None
@@ -169,10 +169,37 @@ async def test_remove_record_self_closes_session() -> None:
     payload, effect = await handle_remove_record(
         store,
         ManagementRemoveRecordPayload(psk_id=record.psk_id),
-        requester_server_id=SERVER_ID,
+        requester_psk_id=record.psk_id,
     )
     assert payload.result is ManagementResult.OK
     assert effect is ManagementEffect.GOODBYE_UNAUTHORIZED
+
+
+async def test_remove_shared_record_backing_session_closes_session() -> None:
+    """Removing the shared-PSK record that admitted the session also closes it."""
+    store = InMemoryClientPairingStore()
+    shared = await _seed_record(store, server_id=None)
+    payload, effect = await handle_remove_record(
+        store,
+        ManagementRemoveRecordPayload(psk_id=shared.psk_id),
+        requester_psk_id=shared.psk_id,
+    )
+    assert payload.result is ManagementResult.OK
+    assert effect is ManagementEffect.GOODBYE_UNAUTHORIZED
+
+
+async def test_remove_other_record_same_server_id_keeps_session() -> None:
+    """Removing a different record naming the requester's server does not close the session."""
+    store = InMemoryClientPairingStore()
+    mine = await _seed_record(store, server_id=SERVER_ID)
+    duplicate = await _seed_record(store, server_id=SERVER_ID)
+    payload, effect = await handle_remove_record(
+        store,
+        ManagementRemoveRecordPayload(psk_id=duplicate.psk_id),
+        requester_psk_id=mine.psk_id,
+    )
+    assert payload.result is ManagementResult.OK
+    assert effect is ManagementEffect.NONE
 
 
 # --- server/unpair ------------------------------------------------------------

--- a/tests/integration/test_noise_pairing_flow.py
+++ b/tests/integration/test_noise_pairing_flow.py
@@ -491,6 +491,46 @@ async def test_live_pairing_dynamic_pin() -> None:
             await client.disconnect()
 
 
+async def test_live_pairing_updates_connection_security_trust() -> None:
+    """The post-pairing re-hello propagates the client's re-asserted trust_level."""
+    server_store = InMemoryServerPairingStore()
+    server = _make_server(server_store)
+    client_identity = Identity.generate()
+    client_store = InMemoryClientPairingStore()
+
+    shown: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+
+    async def display(pin: str | None) -> None:
+        if pin is not None and not shown.done():
+            shown.set_result(pin)
+
+    async def provide() -> str:
+        return await shown
+
+    async with _serve(server) as url:
+        client = make_sdk_client(
+            identity=client_identity,
+            pairing_store=client_store,
+            client_name="c",
+            roles=[Roles.CONTROLLER],
+            pin_display=display,
+        )
+        try:
+            await client.connect(url)
+            conn = await _find_connection_by_client_id(server, client_identity.peer_id)
+            await conn.initiate_pairing(
+                PairingAttempt(method=PairMethod.DYNAMIC_PIN, pin_provider=provide)
+            )
+            server_client = conn._client  # noqa: SLF001
+            assert server_client is not None
+            security = server_client.connection_security
+            assert security is not None
+            assert security.psk_category is PskCategory.LONG_TERM
+            assert security.trust_level is TrustLevel.USER
+        finally:
+            await client.disconnect()
+
+
 async def test_live_pairing_dynamic_pin_server_floor_raises_length() -> None:
     """The negotiated length is max(client_min, server_min); the server's higher floor wins."""
     server_store = InMemoryServerPairingStore()

--- a/tests/models/test_management.py
+++ b/tests/models/test_management.py
@@ -20,6 +20,7 @@ from aiosendspin.models.management import (
     PairingMethodConfig,
     RecordModeConfig,
     RecordSummary,
+    ServerUnpairMessage,
     SetDynamicPinConfig,
     SetPairingPskConfig,
     StorageAccounting,
@@ -56,6 +57,19 @@ def test_server_request_round_trips(message: ServerMessage) -> None:
     decoded = ServerMessage.from_json(message.to_json())
     assert type(decoded) is type(message)
     assert decoded == message
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        ServerUnpairMessage(),
+        ManagementListRecordsMessage(),
+        ManagementGetPairingConfigMessage(),
+    ],
+)
+def test_empty_payload_messages_send_payload_key(message: ServerMessage) -> None:
+    """Requests without payload fields still serialize an empty payload object."""
+    assert orjson.loads(message.to_json())["payload"] == {}
 
 
 def test_client_responses_round_trip() -> None:

--- a/tests/noise/test_pairing.py
+++ b/tests/noise/test_pairing.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Sequence
+from dataclasses import replace
 from datetime import UTC, datetime
 
 import pytest
@@ -440,6 +441,46 @@ async def test_dynamic_pin_length_below_client_floor_aborts() -> None:
     assert excinfo.value.reason is PairAbortReason.PIN_LENGTH_UNACCEPTABLE
     assert emitted == []  # no PIN emitted on a length rejection
     assert await client_store.pin_failure_count(PairMethod.DYNAMIC_PIN) == 0
+    assert _added_records(await client_store.list_records()) == []
+    assert await server_store.record_by_client_id("client-A") is None
+
+
+async def test_dynamic_pin_length_below_spec_minimum_aborts() -> None:
+    """A config min under MIN_PIN_DIGITS still aborts cleanly rather than raising ValueError."""
+    client_ews, server_ews, _client_raw, _server_raw = _paired_encrypted_ws()
+    client_store = InMemoryClientPairingStore()
+    cfg = await client_store.get_pairing_config()
+    await client_store.store_pairing_config(replace(cfg, dynamic_pin_min_length=2))
+    server_store = InMemoryServerPairingStore()
+
+    async def emit(pin: str) -> None:
+        pass
+
+    async def provide() -> str:
+        return "00"
+
+    with pytest.raises(PairingAbortError) as excinfo:
+        await asyncio.gather(
+            run_dynamic_pin_client(
+                client_ews,
+                handshake_hash=_HANDSHAKE_HASH,
+                pairing_index=0,
+                pin_emitter=emit,
+                server_id="server-X",
+                store=client_store,
+            ),
+            run_dynamic_pin_server(
+                server_ews,
+                handshake_hash=_HANDSHAKE_HASH,
+                pairing_index=0,
+                pin_length=2,
+                pin_provider=provide,
+                client_id="client-A",
+                store=server_store,
+            ),
+        )
+
+    assert excinfo.value.reason is PairAbortReason.PIN_LENGTH_UNACCEPTABLE
     assert _added_records(await client_store.list_records()) == []
     assert await server_store.record_by_client_id("client-A") is None
 

--- a/tests/noise/test_pairing.py
+++ b/tests/noise/test_pairing.py
@@ -172,6 +172,30 @@ async def test_static_pin_server_gesture_wait_times_out(
     assert server_raw.sent == []
 
 
+async def test_static_pin_server_rejects_non_8_digit_operator_pin() -> None:
+    """A non-8-digit operator PIN aborts the server before it emits its PAKE share."""
+    client_ews, server_ews, _client_raw, server_raw = _paired_encrypted_ws()
+    server_store = InMemoryServerPairingStore()
+
+    async def bad_pin() -> str:
+        return "12345"
+
+    await client_ews.send_str(
+        ClientPairInitMessage(payload=ClientPairInitPayload(pairing_index=0)).to_json(),
+    )
+    with pytest.raises(PairingError, match="8 decimal digits"):
+        await run_static_pin_server(
+            server_ews,
+            handshake_hash=_HANDSHAKE_HASH,
+            pairing_index=0,
+            pin_provider=bad_pin,
+            client_id="client-X",
+            store=server_store,
+        )
+    assert server_raw.sent == []
+    assert await server_store.record_by_client_id("client-X") is None
+
+
 async def test_dynamic_pin_server_times_out_mid_attempt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/noise/test_trust_store.py
+++ b/tests/noise/test_trust_store.py
@@ -338,6 +338,14 @@ async def test_client_static_pin_lifecycle(client_store: ClientPairingStore) -> 
     await client_store.clear_static_pin()
 
 
+@pytest.mark.parametrize("bad_pin", ["1234", "123456789", "abcdefgh", "1234567 "])
+async def test_set_static_pin_rejects_non_8_digit(bad_pin: str) -> None:
+    """The static PIN must be exactly 8 decimal digits (spec definition)."""
+    store = InMemoryClientPairingStore()
+    with pytest.raises(ValueError, match="8 decimal digits"):
+        await store.set_static_pin(bad_pin)
+
+
 async def test_client_store_resolves_by_psk_id_and_finds_by_server_id(
     client_store: ClientPairingStore,
 ) -> None:

--- a/tests/server/test_disconnect_cancels_pairing.py
+++ b/tests/server/test_disconnect_cancels_pairing.py
@@ -1,0 +1,36 @@
+"""disconnect() cancels an in-progress pairing task."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from aiosendspin.server.clock import LoopClock
+from aiosendspin.server.connection import SendspinConnection
+
+
+@dataclass(slots=True)
+class _DummyServer:
+    loop: asyncio.AbstractEventLoop
+    clock: Any
+    id: str = "srv"
+    name: str = "server"
+
+
+@pytest.mark.asyncio
+async def test_disconnect_cancels_pairing_task() -> None:
+    """A pairing task parked on operator input is cancelled when the connection drops."""
+    loop = asyncio.get_running_loop()
+    conn = SendspinConnection(
+        _DummyServer(loop=loop, clock=LoopClock(loop)), wsock_client=MagicMock()
+    )
+    parked = loop.create_task(asyncio.Event().wait())
+    conn._pairing_task = parked  # noqa: SLF001
+
+    await conn.disconnect(retry_connection=False)
+
+    assert parked.cancelled()

--- a/tests/server/test_malformed_hello.py
+++ b/tests/server/test_malformed_hello.py
@@ -1,0 +1,35 @@
+"""A malformed client/hello is rejected instead of raising out of the connection."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aiosendspin.server.clock import LoopClock
+from aiosendspin.server.connection import SendspinConnection
+
+
+@dataclass(slots=True)
+class _DummyServer:
+    loop: asyncio.AbstractEventLoop
+    clock: Any
+    id: str = "srv"
+    name: str = "server"
+
+
+@pytest.mark.asyncio
+async def test_malformed_client_hello_rejects_without_raising() -> None:
+    """Undeserializable hello text disconnects and returns False, it does not raise."""
+    loop = asyncio.get_running_loop()
+    conn = SendspinConnection(
+        _DummyServer(loop=loop, clock=LoopClock(loop)), wsock_client=MagicMock()
+    )
+    conn.disconnect = AsyncMock()  # type: ignore[method-assign]
+
+    assert await conn._ingest_client_hello("{not json") is False  # noqa: SLF001
+
+    conn.disconnect.assert_awaited_once_with(retry_connection=False)

--- a/tests/server/test_multi_server.py
+++ b/tests/server/test_multi_server.py
@@ -25,11 +25,13 @@ from aiosendspin.models.types import (
     Activity,
     AudioCodec,
     ConnectionReason,
+    PairAbortReason,
     PlaybackStateType,
     PlayerCommand,
     Roles,
 )
 from aiosendspin.noise.keys import generate_psk, psk_id_for
+from aiosendspin.noise.pairing import PairingAbortError, RemotePairingAbortError
 from aiosendspin.noise.trust_store import (
     InMemoryServerPairingStore,
     PskCategory,
@@ -37,6 +39,7 @@ from aiosendspin.noise.trust_store import (
     ServerPairingStore,
     TrustedUnpairedClient,
 )
+from aiosendspin.noise.wire import EncryptedWebSocket
 from aiosendspin.server.client import SendspinClient
 from aiosendspin.server.clock import LoopClock
 from aiosendspin.server.connection import SendspinConnection
@@ -354,6 +357,57 @@ class TestLegacyServerHello:
 
         reason = fake.sent_payloads()[0]["payload"]["connection_reason"]
         assert reason == ConnectionReason.DISCOVERY.value
+
+
+class _FakePairingTransport(_FakeTransport, EncryptedWebSocket):
+    """A recording transport that satisfies the encrypted-transport check in pairing."""
+
+    # Shadow the EncryptedWebSocket properties so _FakeTransport.__init__ can assign them.
+    closed = False
+    close_code: int | None = None
+
+    def __init__(self, incoming: list[WSMessage] | None = None) -> None:
+        _FakeTransport.__init__(self, incoming)
+
+
+class TestInitialConnectPairingAbort:
+    """Aborted initial-connect pairing follows the spec's closing/non-closing split."""
+
+    @staticmethod
+    def _pairing_connection(
+        mock_server: _MockServer, reason: PairAbortReason
+    ) -> tuple[SendspinConnection, _FakePairingTransport]:
+        conn = SendspinConnection(mock_server, wsock_client=AsyncMock())
+        psk = generate_psk()
+        conn._client_id = "client-1"  # noqa: SLF001
+        conn._noise_psk = ResolvedPsk(  # noqa: SLF001
+            psk_id=psk_id_for(psk), psk=psk, category=PskCategory.PAIRING
+        )
+        fake = _FakePairingTransport([_client_hello_frame("client-1")])
+        conn._transport = fake  # noqa: SLF001
+        conn._pair = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
+            side_effect=RemotePairingAbortError(reason)
+        )
+        return conn, fake
+
+    @pytest.mark.asyncio
+    async def test_nonclosing_abort_keeps_connection(self, mock_server: _MockServer) -> None:
+        """A non-closing abort reason ends pairing with a leave activate, not a teardown."""
+        conn, fake = self._pairing_connection(mock_server, PairAbortReason.ATTEMPT_TIMEOUT)
+
+        assert await conn._exchange_hellos() is True  # noqa: SLF001
+
+        payloads = fake.sent_payloads()
+        assert payloads[-1]["type"] == "server/activate"
+        assert Activity.PAIRING.value not in payloads[-1]["payload"]["activities"]
+
+    @pytest.mark.asyncio
+    async def test_closing_abort_propagates(self, mock_server: _MockServer) -> None:
+        """A closing abort reason still tears the connection down."""
+        conn, _ = self._pairing_connection(mock_server, PairAbortReason.CONCURRENT_ATTEMPT)
+
+        with pytest.raises(PairingAbortError):
+            await conn._exchange_hellos()  # noqa: SLF001
 
 
 class TestHandshakeOrdering:

--- a/tests/server/test_multi_server.py
+++ b/tests/server/test_multi_server.py
@@ -338,6 +338,23 @@ class TestLegacyServerHello:
         assert [p["type"] for p in payloads] == ["server/hello"]
         assert payloads[0]["payload"]["connection_reason"] == ConnectionReason.PLAYBACK.value
 
+    @pytest.mark.asyncio
+    async def test_legacy_hello_clamps_post_legacy_reasons(self, mock_server: _MockServer) -> None:
+        """Reasons legacy clients cannot parse are sent as discovery."""
+        url = "ws://192.168.1.100:8927/sendspin"
+        mock_server._connection_reasons[url] = ConnectionReason.MANAGEMENT  # noqa: SLF001
+        conn = SendspinConnection(mock_server, wsock_client=AsyncMock(), url=url)
+
+        fake = _FakeTransport()
+        conn._transport = fake  # type: ignore[assignment]  # noqa: SLF001
+        conn._pending_first_text = ClientHelloMessage(  # noqa: SLF001
+            payload=_player_hello("client-1")
+        ).to_json()
+        await conn._exchange_hellos()  # noqa: SLF001
+
+        reason = fake.sent_payloads()[0]["payload"]["connection_reason"]
+        assert reason == ConnectionReason.DISCOVERY.value
+
 
 class TestHandshakeOrdering:
     """Tests for server/hello ordering relative to role messages."""

--- a/tests/server/test_server_initial_connect.py
+++ b/tests/server/test_server_initial_connect.py
@@ -11,8 +11,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from aiohttp import ClientConnectionError, ClientWebSocketResponse
 
-from aiosendspin.models.types import GoodbyeReason
-from aiosendspin.noise.keys import Identity
+from aiosendspin.models.types import GoodbyeReason, PairMethod
+from aiosendspin.noise.keys import Identity, generate_psk
+from aiosendspin.noise.pairing import PairingAttempt
 from aiosendspin.noise.trust_store import InMemoryServerPairingStore
 from aiosendspin.server.connection import SendspinConnection
 from aiosendspin.server.server import SendspinServer
@@ -648,3 +649,53 @@ async def test_mdns_update_reconnect_decision(
         server.connect_to_client.assert_called_once_with(expected_url)
     else:
         server.connect_to_client.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pairing_attempt_queued_for_existing_dial_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pairing_attempt passed while a dial task exists rides that task's next dial."""
+    session = _PersistentSuccessfulSession()
+    server = _make_server(session)
+    url = "ws://127.0.0.1:9999/sendspin"
+    attempt = PairingAttempt(method=PairMethod.PAIRING_PSK, pairing_psk=generate_psk())
+    received: list[object] = []
+
+    class _FakeConnection:
+        """Connection double recording the pairing_attempt of each dial."""
+
+        closing = False
+        goodbye_reason = None
+
+        def __init__(
+            self,
+            _server: SendspinServer,
+            *,
+            wsock_client: object,  # noqa: ARG002
+            url: str | None = None,  # noqa: ARG002
+            expected_client_id: str | None = None,  # noqa: ARG002
+            pairing_attempt: object | None = None,
+        ) -> None:
+            received.append(pairing_attempt)
+
+        async def handle_client(self) -> None:
+            return
+
+        @property
+        def should_retry_server_initiated_connection(self) -> bool:
+            return len(received) < 2
+
+    monkeypatch.setattr("aiosendspin.server.server.SendspinConnection", _FakeConnection)
+
+    server.connect_to_client(url)
+    for _ in range(50):
+        if received:
+            break
+        await asyncio.sleep(0)
+    assert received == [None]
+
+    server.connect_to_client(url, pairing_attempt=attempt)
+    await _wait_for_connection_task_cleanup(server, url)
+
+    assert received == [None, attempt]

--- a/tests/test_client_pairing.py
+++ b/tests/test_client_pairing.py
@@ -11,6 +11,7 @@ import pytest
 from aiosendspin.client.connection import SendspinConnection
 from aiosendspin.models.core import ServerActivatePayload
 from aiosendspin.models.types import (
+    Activity,
     MediaCommand,
     PairAbortReason,
     PairMethod,
@@ -122,6 +123,41 @@ async def _cancel_time_task(connection: SendspinConnection) -> None:
         task.cancel()
         with suppress(asyncio.CancelledError):
             await task
+
+
+async def test_leave_activate_redeclaring_pairing_runs_next_attempt() -> None:
+    """A leave activate that declares pairing again immediately admits the next attempt."""
+    connection, _ws = _client_with(PskCategory.LONG_TERM)
+    connection._connected = True  # noqa: SLF001
+    attempts = 0
+    activates = iter(
+        [
+            ServerActivatePayload(
+                activities=[Activity.PAIRING],
+                active_roles=[],
+                selected_pair_method=PairMethod.DYNAMIC_PIN,
+            ),
+            ServerActivatePayload(activities=[], active_roles=[]),
+        ]
+    )
+
+    async def fake_protocol() -> str:
+        nonlocal attempts
+        attempts += 1
+        return "leftover"
+
+    async def fake_resolve(leftover: str | None) -> ServerActivatePayload:  # noqa: ARG001
+        return next(activates)
+
+    connection._run_pairing_protocol = fake_protocol  # type: ignore[method-assign]  # noqa: SLF001
+    connection._resolve_pairing_activate = fake_resolve  # type: ignore[method-assign]  # noqa: SLF001
+
+    try:
+        await connection._pair()  # noqa: SLF001
+        assert attempts == 2
+        assert not connection.is_pairing
+    finally:
+        await _cancel_time_task(connection)
 
 
 async def test_leave_activate_resumes_time_sync() -> None:

--- a/tests/test_client_pairing.py
+++ b/tests/test_client_pairing.py
@@ -7,9 +7,10 @@ import logging
 from contextlib import suppress
 
 import pytest
+from aiohttp import WSMessage, WSMsgType
 
 from aiosendspin.client.connection import SendspinConnection
-from aiosendspin.models.core import ServerActivatePayload
+from aiosendspin.models.core import ServerActivateMessage, ServerActivatePayload
 from aiosendspin.models.types import (
     Activity,
     MediaCommand,
@@ -115,6 +116,34 @@ async def test_app_and_time_sends_suppressed_during_exchange() -> None:
     connection._exchange_in_progress = False  # noqa: SLF001
     await connection.send_player_state(available=True, volume=7, muted=True)
     assert len(ws.sent) == 1
+
+
+async def test_pairing_window_tolerates_bare_leave_activate() -> None:
+    """A bare leave server/activate during the gesture wait ends pairing, not the connection."""
+
+    async def never() -> None:
+        await asyncio.Event().wait()
+
+    client = make_sdk_client(client_name="C", roles=[Roles.CONTROLLER], pairing_window=never)
+    connection = SendspinConnection(client)
+    ws = _FakeWS()
+    leave = ServerActivateMessage(
+        payload=ServerActivatePayload(activities=[], active_roles=[])
+    ).to_json()
+
+    async def receive() -> WSMessage:
+        return WSMessage(WSMsgType.TEXT, leave, "")
+
+    ws.receive = receive  # type: ignore[attr-defined]
+    connection._ws = ws  # type: ignore[assignment]  # noqa: SLF001
+    connection._server_id = "server-1"  # noqa: SLF001
+    # Static-PIN pairing (the only flow with a gesture wait) runs over the Sentinel PSK.
+    connection._noise_psk = ResolvedPsk("psk-id", b"\x00" * 32, PskCategory.SENTINEL)  # noqa: SLF001
+
+    payload = await connection._await_pairing_window()  # noqa: SLF001
+
+    assert payload is not None
+    assert payload.activities == []
 
 
 async def _cancel_time_task(connection: SendspinConnection) -> None:

--- a/tests/test_client_pairing.py
+++ b/tests/test_client_pairing.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from contextlib import suppress
 
 import pytest
 
 from aiosendspin.client.connection import SendspinConnection
+from aiosendspin.models.core import ServerActivatePayload
 from aiosendspin.models.types import (
     MediaCommand,
     PairAbortReason,
@@ -111,3 +114,27 @@ async def test_app_and_time_sends_suppressed_during_exchange() -> None:
     connection._exchange_in_progress = False  # noqa: SLF001
     await connection.send_player_state(available=True, volume=7, muted=True)
     assert len(ws.sent) == 1
+
+
+async def _cancel_time_task(connection: SendspinConnection) -> None:
+    task = connection._time_task  # noqa: SLF001
+    if task is not None:
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+
+
+async def test_leave_activate_resumes_time_sync() -> None:
+    """A server/activate that returns the connection to normal service restarts time sync."""
+    connection, _ws = _client_with(PskCategory.LONG_TERM)
+    connection._connected = True  # noqa: SLF001
+    assert connection._time_task is None  # noqa: SLF001
+
+    try:
+        await connection._handle_server_activate(  # noqa: SLF001
+            ServerActivatePayload(activities=[], active_roles=[])
+        )
+        assert connection._time_task is not None  # noqa: SLF001
+        assert not connection._time_task.done()  # noqa: SLF001
+    finally:
+        await _cancel_time_task(connection)

--- a/tests/test_client_pairing.py
+++ b/tests/test_client_pairing.py
@@ -155,10 +155,10 @@ async def test_pairing_window_tolerates_bare_leave_activate() -> None:
     # Static-PIN pairing (the only flow with a gesture wait) runs over the Sentinel PSK.
     connection._noise_psk = ResolvedPsk("psk-id", b"\x00" * 32, PskCategory.SENTINEL)  # noqa: SLF001
 
-    payload = await connection._await_pairing_window()  # noqa: SLF001
+    frame = await connection._await_pairing_window()  # noqa: SLF001
 
-    assert payload is not None
-    assert payload.activities == []
+    # The bare leave activate is surfaced raw for downstream parsing, not raised.
+    assert frame == leave
 
 
 async def _cancel_time_task(connection: SendspinConnection) -> None:

--- a/tests/test_client_pairing.py
+++ b/tests/test_client_pairing.py
@@ -13,6 +13,7 @@ from aiosendspin.client.connection import SendspinConnection
 from aiosendspin.models.core import ServerActivateMessage, ServerActivatePayload
 from aiosendspin.models.types import (
     Activity,
+    GoodbyeReason,
     MediaCommand,
     PairAbortReason,
     PairMethod,
@@ -116,6 +117,20 @@ async def test_app_and_time_sends_suppressed_during_exchange() -> None:
     connection._exchange_in_progress = False  # noqa: SLF001
     await connection.send_player_state(available=True, volume=7, muted=True)
     assert len(ws.sent) == 1
+
+
+async def test_pair_abort_and_goodbye_bypass_exchange_suppression() -> None:
+    """pair/abort and client/goodbye still reach the wire while an exchange owns it."""
+    connection, ws = _client_with(PskCategory.PAIRING)
+    connection._connected = True  # noqa: SLF001
+    connection._exchange_in_progress = True  # noqa: SLF001
+
+    await connection.send_pair_abort(PairAbortReason.CONCURRENT_ATTEMPT)
+    await connection.send_goodbye(GoodbyeReason.ANOTHER_SERVER)
+
+    assert len(ws.sent) == 2
+    abort = PairAbortMessage.from_json(ws.sent[0])
+    assert abort.payload.reason is PairAbortReason.CONCURRENT_ATTEMPT
 
 
 async def test_pairing_window_tolerates_bare_leave_activate() -> None:


### PR DESCRIPTION
Follow-up fixes for the encryption support merged in PR #292: PIN-path hardening plus correctness fixes in the pairing lifecycle, management handling, and the connection state machine.

## Changes

### PIN validation

- **Floor dynamic-PIN length check at `MIN_PIN_DIGITS`.** A client config carrying `dynamic_pin_min_length` below 4 (reachable via `from_dict` or direct construction, which the management API does not gate) let a server-sent `pin_length` pass the guard and then raised an uncaught `ValueError` in `derive_pin` instead of aborting the pairing attempt.
- **Enforce 8-digit static PIN.** Reject any static PIN that is not exactly 8 ASCII decimal digits, on both sides that accept one: the client trust store's `set_static_pin` and the server pairing flow, which previously fed an operator-entered PIN straight into CPace and would emit a PAKE share (or crash on a non-ASCII digit) for a malformed value. Both now use the shared `is_valid_static_pin`.

### Server

- **Propagate the re-sent hello to the persistent client after a re-handshake.** The post-pairing `client/hello` (which re-asserts `trust_level` and may change name and capabilities) never reached the persistent `SendspinClient`, so `connection_security` kept reporting `trust_level=none` for the rest of the session and no `ClientUpdatedEvent` fired.
- **Send an empty payload object on payload-less management messages.** `server/unpair`, `management/list-records`, and `management/get-pairing-config` serialized without the `payload` key the spec requires on every message.
- **Cancel the pairing task on connection disconnect.** An attempt parked in `pin_provider()` (operator input) kept `initiate_pairing` pending for up to 180 s after the client dropped.
- **Clamp legacy `server/hello` `connection_reason` to pre-encryption values.** The new `pairing`/`management` reasons fail the old library's strict enum parse, so a legacy client crashed on the hello instead of connecting.
- **Keep the connection open on non-closing initial-connect pairing aborts.** Per spec only `concurrent_attempt` and `method_not_supported` close the connection; other abort reasons now end pairing with a leave activate and keep the connection up for a retry.
- **Reject malformed `client/hello` instead of raising out of the connection.** Parse errors escaped into aiohttp's handler (a regression: pre-encryption the hello was parsed inside the message loop's broad except).
- **Queue a `pairing_attempt` for an existing dial task instead of dropping it.** `connect_to_client` silently discarded the attempt when a dial task for the URL already existed (common in practice, discovery usually creates the task first), so pairing never started.

### Client SDK

- **Detect the management session's own record by matched `psk_id`.** The `server_id`-based detection missed shared-PSK records (the session kept running on a credential it had just removed, without the spec's `client/goodbye 'unauthorized'`) and spuriously closed the session when removing a different record naming the same server.
- **Resume time sync when a connection returns to normal service.** After an aborted pairing the time-sync task was never restarted, so the connection kept reporting its cached synchronized state while the clock estimate drifted.
- **Send `pair/abort` and goodbye even while an in-band exchange owns the wire.** The exchange send-suppression swallowed a displaced pairing connection's spec-required `pair/abort concurrent_attempt` (the old server saw a bare close) and goodbyes issued during a re-handshake.
- **Tear down the connection on unexpected bring-up failures.** Exceptions outside the known-failure list (e.g. `UnicodeDecodeError` from an invalid decrypted JSON body) left `attach_websocket` half-open: `_connected` true, no reader task, socket never closed.
- **Tolerate a bare pairing-leave `server/activate` during the gesture wait.** A third-party server may leave pairing without a `pair/abort` while no attempt has started; the client tore the connection down instead of applying the activate and returning to normal service.
- **Run the next pairing attempt when a leave activate redeclares pairing.** The pairing tail skipped the `is_pairing` recheck, so the client missed one pairing activate and its `pairing_index` fell permanently behind (the server then discards the next `client/pair-init` as stale). Third-party interop only, this repo's server never emits that sequence.
