### PR TITLE
Add an option to reject outdated, non-spec-compliant clients

### DIFF
--- a/aiosendspin/models/core.py
+++ b/aiosendspin/models/core.py
@@ -8,7 +8,6 @@ synchronization, stream lifecycle management, and role-based state updates and c
 
 from __future__ import annotations
 
-import logging
 from dataclasses import dataclass, field, fields, is_dataclass
 from typing import Annotated, Any, ClassVar, Literal
 
@@ -55,8 +54,6 @@ from .visualizer_draft_r1 import (
 from .visualizer_draft_r1 import (
     StreamStartVisualizer as StreamStartVisualizerDraftR1,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def _has_merge_value(value: Any) -> bool:
@@ -169,6 +166,9 @@ class ClientHelloPayload(DataClassORJSONMixin):
     """Pairing methods this client offers."""
     unpaired_access: UnpairedAccess = field(default_factory=UnpairedAccess)
     """Whether this client currently admits unpaired access."""
+    legacy_support_keys_used: list[str] | None = None
+    """Unversioned support keys the parser rewrote to versioned aliases, recorded for
+    the server to flag. Not part of the wire schema (omitted when None)."""
 
     # Static mapping: unversioned support key -> actual alias key.
     _SUPPORT_KEY_ALIASES: ClassVar[dict[str, str]] = {
@@ -180,22 +180,15 @@ class ClientHelloPayload(DataClassORJSONMixin):
 
     @classmethod
     def __pre_deserialize__(cls, d: dict[str, Any]) -> dict[str, Any]:
-        """Normalize legacy role support keys to versioned names."""
-        legacy_fields_used: list[tuple[str, str]] = []
+        """Rewrite legacy unversioned support keys to versioned aliases, recording which."""
         normalized = dict(d)
+        legacy_keys: list[str] = []
         for legacy_key, versioned_key in cls._SUPPORT_KEY_ALIASES.items():
             if legacy_key in normalized and versioned_key not in normalized:
-                legacy_fields_used.append((legacy_key, versioned_key))
+                legacy_keys.append(legacy_key)
                 normalized[versioned_key] = normalized.pop(legacy_key)
-        if legacy_fields_used:
-            old_names = ", ".join(old for old, _ in legacy_fields_used)
-            new_names = ", ".join(new for _, new in legacy_fields_used)
-            logger.warning(
-                "client/hello message used deprecated field names (%s), "
-                "please update client to use (%s) instead",
-                old_names,
-                new_names,
-            )
+        # Always overwrite so a client cannot spoof the record via the wire.
+        normalized["legacy_support_keys_used"] = legacy_keys or None
         return normalized
 
     def __post_init__(self) -> None:

--- a/aiosendspin/models/core.py
+++ b/aiosendspin/models/core.py
@@ -188,9 +188,13 @@ class ClientHelloPayload(DataClassORJSONMixin):
         normalized = dict(d)
         legacy_keys: list[str] = []
         for legacy_key, versioned_key in cls._SUPPORT_KEY_ALIASES.items():
-            if legacy_key in normalized and versioned_key not in normalized:
-                legacy_keys.append(legacy_key)
-                normalized[versioned_key] = normalized.pop(legacy_key)
+            if legacy_key not in normalized:
+                continue
+            legacy_keys.append(legacy_key)
+            value = normalized.pop(legacy_key)
+            # Rewrite to the versioned alias only when the client didn't also send it.
+            if versioned_key not in normalized:
+                normalized[versioned_key] = value
         # Always overwrite so a client cannot spoof the record via the wire.
         normalized["legacy_support_keys_used"] = legacy_keys or None
         return normalized

--- a/aiosendspin/models/core.py
+++ b/aiosendspin/models/core.py
@@ -169,6 +169,10 @@ class ClientHelloPayload(DataClassORJSONMixin):
     legacy_support_keys_used: list[str] | None = None
     """Unversioned support keys the parser rewrote to versioned aliases, recorded for
     the server to flag. Not part of the wire schema (omitted when None)."""
+    unlisted_support_roles: list[str] | None = None
+    """Roles whose support object was provided without listing the role in
+    ``supported_roles`` (dropped during parse), recorded for the server to flag.
+    Not part of the wire schema (omitted when None)."""
 
     # Static mapping: unversioned support key -> actual alias key.
     _SUPPORT_KEY_ALIASES: ClassVar[dict[str, str]] = {
@@ -197,6 +201,7 @@ class ClientHelloPayload(DataClassORJSONMixin):
         # Require support objects only for the exact role version we parse (e.g. "player@v1").
         # Clients may advertise newer versions (e.g. "player@v2") which this server may not
         # implement. Those must not trigger v1 support requirements.
+        unlisted: list[str] = []
         player_role_supported = Roles.PLAYER.value in self.supported_roles
         if player_role_supported and self.player_support is None:
             raise ValueError(
@@ -204,6 +209,8 @@ class ClientHelloPayload(DataClassORJSONMixin):
                 "'player@v1' is in supported_roles"
             )
         if not player_role_supported:
+            if self.player_support is not None:
+                unlisted.append(Roles.PLAYER.value)
             self.player_support = None
 
         # Validate artwork role and support configuration
@@ -214,6 +221,8 @@ class ClientHelloPayload(DataClassORJSONMixin):
                 "'artwork@v1' is in supported_roles"
             )
         if not artwork_role_supported:
+            if self.artwork_support is not None:
+                unlisted.append(Roles.ARTWORK.value)
             self.artwork_support = None
 
         # Validate visualizer role and support configuration.
@@ -224,6 +233,8 @@ class ClientHelloPayload(DataClassORJSONMixin):
                 "provided when 'visualizer@v1' is in supported_roles"
             )
         if not visualizer_role_supported:
+            if self.visualizer_support is not None:
+                unlisted.append(Roles.VISUALIZER.value)
             self.visualizer_support = None
 
         # Validate legacy `visualizer@_draft_r1` support configuration.
@@ -234,7 +245,12 @@ class ClientHelloPayload(DataClassORJSONMixin):
                 "'visualizer@_draft_r1' is in supported_roles"
             )
         if not visualizer_draft_supported:
+            if self.visualizer_draft_r1_support is not None:
+                unlisted.append("visualizer@_draft_r1")
             self.visualizer_draft_r1_support = None
+
+        # Overwrite so a client cannot spoof the record via the wire.
+        self.unlisted_support_roles = unlisted or None
 
     class Config(BaseConfig):
         """Config for parsing json messages."""

--- a/aiosendspin/models/core.py
+++ b/aiosendspin/models/core.py
@@ -298,13 +298,19 @@ class ClientStatePayload(DataClassORJSONMixin):
     """
     player: PlayerStatePayload | None = None
     """Player state - only if client has player role."""
+    legacy_state_used: bool | None = None
+    """Set when the parser read a legacy top-level `state` field, recorded for the server
+    to flag. Not part of the wire schema (omitted when None)."""
 
     @classmethod
     def __pre_deserialize__(cls, d: dict[str, Any]) -> dict[str, Any]:
-        """Normalize a legacy `state` enum to `available` (only external_source is unavailable)."""
-        if d.get("available") is None and "state" in d:
-            d = dict(d)
+        """Normalize a legacy `state` enum to `available`, recording that it was used."""
+        d = dict(d)
+        legacy_state = "state" in d
+        if d.get("available") is None and legacy_state:
             d["available"] = d["state"] != "external_source"
+        # Always overwrite so a client cannot spoof the record via the wire.
+        d["legacy_state_used"] = legacy_state or None
         return d
 
     class Config(BaseConfig):

--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -140,6 +140,8 @@ class SendspinClient:
 
     def flag_noncompliance(self, reason: str) -> None:
         """Log a tolerated spec violation, or reject it when the server is strict."""
+        # Logged at info while implementers migrate. Bump to warning once they have
+        # had time to fix these, then drop the backwards-compat paths altogether.
         self._logger.info("non-compliant client: %s", reason)
         if self._server.strict_clients:
             raise ClientComplianceError(reason)

--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -143,7 +143,7 @@ class SendspinClient:
         # Logged at info while implementers migrate. Bump to warning once they have
         # had time to fix these, then drop the backwards-compat paths altogether.
         self._logger.info("non-compliant client: %s", reason)
-        if self._server.strict_clients:
+        if not self._server.allow_noncompliant_clients:
             raise ClientComplianceError(reason)
 
     @property
@@ -733,7 +733,7 @@ class SendspinClient:
         self._name = client_info.name
         if negotiated_roles is None:
             self._negotiated_role_ids = negotiate_roles(
-                client_info.supported_roles, strict=self._server.strict_clients
+                client_info.supported_roles, strict=not self._server.allow_noncompliant_clients
             )
         else:
             self._negotiated_role_ids = negotiated_roles

--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -732,7 +732,9 @@ class SendspinClient:
         self._info = client_info
         self._name = client_info.name
         if negotiated_roles is None:
-            self._negotiated_role_ids = negotiate_roles(client_info.supported_roles)
+            self._negotiated_role_ids = negotiate_roles(
+                client_info.supported_roles, strict=self._server.strict_clients
+            )
         else:
             self._negotiated_role_ids = negotiated_roles
 

--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -31,6 +31,7 @@ from aiosendspin.models.types import (
 from aiosendspin.noise.trust_store import PskCategory
 from aiosendspin.util import create_task
 
+from .compliance import ClientComplianceError
 from .events import ClientEvent, ClientGroupChangedEvent
 from .roles import Role
 from .roles.base import BinaryHandling
@@ -136,6 +137,12 @@ class SendspinClient:
         self._cleanup_handle: asyncio.Handle | None = None
         # True when we intentionally retain a disconnected client after ANOTHER_SERVER goodbye.
         self._cleanup_on_mdns_removal: bool = False
+
+    def flag_noncompliance(self, reason: str) -> None:
+        """Log a tolerated spec violation, or reject it when the server is strict."""
+        self._logger.info("non-compliant client: %s", reason)
+        if self._server.strict_clients:
+            raise ClientComplianceError(reason)
 
     @property
     def client_id(self) -> str:

--- a/aiosendspin/server/compliance.py
+++ b/aiosendspin/server/compliance.py
@@ -1,0 +1,15 @@
+"""Client spec-compliance signalling.
+
+The server tolerates a range of non-spec-compliant client behavior for
+backwards compatibility. Every such tolerance is funnelled through
+``SendspinClient.flag_noncompliance`` / ``SendspinConnection._flag_noncompliance``,
+which log the deviation and, when the server runs with ``strict_clients=True``,
+raise ``ClientComplianceError`` to reject the client. Grep for those helpers to
+enumerate the workarounds.
+"""
+
+from __future__ import annotations
+
+
+class ClientComplianceError(Exception):
+    """Raised when a strict-mode server rejects a non-spec-compliant client."""

--- a/aiosendspin/server/compliance.py
+++ b/aiosendspin/server/compliance.py
@@ -3,9 +3,9 @@
 The server tolerates a range of non-spec-compliant client behavior for
 backwards compatibility. Every such tolerance is funnelled through
 ``SendspinClient.flag_noncompliance`` / ``SendspinConnection._flag_noncompliance``,
-which log the deviation and, when the server runs with ``strict_clients=True``,
-raise ``ClientComplianceError`` to reject the client. Grep for those helpers to
-enumerate the workarounds.
+which log the deviation and, when the server runs with
+``allow_noncompliant_clients=False``, raise ``ClientComplianceError`` to reject
+the client. Grep for those helpers to enumerate the workarounds.
 """
 
 from __future__ import annotations

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -371,6 +371,15 @@ class SendspinConnection:
         for reason in reasons:
             self._flag_noncompliance(f"initial client/state {reason}")
 
+    def _flag_inactive_role_payloads(self, kind: str, present: dict[str, object]) -> None:
+        """Flag role objects sent for a family the client has no active role in."""
+        if self._client is None:
+            return
+        active = {role.role_family for role in self._client.active_roles}
+        for family, obj in present.items():
+            if obj is not None and family not in active:
+                self._flag_noncompliance(f"{kind} carried a {family} object for an inactive role")
+
     def drop_pending_binary(self, roles: list[str] | None) -> None:
         """Drop queued binary payloads for the specified roles.
 
@@ -1618,6 +1627,7 @@ class SendspinConnection:
 
             if payload.available is not None and payload.available != self._client.available:
                 await self._client.handle_availability_change(available=payload.available)
+            self._flag_inactive_role_payloads("client/state", {"player": payload.player})
             for role in self._client.active_roles:
                 role.on_client_state(payload)
             return
@@ -1625,13 +1635,21 @@ class SendspinConnection:
         if isinstance(message, StreamRequestFormatMessage):
             if self._client is None:
                 return
+            fmt = message.payload
+            self._flag_inactive_role_payloads(
+                "stream/request-format",
+                {"player": fmt.player, "artwork": fmt.artwork, "visualizer": fmt.visualizer},
+            )
             for role in self._client.active_roles:
-                role.on_stream_request_format(message.payload)
+                role.on_stream_request_format(fmt)
             return
 
         if isinstance(message, ClientCommandMessage):
             if self._client is None:
                 return
+            self._flag_inactive_role_payloads(
+                "client/command", {"controller": message.payload.controller}
+            )
             for role in self._client.active_roles:
                 role.on_command(message.payload)
             return

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -922,6 +922,10 @@ class SendspinConnection:
             )
             await self.disconnect(retry_connection=False)
             return False
+        # Encrypted clients carry version in client/init, so only an unencrypted
+        # hello is required to include it.
+        if not self.is_encrypted and client_info.version is None:
+            self._flag_noncompliance("unencrypted client/hello omitted required version")
         # The Noise handshake sets client_id (authenticated); a legacy client
         # instead carries it in the hello payload.
         client_id = self._client_id or client_info.client_id

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -360,24 +360,16 @@ class SendspinConnection:
             return False
         return any(role.requires_initial_state() for role in self._client.active_roles)
 
-    def _initial_state_deviations(self, payload: ClientStatePayload) -> list[str]:
-        """Spec requirements the initial client/state must satisfy but does not."""
+    def _flag_initial_state_deviations(self, payload: ClientStatePayload) -> None:
+        """Flag spec requirements the initial client/state must satisfy but does not."""
         reasons: list[str] = []
         if payload.available is None:
             reasons.append("omitted the required 'available' field")
-        if self._client is not None and any(
-            role.role_family == "player" for role in self._client.active_roles
-        ):
-            player = payload.player
-            if player is None:
-                reasons.append("has an active player role but no player state")
-            elif (
-                player.static_delay_ms is None
-                or player.required_lead_time_ms is None
-                or player.min_buffer_ms is None
-            ):
-                reasons.append("omitted required player timing fields")
-        return reasons
+        if self._client is not None:
+            for role in self._client.active_roles:
+                reasons.extend(role.initial_state_deviations(payload))
+        for reason in reasons:
+            self._flag_noncompliance(f"initial client/state {reason}")
 
     def drop_pending_binary(self, roles: list[str] | None) -> None:
         """Drop queued binary payloads for the specified roles.
@@ -1615,8 +1607,7 @@ class SendspinConnection:
                 return
 
             if self.requires_initial_state() and not self._initial_state_received:
-                for reason in self._initial_state_deviations(payload):
-                    self._flag_noncompliance(f"initial client/state {reason}")
+                self._flag_initial_state_deviations(payload)
                 self._initial_state_received = True
                 if self._initial_state_timeout_handle is not None:
                     self._initial_state_timeout_handle.cancel()

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -38,6 +38,7 @@ from collections import defaultdict, deque
 from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass
+from functools import partial
 from typing import TYPE_CHECKING, Any, cast
 
 import orjson
@@ -300,6 +301,9 @@ class SendspinConnection:
 
         self._initial_state_received = False
         self._initial_state_timeout_handle: asyncio.TimerHandle | None = None
+        # Binary held while a role that receives binary awaits the initial client/state.
+        # The spec forbids sending binary before it; flushed once the state arrives.
+        self._pending_binary: list[Callable[[], None]] = []
 
         self._last_goodbye_reason: GoodbyeReason | None = None
         self._epoch_by_role: defaultdict[str, int] = defaultdict(int)
@@ -360,6 +364,12 @@ class SendspinConnection:
             return False
         return any(role.requires_initial_state() for role in self._client.active_roles)
 
+    def _flush_pending_binary(self) -> None:
+        """Enqueue binary held until the initial client/state arrived."""
+        pending, self._pending_binary = self._pending_binary, []
+        for send in pending:
+            send()
+
     def _flag_initial_state_deviations(self, payload: ClientStatePayload) -> None:
         """Flag spec requirements the initial client/state must satisfy but does not."""
         reasons: list[str] = []
@@ -414,6 +424,22 @@ class SendspinConnection:
             buffer_byte_count: Byte count for buffer tracking.
             duration_us: Duration for buffer tracking.
         """
+        if self.requires_initial_state() and not self._initial_state_received:
+            # No binary before the client's initial state; replay once it arrives.
+            self._pending_binary.append(
+                partial(
+                    self.send_binary,
+                    data,
+                    role=role,
+                    timestamp_us=timestamp_us,
+                    message_type=message_type,
+                    buffer_end_time_us=buffer_end_time_us,
+                    buffer_byte_count=buffer_byte_count,
+                    duration_us=duration_us,
+                )
+            )
+            return
+
         if self._is_role_queue_full(role):
             self._disconnect_due_to_queue_overflow(
                 f"Role queue full for {role} ({len(self._role_queues.get(role, []))}/"
@@ -605,6 +631,7 @@ class SendspinConnection:
             self._initial_state_received = True
             self._client.mark_connected()
             self._server.on_client_first_connect(self._client.client_id)
+            self._flush_pending_binary()
 
     @staticmethod
     def _first_registered_role_id_in_family(
@@ -1632,6 +1659,7 @@ class SendspinConnection:
                     self._initial_state_timeout_handle = None
                 self._client.mark_connected()
                 self._server.on_client_first_connect(self._client.client_id)
+                self._flush_pending_binary()
 
             if payload.available is not None and payload.available != self._client.available:
                 await self._client.handle_availability_change(available=payload.available)

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -49,6 +49,7 @@ from aiosendspin.models.core import (
     ClientHelloMessage,
     ClientHelloPayload,
     ClientStateMessage,
+    ClientStatePayload,
     ClientTimeMessage,
     LegacyServerHelloMessage,
     LegacyServerHelloPayload,
@@ -358,6 +359,25 @@ class SendspinConnection:
         if self._client is None:
             return False
         return any(role.requires_initial_state() for role in self._client.active_roles)
+
+    def _initial_state_deviations(self, payload: ClientStatePayload) -> list[str]:
+        """Spec requirements the initial client/state must satisfy but does not."""
+        reasons: list[str] = []
+        if payload.available is None:
+            reasons.append("omitted the required 'available' field")
+        if self._client is not None and any(
+            role.role_family == "player" for role in self._client.active_roles
+        ):
+            player = payload.player
+            if player is None:
+                reasons.append("has an active player role but no player state")
+            elif (
+                player.static_delay_ms is None
+                or player.required_lead_time_ms is None
+                or player.min_buffer_ms is None
+            ):
+                reasons.append("omitted required player timing fields")
+        return reasons
 
     def drop_pending_binary(self, roles: list[str] | None) -> None:
         """Drop queued binary payloads for the specified roles.
@@ -1591,6 +1611,8 @@ class SendspinConnection:
                 return
 
             if self.requires_initial_state() and not self._initial_state_received:
+                for reason in self._initial_state_deviations(payload):
+                    self._flag_noncompliance(f"initial client/state {reason}")
                 self._initial_state_received = True
                 if self._initial_state_timeout_handle is not None:
                     self._initial_state_timeout_handle.cancel()

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -1593,7 +1593,6 @@ class SendspinConnection:
     async def _handle_message(self, message: ClientMessage, timestamp_us: int) -> None:
         """Handle a single client message, dispatching to roles or the connection."""
         if isinstance(message, ClientHelloMessage):
-            # client/hello is consumed during the hello exchange; a second one is a protocol error.
             self._flag_noncompliance("sent a second client/hello after the hello exchange")
             return
 

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -1651,6 +1651,9 @@ class SendspinConnection:
             if payload.legacy_state_used:
                 self._flag_noncompliance("client/state used the legacy top-level 'state' field")
             self._flag_inactive_role_payloads("client/state", {"player": payload.player})
+            for role in self._client.active_roles:
+                for reason in role.client_state_deviations(payload):
+                    self._flag_noncompliance(f"client/state {reason}")
 
             if is_initial:
                 self._initial_state_received = True

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -931,6 +931,11 @@ class SendspinConnection:
         self._negotiated_roles = negotiate_roles(client_info.supported_roles)
         self._logger = logger.getChild(client_id)
         self._logger.debug("Received client/hello: %s", client_info)
+        if client_info.legacy_support_keys_used:
+            self._flag_noncompliance(
+                "client/hello used unversioned support keys: "
+                + ", ".join(client_info.legacy_support_keys_used)
+            )
         if unimplemented := self._unimplemented_roles(client_info.supported_roles):
             self._logger.info(
                 "Client offered roles/versions this server does not implement: %s", unimplemented

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -960,7 +960,9 @@ class SendspinConnection:
 
         self._client_info = client_info
         self._client_id = client_id
-        self._negotiated_roles = negotiate_roles(client_info.supported_roles)
+        self._negotiated_roles = negotiate_roles(
+            client_info.supported_roles, strict=self._server.strict_clients
+        )
         self._logger = logger.getChild(client_id)
         self._logger.debug("Received client/hello: %s", client_info)
         if client_info.legacy_support_keys_used:
@@ -973,8 +975,6 @@ class SendspinConnection:
                 "client/hello sent support objects for unlisted roles: "
                 + ", ".join(client_info.unlisted_support_roles)
             )
-        if "visualizer@_draft_r1" in self._negotiated_roles:
-            self._flag_noncompliance("client negotiated the legacy visualizer@_draft_r1 wire")
         if unimplemented := self._unimplemented_roles(client_info.supported_roles):
             self._logger.info(
                 "Client offered roles/versions this server does not implement: %s", unimplemented

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -968,6 +968,11 @@ class SendspinConnection:
                 "client/hello used unversioned support keys: "
                 + ", ".join(client_info.legacy_support_keys_used)
             )
+        if client_info.unlisted_support_roles:
+            self._flag_noncompliance(
+                "client/hello sent support objects for unlisted roles: "
+                + ", ".join(client_info.unlisted_support_roles)
+            )
         if "visualizer@_draft_r1" in self._negotiated_roles:
             self._flag_noncompliance("client negotiated the legacy visualizer@_draft_r1 wire")
         if unimplemented := self._unimplemented_roles(client_info.supported_roles):

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -1621,6 +1621,8 @@ class SendspinConnection:
             is_initial = self.requires_initial_state() and not self._initial_state_received
             if is_initial:
                 self._flag_initial_state_deviations(payload)
+            if payload.legacy_state_used:
+                self._flag_noncompliance("client/state used the legacy top-level 'state' field")
             self._flag_inactive_role_payloads("client/state", {"player": payload.player})
 
             if is_initial:

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -900,7 +900,7 @@ class SendspinConnection:
             self._client.flag_noncompliance(reason)
             return
         self._logger.info("non-compliant client: %s", reason)
-        if self._server.strict_clients:
+        if not self._server.allow_noncompliant_clients:
             raise ClientComplianceError(reason)
 
     async def _ingest_client_hello(self, text: str) -> bool:
@@ -953,7 +953,7 @@ class SendspinConnection:
         self._client_info = client_info
         self._client_id = client_id
         self._negotiated_roles = negotiate_roles(
-            client_info.supported_roles, strict=self._server.strict_clients
+            client_info.supported_roles, strict=not self._server.allow_noncompliant_clients
         )
         self._logger = logger.getChild(client_id)
         self._logger.debug("Received client/hello: %s", client_info)

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -1616,8 +1616,14 @@ class SendspinConnection:
             if self._client is None:
                 return
 
-            if self.requires_initial_state() and not self._initial_state_received:
+            # Validate before any side effect, so a strict-mode rejection never leaves
+            # the client marked connected or its availability already changed.
+            is_initial = self.requires_initial_state() and not self._initial_state_received
+            if is_initial:
                 self._flag_initial_state_deviations(payload)
+            self._flag_inactive_role_payloads("client/state", {"player": payload.player})
+
+            if is_initial:
                 self._initial_state_received = True
                 if self._initial_state_timeout_handle is not None:
                     self._initial_state_timeout_handle.cancel()
@@ -1627,7 +1633,6 @@ class SendspinConnection:
 
             if payload.available is not None and payload.available != self._client.available:
                 await self._client.handle_availability_change(available=payload.available)
-            self._flag_inactive_role_payloads("client/state", {"player": payload.player})
             for role in self._client.active_roles:
                 role.on_client_state(payload)
             return

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -303,7 +303,9 @@ class SendspinConnection:
         self._initial_state_timeout_handle: asyncio.TimerHandle | None = None
         # Binary held while a role that receives binary awaits the initial client/state.
         # The spec forbids sending binary before it; flushed once the state arrives.
-        self._pending_binary: list[Callable[[], None]] = []
+        # Each entry carries the role's epoch at buffer time so a stream boundary
+        # in the meantime (which bumps the epoch) discards it instead of replaying.
+        self._pending_binary: list[tuple[str, int, Callable[[], None]]] = []
 
         self._last_goodbye_reason: GoodbyeReason | None = None
         self._epoch_by_role: defaultdict[str, int] = defaultdict(int)
@@ -365,10 +367,12 @@ class SendspinConnection:
         return any(role.requires_initial_state() for role in self._client.active_roles)
 
     def _flush_pending_binary(self) -> None:
-        """Enqueue binary held until the initial client/state arrived."""
+        """Enqueue binary held until the initial client/state arrived, dropping stale entries."""
         pending, self._pending_binary = self._pending_binary, []
-        for send in pending:
-            send()
+        for role, epoch, send in pending:
+            # A stream boundary during the wait bumped the epoch; that data is stale.
+            if epoch == self._epoch_by_role[role]:
+                send()
 
     def _flag_initial_state_deviations(self, payload: ClientStatePayload) -> None:
         """Flag spec requirements the initial client/state must satisfy but does not."""
@@ -425,17 +429,22 @@ class SendspinConnection:
             duration_us: Duration for buffer tracking.
         """
         if self.requires_initial_state() and not self._initial_state_received:
-            # No binary before the client's initial state; replay once it arrives.
+            # No binary before the client's initial state; replay once it arrives,
+            # tagged with the current epoch so a stream boundary can invalidate it.
             self._pending_binary.append(
-                partial(
-                    self.send_binary,
-                    data,
-                    role=role,
-                    timestamp_us=timestamp_us,
-                    message_type=message_type,
-                    buffer_end_time_us=buffer_end_time_us,
-                    buffer_byte_count=buffer_byte_count,
-                    duration_us=duration_us,
+                (
+                    role,
+                    self._epoch_by_role[role],
+                    partial(
+                        self.send_binary,
+                        data,
+                        role=role,
+                        timestamp_us=timestamp_us,
+                        message_type=message_type,
+                        buffer_end_time_us=buffer_end_time_us,
+                        buffer_byte_count=buffer_byte_count,
+                        duration_us=duration_us,
+                    ),
                 )
             )
             return

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -1547,6 +1547,10 @@ class SendspinConnection:
         except asyncio.CancelledError:
             cancelled = True
             self._logger.debug("Message loop cancelled")
+        except ClientComplianceError as exc:
+            # Strict mode: hard-reject (no warm reconnect). Cleanup reads _closing.
+            self._logger.info("Rejecting non-compliant client: %s", exc)
+            self._closing = True
         except Exception:
             self._logger.exception("Unexpected error inside websocket API")
         finally:

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -936,6 +936,8 @@ class SendspinConnection:
                 "client/hello used unversioned support keys: "
                 + ", ".join(client_info.legacy_support_keys_used)
             )
+        if "visualizer@_draft_r1" in self._negotiated_roles:
+            self._flag_noncompliance("client negotiated the legacy visualizer@_draft_r1 wire")
         if unimplemented := self._unimplemented_roles(client_info.supported_roles):
             self._logger.info(
                 "Client offered roles/versions this server does not implement: %s", unimplemented

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -118,6 +118,7 @@ from aiosendspin.noise.wire import EncryptedWebSocket
 from aiosendspin.util import create_task
 
 from .client import SendspinClient
+from .compliance import ClientComplianceError
 from .events import ClientEvent, ClientGroupChangedEvent, GroupEvent, GroupStateChangedEvent
 from .roles.negotiation import negotiate_roles
 from .roles.registry import ROLE_FACTORIES, ROLE_SUPPORT_SPECS
@@ -876,6 +877,19 @@ class SendspinConnection:
         )
         client_hello_text = await receive_text_frame(transport, what="client/hello")
         return await self._ingest_client_hello(client_hello_text)
+
+    def _flag_noncompliance(self, reason: str) -> None:
+        """Log a tolerated spec violation, or reject it when the server is strict.
+
+        Usable during the hello exchange before a persistent client exists; once
+        attached, delegates to the client so its logger carries the client_id.
+        """
+        if self._client is not None:
+            self._client.flag_noncompliance(reason)
+            return
+        self._logger.info("non-compliant client: %s", reason)
+        if self._server.strict_clients:
+            raise ClientComplianceError(reason)
 
     async def _ingest_client_hello(self, text: str) -> bool:
         """Validate and record the client/hello, attaching the client; False if rejected."""

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -585,12 +585,13 @@ class SendspinConnection:
         if self._initial_state_received:
             return
         self._initial_state_timeout_handle = None
-        self._logger.warning(
-            "Client %s failed to send required initial state within timeout (spec violation)",
-            self._client_id or "unknown",
-        )
-        # Be lenient: keep the connection and mark the client as connected anyway.
-        # Some clients may not send an initial state update promptly.
+        try:
+            self._flag_noncompliance("did not send the required initial client/state in time")
+        except ClientComplianceError:
+            # A timer callback can't propagate into the message loop, so tear down here.
+            create_task(self.disconnect(retry_connection=False))
+            return
+        # Lenient: keep the connection and mark the client connected anyway.
         if self._client is not None:
             self._initial_state_received = True
             self._client.mark_connected()

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -1378,7 +1378,7 @@ class SendspinConnection:
         """Deliver a management reply, draining the waiter slot."""
         waiter = self._management_waiter
         if waiter is None:
-            self._logger.warning("Unsolicited management reply; ignoring")
+            self._flag_noncompliance("sent an unsolicited management/result")
             return
         # Clear even an abandoned waiter, so its late reply can't match the next request.
         self._management_waiter = None
@@ -1565,7 +1565,7 @@ class SendspinConnection:
         """Handle a single client message, dispatching to roles or the connection."""
         if isinstance(message, ClientHelloMessage):
             # client/hello is consumed during the hello exchange; a second one is a protocol error.
-            self._logger.warning("Unexpected client/hello after the hello exchange; ignoring")
+            self._flag_noncompliance("sent a second client/hello after the hello exchange")
             return
 
         if isinstance(message, ClientTimeMessage):

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -894,6 +894,14 @@ class SendspinConnection:
     async def _ingest_client_hello(self, text: str) -> bool:
         """Validate and record the client/hello, attaching the client; False if rejected."""
         try:
+            return await self._ingest_client_hello_checked(text)
+        except ClientComplianceError:
+            await self.disconnect(retry_connection=False)
+            return False
+
+    async def _ingest_client_hello_checked(self, text: str) -> bool:
+        """Body of the hello exchange; raises ClientComplianceError in strict mode."""
+        try:
             message = self._deserialize_client_message(text)
         except (LookupError, TypeError, ValueError) as exc:
             self._logger.error("Malformed client/hello: %s", exc)

--- a/aiosendspin/server/roles/artwork/v1.py
+++ b/aiosendspin/server/roles/artwork/v1.py
@@ -64,6 +64,10 @@ class ArtworkV1Role(Role):
         """Role family name for protocol messages."""
         return "artwork"
 
+    def requires_initial_state(self) -> bool:
+        """Artwork receives server binary, gated on the client's initial state."""
+        return True
+
     def on_connect(self) -> None:
         """Initialize channel configs from client hello and subscribe to group."""
         self._init_channel_configs()

--- a/aiosendspin/server/roles/artwork/v1.py
+++ b/aiosendspin/server/roles/artwork/v1.py
@@ -175,10 +175,8 @@ class ArtworkV1Role(Role):
             return
 
         if artwork_request.channel not in self._channel_configs:
-            self._client._logger.warning(  # noqa: SLF001
-                "Client %s requested invalid artwork channel %d",
-                self._client.client_id,
-                artwork_request.channel,
+            self._client.flag_noncompliance(
+                f"stream/request-format targeted unknown artwork channel {artwork_request.channel}"
             )
             return
 

--- a/aiosendspin/server/roles/artwork/v1.py
+++ b/aiosendspin/server/roles/artwork/v1.py
@@ -182,6 +182,23 @@ class ArtworkV1Role(Role):
             )
             return
 
+        invalid_dims = [
+            name
+            for name, value in (
+                ("media_width", artwork_request.media_width),
+                ("media_height", artwork_request.media_height),
+            )
+            if value is not None and value <= 0
+        ]
+        if invalid_dims:
+            # Skip the update: non-positive dims would otherwise raise out of
+            # ArtworkChannel and tear the connection down.
+            self._client.flag_noncompliance(
+                "stream/request-format artwork dimensions must be positive: "
+                + ", ".join(invalid_dims)
+            )
+            return
+
         self._update_channel_config(artwork_request)
 
     def _update_channel_config(self, request: StreamRequestFormatArtwork) -> None:

--- a/aiosendspin/server/roles/base.py
+++ b/aiosendspin/server/roles/base.py
@@ -414,6 +414,10 @@ class Role(ABC):
         """
         return False
 
+    def initial_state_deviations(self, payload: ClientStatePayload) -> list[str]:  # noqa: ARG002
+        """Spec requirements this role's part of the initial client/state does not meet."""
+        return []
+
     def on_group_changed(self, group: object) -> None:  # noqa: ARG002
         """Handle group changes by re-subscribing to the new GroupRole."""
         self._unsubscribe_from_group_role()

--- a/aiosendspin/server/roles/base.py
+++ b/aiosendspin/server/roles/base.py
@@ -418,6 +418,10 @@ class Role(ABC):
         """Spec requirements this role's part of the initial client/state does not meet."""
         return []
 
+    def client_state_deviations(self, payload: ClientStatePayload) -> list[str]:  # noqa: ARG002
+        """Spec violations in any client/state for this role, checked before it is applied."""
+        return []
+
     def on_group_changed(self, group: object) -> None:  # noqa: ARG002
         """Handle group changes by re-subscribing to the new GroupRole."""
         self._unsubscribe_from_group_role()

--- a/aiosendspin/server/roles/negotiation.py
+++ b/aiosendspin/server/roles/negotiation.py
@@ -24,7 +24,7 @@ _FAMILY_ORDER = {
     )
 }
 
-# Legacy backwards-compat wires excluded from negotiation under strict_clients.
+# Legacy backwards-compat wires excluded from negotiation in strict mode.
 _LEGACY_ROLE_IDS = frozenset({"visualizer@_draft_r1"})
 
 

--- a/aiosendspin/server/roles/negotiation.py
+++ b/aiosendspin/server/roles/negotiation.py
@@ -24,22 +24,28 @@ _FAMILY_ORDER = {
     )
 }
 
+# Legacy backwards-compat wires excluded from negotiation under strict_clients.
+_LEGACY_ROLE_IDS = frozenset({"visualizer@_draft_r1"})
+
 
 def sort_role_ids(role_ids: Iterable[str]) -> list[str]:
     """Order role IDs by server-defined family order; unlisted families keep input order."""
     return sorted(role_ids, key=lambda rid: _FAMILY_ORDER.get(role_family(rid), len(_FAMILY_ORDER)))
 
 
-def negotiate_roles(client_supported_roles: list[str]) -> list[str]:
+def negotiate_roles(client_supported_roles: list[str], *, strict: bool = False) -> list[str]:
     """Negotiate the mutually-supported role set from the client-supported role list.
 
-    For each role family, pick the first role in client order that is
-    registered in ROLE_FACTORIES. The result is sorted by the server-defined
-    family activation order.
+    For each role family, pick the first role in client order that is registered
+    in ROLE_FACTORIES. The result is sorted by the server-defined family
+    activation order. When ``strict``, legacy backwards-compat wires are skipped
+    so a later spec role in the same family can win instead.
     """
     active: dict[str, str] = {}
 
     for client_role_id in client_supported_roles:
+        if strict and client_role_id in _LEGACY_ROLE_IDS:
+            continue
         family = role_family(client_role_id)
         if family in active:
             continue

--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -699,6 +699,20 @@ class PlayerV1Role(Role):
         if player_req is None:
             return
 
+        invalid = [
+            name
+            for name, value in (
+                ("sample_rate", player_req.sample_rate),
+                ("channels", player_req.channels),
+                ("bit_depth", player_req.bit_depth),
+            )
+            if value is not None and value <= 0
+        ]
+        if invalid:
+            self._client.flag_noncompliance(
+                "stream/request-format player fields must be positive: " + ", ".join(invalid)
+            )
+
         support = self._client.info.player_support
         if support is None:
             raise ValueError(

--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -635,17 +635,24 @@ class PlayerV1Role(Role):
     # ---- Client message handling ----
 
     def initial_state_deviations(self, payload: ClientStatePayload) -> list[str]:
-        """Report required player timing fields missing from the initial client/state."""
+        """Report required player fields missing from the initial client/state."""
         player = payload.player
         if player is None:
             return ["has an active player role but no player state"]
+        reasons: list[str] = []
         if (
             player.static_delay_ms is None
             or player.required_lead_time_ms is None
             or player.min_buffer_ms is None
         ):
-            return ["omitted required player timing fields"]
-        return []
+            reasons.append("omitted required player timing fields")
+        support = self._client.info.player_support
+        commands = support.supported_commands if support else []
+        if PlayerCommand.VOLUME in commands and player.volume is None:
+            reasons.append("omitted volume despite declaring the volume command")
+        if PlayerCommand.MUTE in commands and player.muted is None:
+            reasons.append("omitted muted despite declaring the mute command")
+        return reasons
 
     def on_client_state(self, payload: ClientStatePayload) -> None:
         """Handle player-specific fields in client/state."""

--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -642,6 +642,9 @@ class PlayerV1Role(Role):
 
         # DEPRECATED(before-spec-pr-50): fall back to player.state for older clients.
         if payload.available is None and state.state is not None:
+            self._client.flag_noncompliance(
+                "client/state used legacy player.state instead of top-level available"
+            )
             create_task(
                 self._client.handle_availability_change(available=state.state != "external_source")
             )

--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -660,13 +660,18 @@ class PlayerV1Role(Role):
         if state is None:
             return
 
-        if payload.available is None and state.state is not None:
+        if state.state is not None:
             self._client.flag_noncompliance(
                 "client/state used legacy player.state instead of top-level available"
             )
-            create_task(
-                self._client.handle_availability_change(available=state.state != "external_source")
-            )
+            # Fall back to player.state for availability only when the compliant
+            # top-level field is absent.
+            if payload.available is None:
+                create_task(
+                    self._client.handle_availability_change(
+                        available=state.state != "external_source"
+                    )
+                )
 
         support = self._client.info.player_support
         changed = False

--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -640,7 +640,6 @@ class PlayerV1Role(Role):
         if state is None:
             return
 
-        # DEPRECATED(before-spec-pr-50): fall back to player.state for older clients.
         if payload.available is None and state.state is not None:
             self._client.flag_noncompliance(
                 "client/state used legacy player.state instead of top-level available"

--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -654,45 +654,50 @@ class PlayerV1Role(Role):
             reasons.append("omitted muted despite declaring the mute command")
         return reasons
 
+    def client_state_deviations(self, payload: ClientStatePayload) -> list[str]:
+        """Report player fields in a client/state that violate the spec."""
+        state = payload.player
+        if state is None:
+            return []
+        support = self._client.info.player_support
+        commands = support.supported_commands if support else []
+        reasons: list[str] = []
+        if state.state is not None:
+            reasons.append("used legacy player.state instead of top-level available")
+        if state.volume is not None and PlayerCommand.VOLUME not in commands:
+            reasons.append("sent volume without declaring the volume command")
+        if state.muted is not None and PlayerCommand.MUTE not in commands:
+            reasons.append("sent muted without declaring the mute command")
+        return reasons
+
     def on_client_state(self, payload: ClientStatePayload) -> None:
-        """Handle player-specific fields in client/state."""
+        """Apply player-specific fields from client/state (validation runs earlier)."""
         state = payload.player
         if state is None:
             return
 
-        if state.state is not None:
-            self._client.flag_noncompliance(
-                "client/state used legacy player.state instead of top-level available"
+        # Fall back to legacy player.state for availability only when the compliant
+        # top-level field is absent.
+        if state.state is not None and payload.available is None:
+            create_task(
+                self._client.handle_availability_change(available=state.state != "external_source")
             )
-            # Fall back to player.state for availability only when the compliant
-            # top-level field is absent.
-            if payload.available is None:
-                create_task(
-                    self._client.handle_availability_change(
-                        available=state.state != "external_source"
-                    )
-                )
 
         support = self._client.info.player_support
+        commands = support.supported_commands if support else []
         changed = False
 
-        if state.volume is not None:
-            if not support or PlayerCommand.VOLUME not in support.supported_commands:
-                self._client.flag_noncompliance(
-                    "client/state sent volume without declaring the volume command"
-                )
-            elif self.volume != state.volume:
-                self.volume = state.volume
-                changed = True
+        if (
+            state.volume is not None
+            and PlayerCommand.VOLUME in commands
+            and self.volume != state.volume
+        ):
+            self.volume = state.volume
+            changed = True
 
-        if state.muted is not None:
-            if not support or PlayerCommand.MUTE not in support.supported_commands:
-                self._client.flag_noncompliance(
-                    "client/state sent muted without declaring the mute command"
-                )
-            elif self.muted != state.muted:
-                self.muted = state.muted
-                changed = True
+        if state.muted is not None and PlayerCommand.MUTE in commands and self.muted != state.muted:
+            self.muted = state.muted
+            changed = True
 
         if changed:
             self.emit_client_event(VolumeChangedEvent(volume=self.volume, muted=self.muted))

--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -634,6 +634,19 @@ class PlayerV1Role(Role):
 
     # ---- Client message handling ----
 
+    def initial_state_deviations(self, payload: ClientStatePayload) -> list[str]:
+        """Report required player timing fields missing from the initial client/state."""
+        player = payload.player
+        if player is None:
+            return ["has an active player role but no player state"]
+        if (
+            player.static_delay_ms is None
+            or player.required_lead_time_ms is None
+            or player.min_buffer_ms is None
+        ):
+            return ["omitted required player timing fields"]
+        return []
+
     def on_client_state(self, payload: ClientStatePayload) -> None:
         """Handle player-specific fields in client/state."""
         state = payload.player

--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -673,8 +673,8 @@ class PlayerV1Role(Role):
 
         if state.volume is not None:
             if not support or PlayerCommand.VOLUME not in support.supported_commands:
-                self._client._logger.warning(  # noqa: SLF001
-                    "Client sent volume field without declaring 'volume' in supported_commands"
+                self._client.flag_noncompliance(
+                    "client/state sent volume without declaring the volume command"
                 )
             elif self.volume != state.volume:
                 self.volume = state.volume
@@ -682,8 +682,8 @@ class PlayerV1Role(Role):
 
         if state.muted is not None:
             if not support or PlayerCommand.MUTE not in support.supported_commands:
-                self._client._logger.warning(  # noqa: SLF001
-                    "Client sent muted field without declaring 'mute' in supported_commands"
+                self._client.flag_noncompliance(
+                    "client/state sent muted without declaring the mute command"
                 )
             elif self.muted != state.muted:
                 self.muted = state.muted

--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -698,25 +698,25 @@ class PlayerV1Role(Role):
         if player_req is None:
             return
 
-        invalid = [
-            name
-            for name, value in (
-                ("sample_rate", player_req.sample_rate),
-                ("channels", player_req.channels),
-                ("bit_depth", player_req.bit_depth),
-            )
-            if value is not None and value <= 0
-        ]
-        if invalid:
-            self._client.flag_noncompliance(
-                "stream/request-format player fields must be positive: " + ", ".join(invalid)
-            )
-
         support = self._client.info.player_support
         if support is None:
             raise ValueError(
                 f"Client {self._client.client_id} sent player format request "
                 "but has no player support"
+            )
+
+        # A requested format must be one the client declared in its hello
+        # supported_formats; only the fields the request actually carries are compared.
+        if not any(
+            (player_req.codec is None or fmt.codec == player_req.codec)
+            and (player_req.sample_rate is None or fmt.sample_rate == player_req.sample_rate)
+            and (player_req.bit_depth is None or fmt.bit_depth == player_req.bit_depth)
+            and (player_req.channels is None or fmt.channels == player_req.channels)
+            for fmt in support.supported_formats
+        ):
+            self._client.flag_noncompliance(
+                "stream/request-format requested a format not in the client's "
+                "declared supported_formats"
             )
 
         supported = filter_encodable_formats(support.supported_formats)

--- a/aiosendspin/server/roles/visualizer/v1.py
+++ b/aiosendspin/server/roles/visualizer/v1.py
@@ -655,7 +655,24 @@ class VisualizerV1Role(Role):
     def on_stream_request_format(self, payload: StreamRequestFormatPayload) -> None:
         """Apply mid-stream renegotiation. All v1 fields are optional and merged."""
         request = payload.visualizer
-        if request is None or self._stream_config is None or self._support is None:
+        if request is None:
+            return
+
+        invalid = [
+            name
+            for name, value in (
+                ("rate_max", request.rate_max),
+                ("buffer_capacity", request.buffer_capacity),
+            )
+            if value is not None and value <= 0
+        ]
+        if invalid:
+            self._client.flag_noncompliance(
+                "stream/request-format visualizer fields must be positive: " + ", ".join(invalid)
+            )
+            return
+
+        if self._stream_config is None or self._support is None:
             return
 
         # Build the merged payload as a plain dict so the support

--- a/aiosendspin/server/roles/visualizer/v1.py
+++ b/aiosendspin/server/roles/visualizer/v1.py
@@ -747,6 +747,20 @@ class VisualizerV1Role(Role):
                 self._client.client_id,
                 dropped,
             )
+        # `pitch` rides spec-reserved binary type 21, so a compliance-strict server
+        # drops it up front (not just from stream/start). A client left with no
+        # compliant type has no visualizer capability and gets no stream at all.
+        if not self._client._server.allow_noncompliant_clients:  # noqa: SLF001
+            compliant = [t for t in kept if t != "pitch"]
+            if not compliant:
+                _LOGGER.info(
+                    "client %s supports only the reserved 'pitch' visualizer type; not streaming",
+                    self._client.client_id,
+                )
+                self._support = None
+                self._stream_config = None
+                return
+            kept = compliant
         if not kept:
             _LOGGER.warning(
                 "client %s requested no implemented visualizer types; falling back to ['loudness']",

--- a/aiosendspin/server/roles/visualizer/v1.py
+++ b/aiosendspin/server/roles/visualizer/v1.py
@@ -244,6 +244,10 @@ class VisualizerV1Role(Role):
         else:
             self._buffer_tracker.capacity_bytes = capacity
 
+    def requires_initial_state(self) -> bool:
+        """Visualizer receives server binary, gated on the client's initial state."""
+        return True
+
     def on_connect(self) -> None:
         """Initialize stream config and subscribe to group role."""
         self._init_stream_config()

--- a/aiosendspin/server/roles/visualizer/v1.py
+++ b/aiosendspin/server/roles/visualizer/v1.py
@@ -786,9 +786,13 @@ class VisualizerV1Role(Role):
         else:
             exposed_types = [t for t in client_types if t != "beat"]
         # Server-wide pitch shed: drop the (heavy) pitch feature unless it is
-        # the only exposed type — `stream/start` must keep at least one, and we
-        # cannot add a type the client did not request.
-        if not self._client._server.visualizer_pitch_enabled:  # noqa: SLF001
+        # the only exposed type. stream/start must keep at least one, and we
+        # cannot add a type the client did not request. The pitch toggle is
+        # ignored when the server rejects non-compliant clients, since pitch
+        # rides spec-reserved binary type 21.
+        server = self._client._server  # noqa: SLF001
+        pitch_enabled = server.visualizer_pitch_enabled and server.allow_noncompliant_clients
+        if not pitch_enabled:
             without_pitch = [t for t in exposed_types if t != "pitch"]
             if without_pitch:
                 exposed_types = without_pitch

--- a/aiosendspin/server/roles/visualizer/v1.py
+++ b/aiosendspin/server/roles/visualizer/v1.py
@@ -658,6 +658,12 @@ class VisualizerV1Role(Role):
         if request is None:
             return
 
+        if request.buffer_capacity is not None:
+            # buffer_capacity is not a visualizer stream/request-format field per spec.
+            self._client.flag_noncompliance(
+                "stream/request-format set buffer_capacity, not a visualizer field here"
+            )
+
         invalid = [
             name
             for name, value in (

--- a/aiosendspin/server/server.py
+++ b/aiosendspin/server/server.py
@@ -124,6 +124,7 @@ class SendspinServer:
         *,
         pairing_store: ServerPairingStore,
         allow_unencrypted: bool = False,
+        strict_clients: bool = False,
         min_pin_length: int = DEFAULT_MIN_PIN_DIGITS,
         clock: Clock | None = None,
     ) -> None:
@@ -137,6 +138,7 @@ class SendspinServer:
         self._name = server_name
         self._pairing_store = pairing_store
         self._allow_unencrypted = allow_unencrypted
+        self._strict_clients = strict_clients
         self._min_pin_length = min_pin_length
         self._clock: Clock = clock or RawMonotonicClock()
 
@@ -216,6 +218,11 @@ class SendspinServer:
     def allow_unencrypted(self) -> bool:
         """Whether transition mode is enabled (accepts legacy unencrypted clients)."""
         return self._allow_unencrypted
+
+    @property
+    def strict_clients(self) -> bool:
+        """Whether non-spec-compliant clients are rejected instead of tolerated."""
+        return self._strict_clients
 
     @property
     def name(self) -> str:

--- a/aiosendspin/server/server.py
+++ b/aiosendspin/server/server.py
@@ -128,7 +128,22 @@ class SendspinServer:
         min_pin_length: int = DEFAULT_MIN_PIN_DIGITS,
         clock: Clock | None = None,
     ) -> None:
-        """Initialize a Sendspin server instance."""
+        """Initialize a Sendspin server instance.
+
+        Args:
+            loop: Event loop the server runs on.
+            identity: The server's long-term Noise identity.
+            server_name: Human-readable name advertised to clients.
+            client_session: Shared aiohttp session, or None to create and own one.
+            pairing_store: Persistent store for pairing records and config.
+            allow_unencrypted: Accept legacy unencrypted clients (transition mode).
+            allow_noncompliant_clients: Tolerate and log deviations from clients
+                built against pre-1.0 spec drafts when True, reject the client when
+                False. Tolerance is transitional and will be removed in a future
+                version.
+            min_pin_length: Minimum dynamic-PIN length the server accepts.
+            clock: Clock source, or None for the default monotonic clock.
+        """
         if not MIN_PIN_DIGITS <= min_pin_length <= MAX_PIN_DIGITS:
             msg = f"min_pin_length must be in [{MIN_PIN_DIGITS}, {MAX_PIN_DIGITS}]"
             raise ValueError(msg)

--- a/aiosendspin/server/server.py
+++ b/aiosendspin/server/server.py
@@ -271,10 +271,12 @@ class SendspinServer:
     def set_visualizer_pitch_enabled(self, *, enabled: bool) -> None:
         """Enable or disable the visualizer `pitch` feature server-wide.
 
-        Enabling is technically non-compliant: `pitch` uses reserved binary type
-        21, which the spec says must not be used. It stays available as an opt-in
-        extension. Pitch (YINFFT) is also the heaviest per-frame visualizer
-        computation, so leaving it off sheds that cost on constrained hardware.
+        This option is ignored while `allow_noncompliant_clients` is False: `pitch`
+        uses reserved binary type 21, which the spec forbids, so a compliance-strict
+        server never emits it regardless of this toggle. It otherwise stays available
+        as an opt-in extension. Pitch (YINFFT) is also the heaviest per-frame
+        visualizer computation, so leaving it off sheds that cost on constrained
+        hardware.
         Toggling drops/adds `pitch` on live roles' negotiated types and re-emits
         `stream/start`; new roles pick the setting up when they connect.
         """

--- a/aiosendspin/server/server.py
+++ b/aiosendspin/server/server.py
@@ -124,7 +124,7 @@ class SendspinServer:
         *,
         pairing_store: ServerPairingStore,
         allow_unencrypted: bool = False,
-        strict_clients: bool = False,
+        allow_noncompliant_clients: bool = True,
         min_pin_length: int = DEFAULT_MIN_PIN_DIGITS,
         clock: Clock | None = None,
     ) -> None:
@@ -138,7 +138,7 @@ class SendspinServer:
         self._name = server_name
         self._pairing_store = pairing_store
         self._allow_unencrypted = allow_unencrypted
-        self._strict_clients = strict_clients
+        self._allow_noncompliant_clients = allow_noncompliant_clients
         self._min_pin_length = min_pin_length
         self._clock: Clock = clock or RawMonotonicClock()
 
@@ -220,9 +220,9 @@ class SendspinServer:
         return self._allow_unencrypted
 
     @property
-    def strict_clients(self) -> bool:
-        """Whether non-spec-compliant clients are rejected instead of tolerated."""
-        return self._strict_clients
+    def allow_noncompliant_clients(self) -> bool:
+        """Whether non-spec-compliant clients are tolerated instead of rejected."""
+        return self._allow_noncompliant_clients
 
     @property
     def name(self) -> str:

--- a/tests/models/test_client_state_available.py
+++ b/tests/models/test_client_state_available.py
@@ -33,3 +33,15 @@ def test_new_available_wins_over_legacy_state_on_wire() -> None:
     """When both are present on the wire, `available` is authoritative."""
     payload = ClientStatePayload.from_dict({"available": True, "state": "external_source"})
     assert payload.available is True
+
+
+def test_legacy_state_presence_is_recorded() -> None:
+    """A top-level `state` field is recorded even when `available` is also present."""
+    payload = ClientStatePayload.from_dict({"available": True, "state": "synchronized"})
+    assert payload.legacy_state_used is True
+
+
+def test_compliant_state_records_no_legacy_use() -> None:
+    """A client/state without `state` records nothing, even if it spoofs the field."""
+    payload = ClientStatePayload.from_dict({"available": True, "legacy_state_used": True})
+    assert payload.legacy_state_used is None

--- a/tests/server/roles/artwork/test_v1.py
+++ b/tests/server/roles/artwork/test_v1.py
@@ -53,6 +53,30 @@ def test_artwork_role_has_role_id() -> None:
     assert role.role_id == "artwork@v1"
 
 
+def test_artwork_role_flags_nonpositive_request_dimensions() -> None:
+    """A stream/request-format with non-positive dimensions is flagged, not applied."""
+    client = _make_client_stub_with_channel()
+    role = ArtworkV1Role(client=client)
+    role.on_connect()
+    role.on_stream_request_format(
+        StreamRequestFormatPayload(artwork=StreamRequestFormatArtwork(channel=0, media_width=-10))
+    )
+    client.flag_noncompliance.assert_called_once()
+
+
+def test_artwork_role_no_flag_for_valid_request_dimensions() -> None:
+    """A stream/request-format with positive dimensions is not flagged."""
+    client = _make_client_stub_with_channel()
+    role = ArtworkV1Role(client=client)
+    role.on_connect()
+    role.on_stream_request_format(
+        StreamRequestFormatPayload(
+            artwork=StreamRequestFormatArtwork(channel=0, media_width=100, media_height=100)
+        )
+    )
+    client.flag_noncompliance.assert_not_called()
+
+
 def test_artwork_role_has_role_family() -> None:
     """ArtworkV1Role has role_family of 'artwork'."""
     client = _make_client_stub()

--- a/tests/server/roles/artwork/test_v1.py
+++ b/tests/server/roles/artwork/test_v1.py
@@ -77,6 +77,17 @@ def test_artwork_role_no_flag_for_valid_request_dimensions() -> None:
     client.flag_noncompliance.assert_not_called()
 
 
+def test_artwork_role_flags_unknown_request_channel() -> None:
+    """A stream/request-format for a channel with no config is flagged."""
+    client = _make_client_stub_with_channel()
+    role = ArtworkV1Role(client=client)
+    role.on_connect()
+    role.on_stream_request_format(
+        StreamRequestFormatPayload(artwork=StreamRequestFormatArtwork(channel=1))
+    )
+    client.flag_noncompliance.assert_called_once()
+
+
 def test_artwork_role_has_role_family() -> None:
     """ArtworkV1Role has role_family of 'artwork'."""
     client = _make_client_stub()

--- a/tests/server/roles/test_player_v1.py
+++ b/tests/server/roles/test_player_v1.py
@@ -83,6 +83,28 @@ async def test_player_role_no_flag_when_available_present() -> None:
     client.flag_noncompliance.assert_not_called()
 
 
+def test_player_role_initial_state_deviations_flags_missing_timing() -> None:
+    """A player initial state without the required timing fields is reported incomplete."""
+    role = PlayerV1Role(client=_make_client_stub())
+    assert role.initial_state_deviations(ClientStatePayload(available=True)) != []
+    assert (
+        role.initial_state_deviations(
+            ClientStatePayload(available=True, player=PlayerStatePayload(volume=50))
+        )
+        != []
+    )
+
+
+def test_player_role_initial_state_deviations_accepts_complete_timing() -> None:
+    """A player initial state with all required timing fields is accepted."""
+    role = PlayerV1Role(client=_make_client_stub())
+    payload = ClientStatePayload(
+        available=True,
+        player=PlayerStatePayload(static_delay_ms=0, required_lead_time_ms=100, min_buffer_ms=200),
+    )
+    assert role.initial_state_deviations(payload) == []
+
+
 def _stub_with_player_support() -> MagicMock:
     client = _make_client_stub()
     client.info.player_support = ClientHelloPlayerSupport(

--- a/tests/server/roles/test_player_v1.py
+++ b/tests/server/roles/test_player_v1.py
@@ -83,6 +83,19 @@ async def test_player_role_no_flag_when_available_present() -> None:
     client.flag_noncompliance.assert_not_called()
 
 
+@pytest.mark.asyncio
+async def test_player_role_flags_player_state_even_when_available_present() -> None:
+    """A nested legacy player.state is flagged even when top-level available is present."""
+    client = _make_client_stub()
+    client.handle_availability_change = AsyncMock()
+    role = PlayerV1Role(client=client)
+    role.on_client_state(
+        ClientStatePayload(available=True, player=PlayerStatePayload(state="synchronized"))
+    )
+    client.flag_noncompliance.assert_called_once()
+    client.handle_availability_change.assert_not_called()
+
+
 def test_player_role_initial_state_deviations_flags_missing_player_object() -> None:
     """An active player whose initial state carries no player object is reported incomplete."""
     role = PlayerV1Role(client=_make_client_stub())

--- a/tests/server/roles/test_player_v1.py
+++ b/tests/server/roles/test_player_v1.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
+
+import pytest
 
 from aiosendspin.models import AudioCodec, unpack_binary_header
 from aiosendspin.models.core import (
@@ -57,6 +59,26 @@ def test_player_role_has_role_id() -> None:
     client = _make_client_stub()
     role = PlayerV1Role(client=client)
     assert role.role_id == "player@v1"
+
+
+@pytest.mark.asyncio
+async def test_player_role_flags_legacy_state_fallback() -> None:
+    """A client/state with no top-level `available` but a legacy player.state is flagged."""
+    client = _make_client_stub()
+    client.handle_availability_change = AsyncMock()
+    role = PlayerV1Role(client=client)
+    role.on_client_state(ClientStatePayload(player=PlayerStatePayload(state="synchronized")))
+    client.flag_noncompliance.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_player_role_no_flag_when_available_present() -> None:
+    """A spec-compliant client/state carrying `available` is not flagged."""
+    client = _make_client_stub()
+    client.handle_availability_change = AsyncMock()
+    role = PlayerV1Role(client=client)
+    role.on_client_state(ClientStatePayload(available=True, player=PlayerStatePayload()))
+    client.flag_noncompliance.assert_not_called()
 
 
 def test_player_role_has_role_family() -> None:

--- a/tests/server/roles/test_player_v1.py
+++ b/tests/server/roles/test_player_v1.py
@@ -83,10 +83,15 @@ async def test_player_role_no_flag_when_available_present() -> None:
     client.flag_noncompliance.assert_not_called()
 
 
-def test_player_role_initial_state_deviations_flags_missing_timing() -> None:
-    """A player initial state without the required timing fields is reported incomplete."""
+def test_player_role_initial_state_deviations_flags_missing_player_object() -> None:
+    """An active player whose initial state carries no player object is reported incomplete."""
     role = PlayerV1Role(client=_make_client_stub())
     assert role.initial_state_deviations(ClientStatePayload(available=True)) != []
+
+
+def test_player_role_initial_state_deviations_flags_missing_timing() -> None:
+    """A player object present but missing the required timing fields is reported incomplete."""
+    role = PlayerV1Role(client=_make_client_stub())
     assert (
         role.initial_state_deviations(
             ClientStatePayload(available=True, player=PlayerStatePayload(volume=50))

--- a/tests/server/roles/test_player_v1.py
+++ b/tests/server/roles/test_player_v1.py
@@ -95,18 +95,18 @@ def _stub_with_player_support() -> MagicMock:
     return client
 
 
-def test_player_role_flags_nonpositive_format_request() -> None:
-    """A stream/request-format with a non-positive numeric field is flagged."""
+def test_player_role_flags_undeclared_format_request() -> None:
+    """A request for a format not in the client's declared supported_formats is flagged."""
     client = _stub_with_player_support()
     role = PlayerV1Role(client=client)
     role.on_stream_request_format(
-        StreamRequestFormatPayload(player=StreamRequestFormatPlayer(sample_rate=-1))
+        StreamRequestFormatPayload(player=StreamRequestFormatPlayer(sample_rate=96000))
     )
     client.flag_noncompliance.assert_called_once()
 
 
-def test_player_role_no_flag_for_valid_format_request() -> None:
-    """A stream/request-format with positive fields is not flagged."""
+def test_player_role_no_flag_for_declared_format_request() -> None:
+    """A request matching a declared supported_format is not flagged."""
     client = _stub_with_player_support()
     role = PlayerV1Role(client=client)
     role.on_stream_request_format(

--- a/tests/server/roles/test_player_v1.py
+++ b/tests/server/roles/test_player_v1.py
@@ -168,6 +168,22 @@ def test_player_role_no_flag_for_declared_format_request() -> None:
     client.flag_noncompliance.assert_not_called()
 
 
+def test_player_role_flags_volume_without_declared_support() -> None:
+    """A volume field sent with no declared volume command is flagged."""
+    client = _make_client_stub()  # player_support is None
+    role = PlayerV1Role(client=client)
+    role.on_client_state(ClientStatePayload(available=True, player=PlayerStatePayload(volume=50)))
+    client.flag_noncompliance.assert_called_once()
+
+
+def test_player_role_flags_muted_without_declared_support() -> None:
+    """A muted field sent with no declared mute command is flagged."""
+    client = _make_client_stub()  # player_support is None
+    role = PlayerV1Role(client=client)
+    role.on_client_state(ClientStatePayload(available=True, player=PlayerStatePayload(muted=True)))
+    client.flag_noncompliance.assert_called_once()
+
+
 def test_player_role_has_role_family() -> None:
     """PlayerV1Role has role_family of 'player'."""
     client = _make_client_stub()

--- a/tests/server/roles/test_player_v1.py
+++ b/tests/server/roles/test_player_v1.py
@@ -12,11 +12,13 @@ from aiosendspin.models.core import (
     ClientStatePayload,
     StreamClearMessage,
     StreamEndMessage,
+    StreamRequestFormatPayload,
     StreamStartMessage,
 )
 from aiosendspin.models.player import (
     ClientHelloPlayerSupport,
     PlayerStatePayload,
+    StreamRequestFormatPlayer,
     SupportedAudioFormat,
 )
 from aiosendspin.models.types import BinaryMessageType, PlayerCommand
@@ -78,6 +80,38 @@ async def test_player_role_no_flag_when_available_present() -> None:
     client.handle_availability_change = AsyncMock()
     role = PlayerV1Role(client=client)
     role.on_client_state(ClientStatePayload(available=True, player=PlayerStatePayload()))
+    client.flag_noncompliance.assert_not_called()
+
+
+def _stub_with_player_support() -> MagicMock:
+    client = _make_client_stub()
+    client.info.player_support = ClientHelloPlayerSupport(
+        supported_formats=[
+            SupportedAudioFormat(codec=AudioCodec.PCM, channels=2, sample_rate=48000, bit_depth=16)
+        ],
+        buffer_capacity=100_000,
+        supported_commands=[],
+    )
+    return client
+
+
+def test_player_role_flags_nonpositive_format_request() -> None:
+    """A stream/request-format with a non-positive numeric field is flagged."""
+    client = _stub_with_player_support()
+    role = PlayerV1Role(client=client)
+    role.on_stream_request_format(
+        StreamRequestFormatPayload(player=StreamRequestFormatPlayer(sample_rate=-1))
+    )
+    client.flag_noncompliance.assert_called_once()
+
+
+def test_player_role_no_flag_for_valid_format_request() -> None:
+    """A stream/request-format with positive fields is not flagged."""
+    client = _stub_with_player_support()
+    role = PlayerV1Role(client=client)
+    role.on_stream_request_format(
+        StreamRequestFormatPayload(player=StreamRequestFormatPlayer(sample_rate=48000))
+    )
     client.flag_noncompliance.assert_not_called()
 
 

--- a/tests/server/roles/test_player_v1.py
+++ b/tests/server/roles/test_player_v1.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
@@ -63,36 +64,45 @@ def test_player_role_has_role_id() -> None:
     assert role.role_id == "player@v1"
 
 
+def test_player_client_state_deviations_flags_legacy_player_state() -> None:
+    """A nested legacy player.state is a deviation even when available is present."""
+    role = PlayerV1Role(client=_make_client_stub())
+    reasons = role.client_state_deviations(
+        ClientStatePayload(available=True, player=PlayerStatePayload(state="synchronized"))
+    )
+    assert any("player.state" in r for r in reasons)
+
+
+def test_player_client_state_deviations_accepts_compliant_state() -> None:
+    """A compliant client/state carrying `available` reports no deviations."""
+    role = PlayerV1Role(client=_make_client_stub())
+    deviations = role.client_state_deviations(
+        ClientStatePayload(available=True, player=PlayerStatePayload())
+    )
+    assert deviations == []
+
+
 @pytest.mark.asyncio
-async def test_player_role_flags_legacy_state_fallback() -> None:
-    """A client/state with no top-level `available` but a legacy player.state is flagged."""
+async def test_player_on_client_state_uses_legacy_state_when_available_absent() -> None:
+    """on_client_state derives availability from legacy player.state when available is absent."""
     client = _make_client_stub()
     client.handle_availability_change = AsyncMock()
     role = PlayerV1Role(client=client)
-    role.on_client_state(ClientStatePayload(player=PlayerStatePayload(state="synchronized")))
-    client.flag_noncompliance.assert_called_once()
+    role.on_client_state(ClientStatePayload(player=PlayerStatePayload(state="external_source")))
+    await asyncio.sleep(0)
+    client.handle_availability_change.assert_awaited_once_with(available=False)
 
 
 @pytest.mark.asyncio
-async def test_player_role_no_flag_when_available_present() -> None:
-    """A spec-compliant client/state carrying `available` is not flagged."""
-    client = _make_client_stub()
-    client.handle_availability_change = AsyncMock()
-    role = PlayerV1Role(client=client)
-    role.on_client_state(ClientStatePayload(available=True, player=PlayerStatePayload()))
-    client.flag_noncompliance.assert_not_called()
-
-
-@pytest.mark.asyncio
-async def test_player_role_flags_player_state_even_when_available_present() -> None:
-    """A nested legacy player.state is flagged even when top-level available is present."""
+async def test_player_on_client_state_ignores_legacy_state_when_available_present() -> None:
+    """on_client_state does not derive availability from player.state when available is present."""
     client = _make_client_stub()
     client.handle_availability_change = AsyncMock()
     role = PlayerV1Role(client=client)
     role.on_client_state(
         ClientStatePayload(available=True, player=PlayerStatePayload(state="synchronized"))
     )
-    client.flag_noncompliance.assert_called_once()
+    await asyncio.sleep(0)
     client.handle_availability_change.assert_not_called()
 
 
@@ -182,19 +192,21 @@ def test_player_role_no_flag_for_declared_format_request() -> None:
 
 
 def test_player_role_flags_volume_without_declared_support() -> None:
-    """A volume field sent with no declared volume command is flagged."""
-    client = _make_client_stub()  # player_support is None
-    role = PlayerV1Role(client=client)
-    role.on_client_state(ClientStatePayload(available=True, player=PlayerStatePayload(volume=50)))
-    client.flag_noncompliance.assert_called_once()
+    """A volume field sent with no declared volume command is a deviation."""
+    role = PlayerV1Role(client=_make_client_stub())  # player_support is None
+    reasons = role.client_state_deviations(
+        ClientStatePayload(available=True, player=PlayerStatePayload(volume=50))
+    )
+    assert any("volume" in r for r in reasons)
 
 
 def test_player_role_flags_muted_without_declared_support() -> None:
-    """A muted field sent with no declared mute command is flagged."""
-    client = _make_client_stub()  # player_support is None
-    role = PlayerV1Role(client=client)
-    role.on_client_state(ClientStatePayload(available=True, player=PlayerStatePayload(muted=True)))
-    client.flag_noncompliance.assert_called_once()
+    """A muted field sent with no declared mute command is a deviation."""
+    role = PlayerV1Role(client=_make_client_stub())  # player_support is None
+    reasons = role.client_state_deviations(
+        ClientStatePayload(available=True, player=PlayerStatePayload(muted=True))
+    )
+    assert any("muted" in r for r in reasons)
 
 
 def test_player_role_has_role_family() -> None:

--- a/tests/server/roles/test_player_v1.py
+++ b/tests/server/roles/test_player_v1.py
@@ -110,16 +110,42 @@ def test_player_role_initial_state_deviations_accepts_complete_timing() -> None:
     assert role.initial_state_deviations(payload) == []
 
 
-def _stub_with_player_support() -> MagicMock:
+def _stub_with_player_support(*commands: PlayerCommand) -> MagicMock:
     client = _make_client_stub()
     client.info.player_support = ClientHelloPlayerSupport(
         supported_formats=[
             SupportedAudioFormat(codec=AudioCodec.PCM, channels=2, sample_rate=48000, bit_depth=16)
         ],
         buffer_capacity=100_000,
-        supported_commands=[],
+        supported_commands=list(commands),
     )
     return client
+
+
+def _complete_timing_state(**overrides: object) -> ClientStatePayload:
+    fields = {"static_delay_ms": 0, "required_lead_time_ms": 100, "min_buffer_ms": 200}
+    fields.update(overrides)
+    return ClientStatePayload(available=True, player=PlayerStatePayload(**fields))  # type: ignore[arg-type]
+
+
+def test_player_role_initial_state_deviations_flags_missing_volume() -> None:
+    """A player that declared the volume command but omits volume is reported incomplete."""
+    role = PlayerV1Role(client=_stub_with_player_support(PlayerCommand.VOLUME))
+    reasons = role.initial_state_deviations(_complete_timing_state())
+    assert any("volume" in r for r in reasons)
+
+
+def test_player_role_initial_state_deviations_flags_missing_muted() -> None:
+    """A player that declared the mute command but omits muted is reported incomplete."""
+    role = PlayerV1Role(client=_stub_with_player_support(PlayerCommand.MUTE))
+    reasons = role.initial_state_deviations(_complete_timing_state())
+    assert any("muted" in r for r in reasons)
+
+
+def test_player_role_initial_state_deviations_accepts_declared_commands_reported() -> None:
+    """Declared volume/mute commands with their values present are accepted."""
+    role = PlayerV1Role(client=_stub_with_player_support(PlayerCommand.VOLUME, PlayerCommand.MUTE))
+    assert role.initial_state_deviations(_complete_timing_state(volume=50, muted=False)) == []
 
 
 def test_player_role_flags_undeclared_format_request() -> None:

--- a/tests/server/roles/test_role_negotiation_custom.py
+++ b/tests/server/roles/test_role_negotiation_custom.py
@@ -38,6 +38,23 @@ def test_negotiate_orders_player_before_controller() -> None:
     assert active == ["player@v1", "controller@v1"]
 
 
+def test_negotiate_activates_draft_visualizer_by_default() -> None:
+    """The legacy visualizer@_draft_r1 wire is negotiated in the default (lenient) mode."""
+    assert negotiate_roles(["visualizer@_draft_r1"]) == ["visualizer@_draft_r1"]
+
+
+def test_strict_excludes_draft_visualizer() -> None:
+    """Under strict, the legacy draft wire is skipped and not activated."""
+    assert negotiate_roles(["visualizer@_draft_r1"], strict=True) == []
+
+
+def test_strict_falls_back_to_v1_visualizer() -> None:
+    """Under strict, a client offering both draft and v1 gets v1 for the family."""
+    assert negotiate_roles(["visualizer@_draft_r1", "visualizer@v1"], strict=True) == [
+        "visualizer@v1"
+    ]
+
+
 def test_negotiate_orders_player_before_controller_with_metadata() -> None:
     """Player before controller even when other families are present."""
     active = negotiate_roles(["metadata@v1", "controller@v1", "player@v1"])

--- a/tests/server/roles/visualizer/test_v1.py
+++ b/tests/server/roles/visualizer/test_v1.py
@@ -1155,6 +1155,24 @@ def test_pitch_kept_when_sole_type_even_if_disabled() -> None:
     assert _last_stream_start(client).payload.visualizer.types == ("pitch",)
 
 
+def test_pitch_only_client_is_inert_when_clients_must_be_compliant() -> None:
+    """A pitch-only client has no compliant visualizer capability in strict mode."""
+    client = _make_client_stub()
+    client.info.visualizer_support = {
+        "types": ["pitch"],
+        "buffer_capacity": 65536,
+        "rate_max": 60,
+    }
+    client._server.allow_noncompliant_clients = False  # noqa: SLF001
+    role = VisualizerV1Role(client)
+    role.on_connect()
+    role.on_stream_start()
+    assert role._stream_config is None  # noqa: SLF001
+    client.send_binary.reset_mock()
+    role.on_audio_chunk(_audio_chunk(timestamp_us=1_000_000))
+    client.send_binary.assert_not_called()
+
+
 def test_refresh_pitch_setting_reissues_stream_start_on_change() -> None:
     """Flipping the server flag live re-emits stream/start without pitch."""
     client = _make_pitch_client_stub()

--- a/tests/server/roles/visualizer/test_v1.py
+++ b/tests/server/roles/visualizer/test_v1.py
@@ -144,6 +144,16 @@ def test_visualizer_role_no_flag_for_valid_request_fields() -> None:
     client.flag_noncompliance.assert_not_called()
 
 
+def test_visualizer_role_flags_request_buffer_capacity() -> None:
+    """buffer_capacity is not a visualizer stream/request-format field and is flagged."""
+    client = _make_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_stream_request_format(
+        StreamRequestFormatPayload(visualizer=StreamRequestFormatVisualizer(buffer_capacity=32_768))
+    )
+    client.flag_noncompliance.assert_called_once()
+
+
 def test_on_connect_subscribes_to_group_role() -> None:
     """On connect subscribes to group role."""
     client = _make_client_stub()

--- a/tests/server/roles/visualizer/test_v1.py
+++ b/tests/server/roles/visualizer/test_v1.py
@@ -1114,6 +1114,19 @@ def test_pitch_dropped_when_server_disabled() -> None:
     assert "loudness" in types
 
 
+def test_pitch_dropped_when_clients_must_be_compliant() -> None:
+    """The pitch toggle is ignored (pitch shed) when non-compliant clients are disallowed."""
+    client = _make_pitch_client_stub()
+    client._server.visualizer_pitch_enabled = True  # noqa: SLF001
+    client._server.allow_noncompliant_clients = False  # noqa: SLF001
+    role = VisualizerV1Role(client)
+    role.on_connect()
+    role.on_stream_start()
+    types = _last_stream_start(client).payload.visualizer.types
+    assert "pitch" not in types
+    assert "loudness" in types
+
+
 def test_disabled_pitch_emits_no_pitch_binary() -> None:
     """With pitch disabled, no PITCH binary is produced from an audio chunk."""
     client = _make_pitch_client_stub()

--- a/tests/server/roles/visualizer/test_v1.py
+++ b/tests/server/roles/visualizer/test_v1.py
@@ -124,6 +124,26 @@ def test_role_id_is_v1() -> None:
     assert role.role_family == "visualizer"
 
 
+def test_visualizer_role_flags_nonpositive_request_fields() -> None:
+    """A stream/request-format with a non-positive field is flagged."""
+    client = _make_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_stream_request_format(
+        StreamRequestFormatPayload(visualizer=StreamRequestFormatVisualizer(rate_max=0))
+    )
+    client.flag_noncompliance.assert_called_once()
+
+
+def test_visualizer_role_no_flag_for_valid_request_fields() -> None:
+    """A stream/request-format with positive fields is not flagged."""
+    client = _make_client_stub()
+    role = VisualizerV1Role(client=client)
+    role.on_stream_request_format(
+        StreamRequestFormatPayload(visualizer=StreamRequestFormatVisualizer(rate_max=30))
+    )
+    client.flag_noncompliance.assert_not_called()
+
+
 def test_on_connect_subscribes_to_group_role() -> None:
     """On connect subscribes to group role."""
     client = _make_client_stub()

--- a/tests/server/test_buffer_registration_timing.py
+++ b/tests/server/test_buffer_registration_timing.py
@@ -54,7 +54,7 @@ class _DummyGroup:
 
 
 @pytest.mark.asyncio
-async def test_buffer_tracker_does_not_backpressure_until_send() -> None:
+async def test_buffer_tracker_does_not_backpressure_until_send() -> None:  # noqa: PLR0915
     """
     Backpressure must reflect bytes that have actually left the server.
 
@@ -78,6 +78,8 @@ async def test_buffer_tracker_does_not_backpressure_until_send() -> None:
     conn = SendspinConnection(server, wsock_client=wsock)
     conn._transport = wsock  # noqa: SLF001
     await conn._setup_connection()  # noqa: SLF001
+    # Streaming player: initial state already received.
+    conn._initial_state_received = True  # noqa: SLF001
     conn._writer_task = asyncio.create_task(conn._writer())  # noqa: SLF001
 
     group = _DummyGroup(clients=[])

--- a/tests/server/test_client_state_dispatch.py
+++ b/tests/server/test_client_state_dispatch.py
@@ -143,6 +143,24 @@ def _role(family: str) -> MagicMock:
 
 
 @pytest.mark.asyncio
+async def test_binary_is_held_until_initial_state() -> None:
+    """Binary enqueued before the initial client/state is buffered, then flushed on arrival."""
+    conn, client = _conn_with_client()
+    role = _role("artwork")
+    role.requires_initial_state.return_value = True
+    client.active_roles = [role]
+
+    conn.send_binary(b"snapshot", role="artwork", timestamp_us=0, message_type=30)
+    assert not conn._role_queues.get("artwork")  # nothing on the wire yet  # noqa: SLF001
+    assert len(conn._pending_binary) == 1  # noqa: SLF001
+
+    conn._initial_state_received = True  # noqa: SLF001
+    conn._flush_pending_binary()  # noqa: SLF001
+    assert conn._pending_binary == []  # noqa: SLF001
+    assert conn._role_queues.get("artwork")  # now enqueued  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_client_state_player_object_for_inactive_role_is_flagged() -> None:
     """A player state object with no active player role is flagged."""
     conn, client = _conn_with_client()

--- a/tests/server/test_client_state_dispatch.py
+++ b/tests/server/test_client_state_dispatch.py
@@ -161,6 +161,23 @@ async def test_binary_is_held_until_initial_state() -> None:
 
 
 @pytest.mark.asyncio
+async def test_pending_binary_dropped_when_stream_boundary_intervenes() -> None:
+    """A stream boundary during the wait bumps the epoch and discards stale buffered binary."""
+    conn, client = _conn_with_client()
+    role = _role("artwork")
+    role.requires_initial_state.return_value = True
+    client.active_roles = [role]
+
+    conn.send_binary(b"snapshot", role="artwork", timestamp_us=0, message_type=30)
+    assert len(conn._pending_binary) == 1  # noqa: SLF001
+
+    conn.drop_pending_binary(["artwork"])  # stream/clear or stream/end bumps the epoch
+    conn._initial_state_received = True  # noqa: SLF001
+    conn._flush_pending_binary()  # noqa: SLF001
+    assert not conn._role_queues.get("artwork")  # stale binary not replayed  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_client_state_player_object_for_inactive_role_is_flagged() -> None:
     """A player state object with no active player role is flagged."""
     conn, client = _conn_with_client()

--- a/tests/server/test_client_state_dispatch.py
+++ b/tests/server/test_client_state_dispatch.py
@@ -204,3 +204,20 @@ async def test_strict_rejection_applies_no_side_effects() -> None:
         )
     client.mark_connected.assert_not_called()
     client.handle_availability_change.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_role_client_state_deviation_flagged_before_side_effects() -> None:
+    """A role's client/state deviation is flagged before availability is applied."""
+    conn, client = _conn_with_client()
+    conn._initial_state_received = True  # noqa: SLF001
+    client.flag_noncompliance.side_effect = ClientComplianceError("nope")
+    client.handle_availability_change = AsyncMock()
+    role = _role("player")
+    role.client_state_deviations.return_value = ["used legacy player.state"]
+    client.active_roles = [role]
+    with pytest.raises(ClientComplianceError):
+        await conn._handle_message(  # noqa: SLF001
+            ClientStateMessage(payload=ClientStatePayload(available=False)), timestamp_us=0
+        )
+    client.handle_availability_change.assert_not_called()

--- a/tests/server/test_client_state_dispatch.py
+++ b/tests/server/test_client_state_dispatch.py
@@ -18,6 +18,7 @@ from aiosendspin.models.core import (
 from aiosendspin.models.management import ManagementResultMessage, ManagementResultPayload
 from aiosendspin.models.types import ManagementResult
 from aiosendspin.server.clock import LoopClock
+from aiosendspin.server.compliance import ClientComplianceError
 from aiosendspin.server.connection import SendspinConnection
 
 
@@ -27,6 +28,9 @@ class _DummyServer:
     clock: Any
     id: str = "srv"
     name: str = "server"
+
+    def on_client_first_connect(self, client_id: str) -> None:
+        """No-op: the dispatch tests don't exercise first-connect side effects."""
 
 
 @pytest.mark.asyncio
@@ -108,3 +112,24 @@ async def test_initial_state_complete_state_is_not_flagged() -> None:
     client.active_roles = [_role_mock([])]
     conn._flag_initial_state_deviations(ClientStatePayload(available=True))  # noqa: SLF001
     client.flag_noncompliance.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_missing_initial_state_rejects_when_flagged() -> None:
+    """A never-sent initial state hard-disconnects when the flag raises."""
+    conn, client = _conn_with_client()
+    client.flag_noncompliance.side_effect = ClientComplianceError("nope")
+    conn.disconnect = AsyncMock()  # type: ignore[method-assign]
+    conn._initial_state_timeout_callback()  # noqa: SLF001
+    await asyncio.sleep(0)
+    conn.disconnect.assert_awaited_once_with(retry_connection=False)
+    client.mark_connected.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_missing_initial_state_marks_connected_when_lenient() -> None:
+    """A never-sent initial state is tolerated: the client is marked connected."""
+    conn, client = _conn_with_client()
+    conn._initial_state_timeout_callback()  # noqa: SLF001
+    assert conn._initial_state_received is True  # noqa: SLF001
+    client.mark_connected.assert_called_once()

--- a/tests/server/test_client_state_dispatch.py
+++ b/tests/server/test_client_state_dispatch.py
@@ -16,7 +16,6 @@ from aiosendspin.models.core import (
     ClientStatePayload,
 )
 from aiosendspin.models.management import ManagementResultMessage, ManagementResultPayload
-from aiosendspin.models.player import PlayerStatePayload
 from aiosendspin.models.types import ManagementResult
 from aiosendspin.server.clock import LoopClock
 from aiosendspin.server.connection import SendspinConnection
@@ -85,29 +84,27 @@ async def test_unsolicited_management_result_is_flagged() -> None:
     client.flag_noncompliance.assert_called_once()
 
 
-def _player_role_mock() -> MagicMock:
+def _role_mock(deviations: list[str]) -> MagicMock:
     role = MagicMock()
-    role.role_family = "player"
+    role.initial_state_deviations.return_value = deviations
     return role
 
 
 @pytest.mark.asyncio
-async def test_initial_state_deviations_flags_incomplete_player_state() -> None:
-    """An empty initial client/state for a player is flagged as incomplete."""
+async def test_initial_state_flags_missing_available_and_role_reasons() -> None:
+    """Missing `available` plus each active role's own deviations are each flagged."""
     conn, client = _conn_with_client()
-    client.active_roles = [_player_role_mock()]
-    reasons = conn._initial_state_deviations(ClientStatePayload())  # noqa: SLF001
-    assert any("available" in r for r in reasons)
-    assert any("player" in r for r in reasons)
+    client.active_roles = [_role_mock(["role-specific problem"])]
+    conn._flag_initial_state_deviations(ClientStatePayload())  # noqa: SLF001
+    flagged = [call.args[0] for call in client.flag_noncompliance.call_args_list]
+    assert any("available" in r for r in flagged)
+    assert any("role-specific problem" in r for r in flagged)
 
 
 @pytest.mark.asyncio
-async def test_initial_state_deviations_accepts_complete_player_state() -> None:
-    """A complete initial client/state for a player yields no deviations."""
+async def test_initial_state_complete_state_is_not_flagged() -> None:
+    """A complete initial client/state with compliant roles is not flagged."""
     conn, client = _conn_with_client()
-    client.active_roles = [_player_role_mock()]
-    payload = ClientStatePayload(
-        available=True,
-        player=PlayerStatePayload(static_delay_ms=0, required_lead_time_ms=100, min_buffer_ms=200),
-    )
-    assert conn._initial_state_deviations(payload) == []  # noqa: SLF001
+    client.active_roles = [_role_mock([])]
+    conn._flag_initial_state_deviations(ClientStatePayload(available=True))  # noqa: SLF001
+    client.flag_noncompliance.assert_not_called()

--- a/tests/server/test_client_state_dispatch.py
+++ b/tests/server/test_client_state_dispatch.py
@@ -16,6 +16,7 @@ from aiosendspin.models.core import (
     ClientStatePayload,
 )
 from aiosendspin.models.management import ManagementResultMessage, ManagementResultPayload
+from aiosendspin.models.player import PlayerStatePayload
 from aiosendspin.models.types import ManagementResult
 from aiosendspin.server.clock import LoopClock
 from aiosendspin.server.compliance import ClientComplianceError
@@ -133,3 +134,36 @@ async def test_missing_initial_state_marks_connected_when_lenient() -> None:
     conn._initial_state_timeout_callback()  # noqa: SLF001
     assert conn._initial_state_received is True  # noqa: SLF001
     client.mark_connected.assert_called_once()
+
+
+def _role(family: str) -> MagicMock:
+    role = MagicMock()
+    role.role_family = family
+    return role
+
+
+@pytest.mark.asyncio
+async def test_client_state_player_object_for_inactive_role_is_flagged() -> None:
+    """A player state object with no active player role is flagged."""
+    conn, client = _conn_with_client()
+    client.active_roles = [_role("controller")]
+    conn._initial_state_received = True  # noqa: SLF001
+    client.available = None
+    await conn._handle_message(  # noqa: SLF001
+        ClientStateMessage(payload=ClientStatePayload(player=PlayerStatePayload())), timestamp_us=0
+    )
+    flagged = [call.args[0] for call in client.flag_noncompliance.call_args_list]
+    assert any("player" in r and "inactive role" in r for r in flagged)
+
+
+@pytest.mark.asyncio
+async def test_client_state_player_object_for_active_role_is_not_flagged() -> None:
+    """A player state object with an active player role is not flagged."""
+    conn, client = _conn_with_client()
+    client.active_roles = [_role("player")]
+    conn._initial_state_received = True  # noqa: SLF001
+    client.available = None
+    await conn._handle_message(  # noqa: SLF001
+        ClientStateMessage(payload=ClientStatePayload(player=PlayerStatePayload())), timestamp_us=0
+    )
+    client.flag_noncompliance.assert_not_called()

--- a/tests/server/test_client_state_dispatch.py
+++ b/tests/server/test_client_state_dispatch.py
@@ -167,3 +167,22 @@ async def test_client_state_player_object_for_active_role_is_not_flagged() -> No
         ClientStateMessage(payload=ClientStatePayload(player=PlayerStatePayload())), timestamp_us=0
     )
     client.flag_noncompliance.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_strict_rejection_applies_no_side_effects() -> None:
+    """A rejected client/state does not change availability before the rejection."""
+    conn, client = _conn_with_client()
+    conn._initial_state_received = True  # noqa: SLF001
+    client.flag_noncompliance.side_effect = ClientComplianceError("nope")
+    client.handle_availability_change = AsyncMock()
+    client.active_roles = [_role("controller")]  # player object below is for an inactive role
+    with pytest.raises(ClientComplianceError):
+        await conn._handle_message(  # noqa: SLF001
+            ClientStateMessage(
+                payload=ClientStatePayload(available=False, player=PlayerStatePayload())
+            ),
+            timestamp_us=0,
+        )
+    client.mark_connected.assert_not_called()
+    client.handle_availability_change.assert_not_called()

--- a/tests/server/test_client_state_dispatch.py
+++ b/tests/server/test_client_state_dispatch.py
@@ -16,6 +16,7 @@ from aiosendspin.models.core import (
     ClientStatePayload,
 )
 from aiosendspin.models.management import ManagementResultMessage, ManagementResultPayload
+from aiosendspin.models.player import PlayerStatePayload
 from aiosendspin.models.types import ManagementResult
 from aiosendspin.server.clock import LoopClock
 from aiosendspin.server.connection import SendspinConnection
@@ -82,3 +83,31 @@ async def test_unsolicited_management_result_is_flagged() -> None:
         timestamp_us=0,
     )
     client.flag_noncompliance.assert_called_once()
+
+
+def _player_role_mock() -> MagicMock:
+    role = MagicMock()
+    role.role_family = "player"
+    return role
+
+
+@pytest.mark.asyncio
+async def test_initial_state_deviations_flags_incomplete_player_state() -> None:
+    """An empty initial client/state for a player is flagged as incomplete."""
+    conn, client = _conn_with_client()
+    client.active_roles = [_player_role_mock()]
+    reasons = conn._initial_state_deviations(ClientStatePayload())  # noqa: SLF001
+    assert any("available" in r for r in reasons)
+    assert any("player" in r for r in reasons)
+
+
+@pytest.mark.asyncio
+async def test_initial_state_deviations_accepts_complete_player_state() -> None:
+    """A complete initial client/state for a player yields no deviations."""
+    conn, client = _conn_with_client()
+    client.active_roles = [_player_role_mock()]
+    payload = ClientStatePayload(
+        available=True,
+        player=PlayerStatePayload(static_delay_ms=0, required_lead_time_ms=100, min_buffer_ms=200),
+    )
+    assert conn._initial_state_deviations(payload) == []  # noqa: SLF001

--- a/tests/server/test_client_state_dispatch.py
+++ b/tests/server/test_client_state_dispatch.py
@@ -9,7 +9,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from aiosendspin.models.core import ClientStateMessage, ClientStatePayload
+from aiosendspin.models.core import (
+    ClientHelloMessage,
+    ClientHelloPayload,
+    ClientStateMessage,
+    ClientStatePayload,
+)
+from aiosendspin.models.management import ManagementResultMessage, ManagementResultPayload
+from aiosendspin.models.types import ManagementResult
 from aiosendspin.server.clock import LoopClock
 from aiosendspin.server.connection import SendspinConnection
 
@@ -42,3 +49,36 @@ async def test_available_false_drives_external_source_transition() -> None:
     )
 
     client.handle_availability_change.assert_awaited_once_with(available=False)
+
+
+def _conn_with_client() -> tuple[SendspinConnection, MagicMock]:
+    loop = asyncio.get_running_loop()
+    conn = SendspinConnection(
+        _DummyServer(loop=loop, clock=LoopClock(loop)), wsock_client=MagicMock()
+    )
+    client = MagicMock()
+    conn._client = client  # noqa: SLF001
+    return conn, client
+
+
+@pytest.mark.asyncio
+async def test_second_client_hello_is_flagged() -> None:
+    """A client/hello after the hello exchange is flagged as non-compliant."""
+    conn, client = _conn_with_client()
+    await conn._handle_message(  # noqa: SLF001
+        ClientHelloMessage(payload=ClientHelloPayload(name="c", supported_roles=[])),
+        timestamp_us=0,
+    )
+    client.flag_noncompliance.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_unsolicited_management_result_is_flagged() -> None:
+    """A management/result with no request in flight is flagged as non-compliant."""
+    conn, client = _conn_with_client()
+    conn._management_waiter = None  # noqa: SLF001
+    await conn._handle_message(  # noqa: SLF001
+        ManagementResultMessage(payload=ManagementResultPayload(result=ManagementResult.OK)),
+        timestamp_us=0,
+    )
+    client.flag_noncompliance.assert_called_once()

--- a/tests/server/test_compliance.py
+++ b/tests/server/test_compliance.py
@@ -14,7 +14,7 @@ from aiosendspin.server import SendspinServer
 from aiosendspin.server.compliance import ClientComplianceError
 
 
-def _make_server(*, strict_clients: bool = False) -> SendspinServer:
+def _make_server(*, allow_noncompliant_clients: bool = True) -> SendspinServer:
     loop = asyncio.get_running_loop()
     client_session = MagicMock()
     client_session.closed = True
@@ -25,15 +25,15 @@ def _make_server(*, strict_clients: bool = False) -> SendspinServer:
         server_name="server",
         client_session=client_session,
         pairing_store=InMemoryServerPairingStore(),
-        strict_clients=strict_clients,
+        allow_noncompliant_clients=allow_noncompliant_clients,
     )
 
 
 @pytest.mark.asyncio
-async def test_strict_clients_defaults_to_false() -> None:
-    """strict_clients is opt-in."""
+async def test_allow_noncompliant_clients_defaults_to_true() -> None:
+    """Rejecting non-compliant clients is opt-in."""
     server = _make_server()
-    assert server.strict_clients is False
+    assert server.allow_noncompliant_clients is True
 
 
 @pytest.mark.asyncio
@@ -53,7 +53,7 @@ async def test_flag_noncompliance_lenient_logs_every_time(
 @pytest.mark.asyncio
 async def test_flag_noncompliance_strict_raises() -> None:
     """Strict mode raises ClientComplianceError."""
-    server = _make_server(strict_clients=True)
+    server = _make_server(allow_noncompliant_clients=False)
     client = server.get_or_create_client("dev")
     with pytest.raises(ClientComplianceError, match="legacy thing"):
         client.flag_noncompliance("legacy thing")

--- a/tests/server/test_compliance.py
+++ b/tests/server/test_compliance.py
@@ -1,0 +1,59 @@
+"""Tests for the client spec-compliance signalling helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aiosendspin.noise.keys import Identity
+from aiosendspin.noise.trust_store import InMemoryServerPairingStore
+from aiosendspin.server import SendspinServer
+from aiosendspin.server.compliance import ClientComplianceError
+
+
+def _make_server(*, strict_clients: bool = False) -> SendspinServer:
+    loop = asyncio.get_running_loop()
+    client_session = MagicMock()
+    client_session.closed = True
+    client_session.close = AsyncMock()
+    return SendspinServer(
+        loop=loop,
+        identity=Identity.generate(),
+        server_name="server",
+        client_session=client_session,
+        pairing_store=InMemoryServerPairingStore(),
+        strict_clients=strict_clients,
+    )
+
+
+@pytest.mark.asyncio
+async def test_strict_clients_defaults_to_false() -> None:
+    """strict_clients is opt-in."""
+    server = _make_server()
+    assert server.strict_clients is False
+
+
+@pytest.mark.asyncio
+async def test_flag_noncompliance_lenient_logs_every_time(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Lenient mode logs each occurrence (no dedup)."""
+    server = _make_server()
+    client = server.get_or_create_client("dev")
+    with caplog.at_level(logging.INFO):
+        client.flag_noncompliance("legacy thing")
+        client.flag_noncompliance("legacy thing")
+    hits = [r for r in caplog.records if "non-compliant client: legacy thing" in r.message]
+    assert len(hits) == 2
+
+
+@pytest.mark.asyncio
+async def test_flag_noncompliance_strict_raises() -> None:
+    """Strict mode raises ClientComplianceError."""
+    server = _make_server(strict_clients=True)
+    client = server.get_or_create_client("dev")
+    with pytest.raises(ClientComplianceError, match="legacy thing"):
+        client.flag_noncompliance("legacy thing")

--- a/tests/server/test_group_remove_client.py
+++ b/tests/server/test_group_remove_client.py
@@ -34,6 +34,7 @@ class _DummyServer:
     id: str = "srv"
     name: str = "server"
     visualizer_pitch_enabled: bool = True
+    allow_noncompliant_clients: bool = True
     _clients: dict[str, SendspinClient] = dataclasses.field(default_factory=dict)
 
     def is_external_player(self, client_id: str) -> bool:  # noqa: ARG002

--- a/tests/server/test_management_issuer.py
+++ b/tests/server/test_management_issuer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from types import SimpleNamespace
 
 import pytest
 
@@ -26,6 +27,8 @@ def _bare_connection() -> SendspinConnection:
     conn = SendspinConnection.__new__(SendspinConnection)
     conn._logger = logging.getLogger("test")  # noqa: SLF001
     conn._management_waiter = None  # noqa: SLF001
+    conn._client = None  # noqa: SLF001
+    conn._server = SimpleNamespace(strict_clients=False)  # type: ignore[assignment]  # noqa: SLF001
     return conn
 
 

--- a/tests/server/test_management_issuer.py
+++ b/tests/server/test_management_issuer.py
@@ -28,7 +28,7 @@ def _bare_connection() -> SendspinConnection:
     conn._logger = logging.getLogger("test")  # noqa: SLF001
     conn._management_waiter = None  # noqa: SLF001
     conn._client = None  # noqa: SLF001
-    conn._server = SimpleNamespace(strict_clients=False)  # type: ignore[assignment]  # noqa: SLF001
+    conn._server = SimpleNamespace(allow_noncompliant_clients=True)  # type: ignore[assignment]  # noqa: SLF001
     return conn
 
 

--- a/tests/server/test_multi_server.py
+++ b/tests/server/test_multi_server.py
@@ -773,6 +773,34 @@ class TestCustomRoleSupportParsing:
         assert msg.payload.player_support is not None
         assert msg.payload.legacy_support_keys_used == ["player_support"]
 
+    def test_deserialize_client_hello_records_legacy_key_alongside_canonical(self) -> None:
+        """A hello sending both the legacy and versioned support keys still records the legacy."""
+        support = {
+            "supported_formats": [
+                {"codec": "pcm", "sample_rate": 48000, "bit_depth": 16, "channels": 2}
+            ],
+            "buffer_capacity": 100_000,
+            "supported_commands": [],
+        }
+        raw = orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "c1",
+                    "name": "Client",
+                    "version": 1,
+                    "supported_roles": ["player@v1"],
+                    "player@v1_support": support,
+                    "player_support": support,
+                },
+            }
+        ).decode()
+
+        msg = SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
+        assert isinstance(msg, ClientHelloMessage)
+        assert msg.payload.player_support is not None
+        assert msg.payload.legacy_support_keys_used == ["player_support"]
+
     def test_deserialize_client_hello_records_unlisted_support(self) -> None:
         """A support object for a role not in supported_roles is dropped and recorded."""
         raw = orjson.dumps(

--- a/tests/server/test_multi_server.py
+++ b/tests/server/test_multi_server.py
@@ -59,6 +59,7 @@ class _MockServer:
     clock: LoopClock
     id: str = "srv"
     name: str = "server"
+    strict_clients: bool = False
     pairing_store: ServerPairingStore = field(default_factory=InMemoryServerPairingStore)
     remove_client: AsyncMock = field(default_factory=AsyncMock)
 
@@ -239,6 +240,44 @@ class TestEncryptedActivities:
         assert activate["activities"] == []
         # active_roles present because the connection is playback-capable.
         assert Roles.PLAYER.value in activate["active_roles"]
+
+    @pytest.mark.asyncio
+    async def test_legacy_support_keys_logged_on_ingest(
+        self, mock_server: _MockServer, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A hello carrying unversioned support keys is admitted and logged."""
+        raw = orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "client-1",
+                    "name": "client-1",
+                    "version": 1,
+                    "supported_roles": ["player@v1"],
+                    "player_support": {
+                        "supported_formats": [
+                            {"codec": "pcm", "channels": 2, "sample_rate": 48000, "bit_depth": 16}
+                        ],
+                        "buffer_capacity": 100_000,
+                        "supported_commands": [],
+                    },
+                },
+            }
+        ).decode()
+        conn = SendspinConnection(mock_server, wsock_client=AsyncMock())
+        psk = generate_psk()
+        conn._client_id = "client-1"  # noqa: SLF001
+        conn._noise_psk = ResolvedPsk(  # noqa: SLF001
+            psk_id=psk_id_for(psk),
+            psk=psk,
+            category=PskCategory.LONG_TERM,
+            counterparty_id="client-1",
+        )
+        conn._transport = _FakeTransport([WSMessage(WSMsgType.TEXT, raw, "")])  # type: ignore[assignment]  # noqa: SLF001
+
+        with caplog.at_level("INFO"):
+            assert await conn._exchange_hellos() is True  # noqa: SLF001
+        assert "unversioned support keys" in caplog.text
 
     @pytest.mark.asyncio
     async def test_dialed_for_playback_declares_playback(self, mock_server: _MockServer) -> None:
@@ -547,11 +586,8 @@ class TestCustomRoleSupportParsing:
         with pytest.raises(ValueError, match=missing_support_key):
             SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
 
-    def test_deserialize_client_hello_logs_legacy_support_conversion_warning(
-        self, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """Legacy support alias conversion warning is preserved for v1 roles."""
-        caplog.set_level("WARNING")
+    def test_deserialize_client_hello_records_legacy_support_key_use(self) -> None:
+        """Unversioned support keys are rewritten to v1 aliases and recorded, not logged."""
         raw = orjson.dumps(
             {
                 "type": "client/hello",
@@ -578,7 +614,39 @@ class TestCustomRoleSupportParsing:
 
         msg = SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
         assert isinstance(msg, ClientHelloMessage)
-        assert "client/hello message used deprecated field names" in caplog.text
+        assert msg.payload.player_support is not None
+        assert msg.payload.legacy_support_keys_used == ["player_support"]
+
+    def test_deserialize_client_hello_ignores_spoofed_legacy_record(self) -> None:
+        """A versioned hello records nothing, even if it spoofs legacy_support_keys_used."""
+        raw = orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "c1",
+                    "name": "Client",
+                    "version": 1,
+                    "supported_roles": ["player@v1"],
+                    "legacy_support_keys_used": ["player_support"],
+                    "player@v1_support": {
+                        "supported_formats": [
+                            {
+                                "codec": "pcm",
+                                "sample_rate": 48000,
+                                "bit_depth": 16,
+                                "channels": 2,
+                            }
+                        ],
+                        "buffer_capacity": 100_000,
+                        "supported_commands": [],
+                    },
+                },
+            }
+        ).decode()
+
+        msg = SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
+        assert isinstance(msg, ClientHelloMessage)
+        assert msg.payload.legacy_support_keys_used is None
 
     def test_legacy_visualizer_support_key_is_not_normalized_to_v1(self) -> None:
         """Legacy visualizer_support must not be rewritten to visualizer@v1_support."""

--- a/tests/server/test_multi_server.py
+++ b/tests/server/test_multi_server.py
@@ -382,6 +382,26 @@ class TestEncryptedActivities:
         assert conn._closing is True  # noqa: SLF001
 
     @pytest.mark.asyncio
+    async def test_unencrypted_hello_without_version_is_flagged(
+        self, mock_server: _MockServer, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An unencrypted hello that omits the required version is admitted and flagged."""
+        conn = SendspinConnection(mock_server, wsock_client=AsyncMock())  # no PSK => unencrypted
+        raw = orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "legacy-1",
+                    "name": "legacy-1",
+                    "supported_roles": [],
+                },
+            }
+        ).decode()
+        with caplog.at_level("INFO"):
+            assert await conn._ingest_client_hello(raw) is True  # noqa: SLF001
+        assert "omitted required version" in caplog.text
+
+    @pytest.mark.asyncio
     async def test_dialed_for_playback_declares_playback(self, mock_server: _MockServer) -> None:
         """A connection dialed for playback declares the playback activity up front."""
         url = "ws://192.168.1.100:8927/sendspin"

--- a/tests/server/test_multi_server.py
+++ b/tests/server/test_multi_server.py
@@ -388,6 +388,34 @@ class TestEncryptedActivities:
         conn.disconnect.assert_awaited_once_with(retry_connection=False)
 
     @pytest.mark.asyncio
+    async def test_client_binary_frame_rejected_when_strict(self) -> None:
+        """A client binary frame ends the loop when noncompliance is disallowed."""
+
+        class _AsyncIterTransport:
+            close_code = 1000
+
+            def __init__(self, msgs: list[WSMessage]) -> None:
+                self._msgs = msgs
+
+            def __aiter__(self) -> _AsyncIterTransport:
+                return self
+
+            async def __anext__(self) -> WSMessage:
+                if not self._msgs:
+                    raise StopAsyncIteration
+                return self._msgs.pop(0)
+
+        loop = asyncio.get_running_loop()
+        strict_server = _MockServer(
+            loop=loop, clock=LoopClock(loop), allow_noncompliant_clients=False
+        )
+        conn = SendspinConnection(strict_server, wsock_client=AsyncMock())
+        conn._transport = _AsyncIterTransport([WSMessage(WSMsgType.BINARY, b"\x00", "")])  # type: ignore[assignment]  # noqa: SLF001
+
+        await conn._run_message_loop()  # noqa: SLF001
+        assert conn._closing is True  # noqa: SLF001
+
+    @pytest.mark.asyncio
     async def test_unencrypted_hello_without_version_is_flagged(
         self, mock_server: _MockServer, caplog: pytest.LogCaptureFixture
     ) -> None:

--- a/tests/server/test_multi_server.py
+++ b/tests/server/test_multi_server.py
@@ -739,6 +739,37 @@ class TestCustomRoleSupportParsing:
         assert msg.payload.player_support is not None
         assert msg.payload.legacy_support_keys_used == ["player_support"]
 
+    def test_deserialize_client_hello_records_unlisted_support(self) -> None:
+        """A support object for a role not in supported_roles is dropped and recorded."""
+        raw = orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "c1",
+                    "name": "Client",
+                    "version": 1,
+                    "supported_roles": [],
+                    "player@v1_support": {
+                        "supported_formats": [
+                            {
+                                "codec": "pcm",
+                                "sample_rate": 48000,
+                                "bit_depth": 16,
+                                "channels": 2,
+                            }
+                        ],
+                        "buffer_capacity": 100_000,
+                        "supported_commands": [],
+                    },
+                },
+            }
+        ).decode()
+
+        msg = SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
+        assert isinstance(msg, ClientHelloMessage)
+        assert msg.payload.player_support is None
+        assert msg.payload.unlisted_support_roles == ["player@v1"]
+
     def test_deserialize_client_hello_ignores_spoofed_legacy_record(self) -> None:
         """A versioned hello records nothing, even if it spoofs legacy_support_keys_used."""
         raw = orjson.dumps(

--- a/tests/server/test_multi_server.py
+++ b/tests/server/test_multi_server.py
@@ -42,6 +42,7 @@ from aiosendspin.noise.trust_store import (
 from aiosendspin.noise.wire import EncryptedWebSocket
 from aiosendspin.server.client import SendspinClient
 from aiosendspin.server.clock import LoopClock
+from aiosendspin.server.compliance import ClientComplianceError
 from aiosendspin.server.connection import SendspinConnection
 from aiosendspin.server.group import SendspinGroup
 from aiosendspin.server.roles.negotiation import negotiate_roles
@@ -351,6 +352,34 @@ class TestEncryptedActivities:
 
         assert await conn._exchange_hellos() is False  # noqa: SLF001
         assert "client-1" not in strict_server._clients  # noqa: SLF001
+
+    @pytest.mark.asyncio
+    async def test_message_loop_hard_rejects_on_compliance_error(
+        self, mock_server: _MockServer
+    ) -> None:
+        """A ClientComplianceError during dispatch ends the loop with no warm reconnect."""
+
+        class _AsyncIterTransport:
+            close_code = 1000
+
+            def __init__(self, msgs: list[WSMessage]) -> None:
+                self._msgs = msgs
+
+            def __aiter__(self) -> _AsyncIterTransport:
+                return self
+
+            async def __anext__(self) -> WSMessage:
+                if not self._msgs:
+                    raise StopAsyncIteration
+                return self._msgs.pop(0)
+
+        conn = SendspinConnection(mock_server, wsock_client=AsyncMock())
+        text = orjson.dumps({"type": "client/time", "payload": {"client_transmitted": 1}}).decode()
+        conn._transport = _AsyncIterTransport([WSMessage(WSMsgType.TEXT, text, "")])  # type: ignore[assignment]  # noqa: SLF001
+        conn._handle_message = AsyncMock(side_effect=ClientComplianceError("bad"))  # type: ignore[method-assign]  # noqa: SLF001
+
+        await conn._run_message_loop()  # noqa: SLF001
+        assert conn._closing is True  # noqa: SLF001
 
     @pytest.mark.asyncio
     async def test_dialed_for_playback_declares_playback(self, mock_server: _MockServer) -> None:

--- a/tests/server/test_multi_server.py
+++ b/tests/server/test_multi_server.py
@@ -316,6 +316,43 @@ class TestEncryptedActivities:
         assert "visualizer@_draft_r1 wire" in caplog.text
 
     @pytest.mark.asyncio
+    async def test_strict_server_rejects_noncompliant_hello(self) -> None:
+        """With strict_clients, a hello using unversioned support keys is rejected."""
+        loop = asyncio.get_running_loop()
+        strict_server = _MockServer(loop=loop, clock=LoopClock(loop), strict_clients=True)
+        raw = orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "client-1",
+                    "name": "client-1",
+                    "version": 1,
+                    "supported_roles": ["player@v1"],
+                    "player_support": {
+                        "supported_formats": [
+                            {"codec": "pcm", "channels": 2, "sample_rate": 48000, "bit_depth": 16}
+                        ],
+                        "buffer_capacity": 100_000,
+                        "supported_commands": [],
+                    },
+                },
+            }
+        ).decode()
+        conn = SendspinConnection(strict_server, wsock_client=AsyncMock())
+        psk = generate_psk()
+        conn._client_id = "client-1"  # noqa: SLF001
+        conn._noise_psk = ResolvedPsk(  # noqa: SLF001
+            psk_id=psk_id_for(psk),
+            psk=psk,
+            category=PskCategory.LONG_TERM,
+            counterparty_id="client-1",
+        )
+        conn._transport = _FakeTransport([WSMessage(WSMsgType.TEXT, raw, "")])  # type: ignore[assignment]  # noqa: SLF001
+
+        assert await conn._exchange_hellos() is False  # noqa: SLF001
+        assert "client-1" not in strict_server._clients  # noqa: SLF001
+
+    @pytest.mark.asyncio
     async def test_dialed_for_playback_declares_playback(self, mock_server: _MockServer) -> None:
         """A connection dialed for playback declares the playback activity up front."""
         url = "ws://192.168.1.100:8927/sendspin"

--- a/tests/server/test_multi_server.py
+++ b/tests/server/test_multi_server.py
@@ -281,10 +281,10 @@ class TestEncryptedActivities:
         assert "unversioned support keys" in caplog.text
 
     @pytest.mark.asyncio
-    async def test_draft_visualizer_wire_logged_on_ingest(
-        self, mock_server: _MockServer, caplog: pytest.LogCaptureFixture
-    ) -> None:
-        """A hello negotiating the legacy visualizer@_draft_r1 wire is admitted and logged."""
+    async def test_strict_server_excludes_draft_visualizer_without_rejecting(self) -> None:
+        """Strict mode does not activate the legacy draft wire, but admits the client."""
+        loop = asyncio.get_running_loop()
+        strict_server = _MockServer(loop=loop, clock=LoopClock(loop), strict_clients=True)
         raw = orjson.dumps(
             {
                 "type": "client/hello",
@@ -301,7 +301,7 @@ class TestEncryptedActivities:
                 },
             }
         ).decode()
-        conn = SendspinConnection(mock_server, wsock_client=AsyncMock())
+        conn = SendspinConnection(strict_server, wsock_client=AsyncMock())
         psk = generate_psk()
         conn._client_id = "client-1"  # noqa: SLF001
         conn._noise_psk = ResolvedPsk(  # noqa: SLF001
@@ -312,9 +312,8 @@ class TestEncryptedActivities:
         )
         conn._transport = _FakeTransport([WSMessage(WSMsgType.TEXT, raw, "")])  # type: ignore[assignment]  # noqa: SLF001
 
-        with caplog.at_level("INFO"):
-            assert await conn._exchange_hellos() is True  # noqa: SLF001
-        assert "visualizer@_draft_r1 wire" in caplog.text
+        assert await conn._exchange_hellos() is True  # noqa: SLF001
+        assert "visualizer@_draft_r1" not in conn._negotiated_roles  # noqa: SLF001
 
     @pytest.mark.asyncio
     async def test_strict_server_rejects_noncompliant_hello(self) -> None:

--- a/tests/server/test_multi_server.py
+++ b/tests/server/test_multi_server.py
@@ -376,9 +376,12 @@ class TestEncryptedActivities:
         text = orjson.dumps({"type": "client/time", "payload": {"client_transmitted": 1}}).decode()
         conn._transport = _AsyncIterTransport([WSMessage(WSMsgType.TEXT, text, "")])  # type: ignore[assignment]  # noqa: SLF001
         conn._handle_message = AsyncMock(side_effect=ClientComplianceError("bad"))  # type: ignore[method-assign]  # noqa: SLF001
+        conn.disconnect = AsyncMock()  # type: ignore[method-assign]
 
         await conn._run_message_loop()  # noqa: SLF001
-        assert conn._closing is True  # noqa: SLF001
+        # Cleanup must tear the connection down without a warm reconnect.
+        await conn._cleanup_connection()  # noqa: SLF001
+        conn.disconnect.assert_awaited_once_with(retry_connection=False)
 
     @pytest.mark.asyncio
     async def test_unencrypted_hello_without_version_is_flagged(

--- a/tests/server/test_multi_server.py
+++ b/tests/server/test_multi_server.py
@@ -280,6 +280,42 @@ class TestEncryptedActivities:
         assert "unversioned support keys" in caplog.text
 
     @pytest.mark.asyncio
+    async def test_draft_visualizer_wire_logged_on_ingest(
+        self, mock_server: _MockServer, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A hello negotiating the legacy visualizer@_draft_r1 wire is admitted and logged."""
+        raw = orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "client-1",
+                    "name": "client-1",
+                    "version": 1,
+                    "supported_roles": ["visualizer@_draft_r1"],
+                    "visualizer@_draft_r1_support": {
+                        "buffer_capacity": 1024,
+                        "types": ["loudness"],
+                        "batch_max": 8,
+                    },
+                },
+            }
+        ).decode()
+        conn = SendspinConnection(mock_server, wsock_client=AsyncMock())
+        psk = generate_psk()
+        conn._client_id = "client-1"  # noqa: SLF001
+        conn._noise_psk = ResolvedPsk(  # noqa: SLF001
+            psk_id=psk_id_for(psk),
+            psk=psk,
+            category=PskCategory.LONG_TERM,
+            counterparty_id="client-1",
+        )
+        conn._transport = _FakeTransport([WSMessage(WSMsgType.TEXT, raw, "")])  # type: ignore[assignment]  # noqa: SLF001
+
+        with caplog.at_level("INFO"):
+            assert await conn._exchange_hellos() is True  # noqa: SLF001
+        assert "visualizer@_draft_r1 wire" in caplog.text
+
+    @pytest.mark.asyncio
     async def test_dialed_for_playback_declares_playback(self, mock_server: _MockServer) -> None:
         """A connection dialed for playback declares the playback activity up front."""
         url = "ws://192.168.1.100:8927/sendspin"

--- a/tests/server/test_multi_server.py
+++ b/tests/server/test_multi_server.py
@@ -803,6 +803,37 @@ class TestCustomRoleSupportParsing:
         assert isinstance(msg, ClientHelloMessage)
         assert msg.payload.legacy_support_keys_used is None
 
+    def test_deserialize_client_hello_ignores_spoofed_unlisted_record(self) -> None:
+        """A hello with no unlisted support records nothing, even if it spoofs the field."""
+        raw = orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "c1",
+                    "name": "Client",
+                    "version": 1,
+                    "supported_roles": ["player@v1"],
+                    "unlisted_support_roles": ["artwork@v1"],
+                    "player@v1_support": {
+                        "supported_formats": [
+                            {
+                                "codec": "pcm",
+                                "sample_rate": 48000,
+                                "bit_depth": 16,
+                                "channels": 2,
+                            }
+                        ],
+                        "buffer_capacity": 100_000,
+                        "supported_commands": [],
+                    },
+                },
+            }
+        ).decode()
+
+        msg = SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
+        assert isinstance(msg, ClientHelloMessage)
+        assert msg.payload.unlisted_support_roles is None
+
     def test_legacy_visualizer_support_key_is_not_normalized_to_v1(self) -> None:
         """Legacy visualizer_support must not be rewritten to visualizer@v1_support."""
         raw = orjson.dumps(

--- a/tests/server/test_multi_server.py
+++ b/tests/server/test_multi_server.py
@@ -388,8 +388,8 @@ class TestEncryptedActivities:
         conn.disconnect.assert_awaited_once_with(retry_connection=False)
 
     @pytest.mark.asyncio
-    async def test_client_binary_frame_rejected_when_strict(self) -> None:
-        """A client binary frame ends the loop when noncompliance is disallowed."""
+    async def test_client_binary_frame_is_ignored_not_rejected(self) -> None:
+        """A client binary frame is logged and skipped, never rejecting the connection."""
 
         class _AsyncIterTransport:
             close_code = 1000
@@ -413,7 +413,7 @@ class TestEncryptedActivities:
         conn._transport = _AsyncIterTransport([WSMessage(WSMsgType.BINARY, b"\x00", "")])  # type: ignore[assignment]  # noqa: SLF001
 
         await conn._run_message_loop()  # noqa: SLF001
-        assert conn._closing is True  # noqa: SLF001
+        assert conn._closing is False  # noqa: SLF001
 
     @pytest.mark.asyncio
     async def test_unencrypted_hello_without_version_is_flagged(

--- a/tests/server/test_multi_server.py
+++ b/tests/server/test_multi_server.py
@@ -60,7 +60,7 @@ class _MockServer:
     clock: LoopClock
     id: str = "srv"
     name: str = "server"
-    strict_clients: bool = False
+    allow_noncompliant_clients: bool = True
     pairing_store: ServerPairingStore = field(default_factory=InMemoryServerPairingStore)
     remove_client: AsyncMock = field(default_factory=AsyncMock)
 
@@ -284,7 +284,9 @@ class TestEncryptedActivities:
     async def test_strict_server_excludes_draft_visualizer_without_rejecting(self) -> None:
         """Strict mode does not activate the legacy draft wire, but admits the client."""
         loop = asyncio.get_running_loop()
-        strict_server = _MockServer(loop=loop, clock=LoopClock(loop), strict_clients=True)
+        strict_server = _MockServer(
+            loop=loop, clock=LoopClock(loop), allow_noncompliant_clients=False
+        )
         raw = orjson.dumps(
             {
                 "type": "client/hello",
@@ -317,9 +319,11 @@ class TestEncryptedActivities:
 
     @pytest.mark.asyncio
     async def test_strict_server_rejects_noncompliant_hello(self) -> None:
-        """With strict_clients, a hello using unversioned support keys is rejected."""
+        """When noncompliance is disallowed, an unversioned-support-key hello is rejected."""
         loop = asyncio.get_running_loop()
-        strict_server = _MockServer(loop=loop, clock=LoopClock(loop), strict_clients=True)
+        strict_server = _MockServer(
+            loop=loop, clock=LoopClock(loop), allow_noncompliant_clients=False
+        )
         raw = orjson.dumps(
             {
                 "type": "client/hello",

--- a/tests/server/test_stream_request_format.py
+++ b/tests/server/test_stream_request_format.py
@@ -63,7 +63,7 @@ def mock_server(mock_loop: MagicMock) -> MagicMock:
     server = MagicMock()
     server.loop = mock_loop
     server.clock = LoopClock(mock_loop)
-    server.strict_clients = False
+    server.allow_noncompliant_clients = True
     return server
 
 

--- a/tests/server/test_stream_request_format.py
+++ b/tests/server/test_stream_request_format.py
@@ -63,6 +63,7 @@ def mock_server(mock_loop: MagicMock) -> MagicMock:
     server = MagicMock()
     server.loop = mock_loop
     server.clock = LoopClock(mock_loop)
+    server.strict_clients = False
     return server
 
 


### PR DESCRIPTION
The Sendspin spec went through several revisions with breaking changes. To keep existing implementations working, the `aiosendspin` server SDK carried workarounds that silently accept and normalize the older wire formats. Now that we are close to a final 1.0, we want to be able to require implementations to follow the latest version of the specification.

This PR adds an `allow_noncompliant_clients` option. When opted out (`False`), the server stops the silent normalization and force-disconnects clients that use any of the known deviations instead. It defaults to `True`, so existing behavior is unchanged unless an operator turns it off.

The option gates the known, catalogued deviations, not arbitrary spec compliance: it rejects the deviations routed through the internal compliance check plus malformed messages rejected elsewhere. It is not a full spec validator.

### What the server no longer tolerates when opted out

Hello / handshake:
- Unversioned `*_support` keys in `client/hello` (legacy aliases such as `player_support` instead of `player@v1_support`).
- Support objects for roles not listed in `supported_roles`.
- An unencrypted `client/hello` that omits the required protocol version.
- A second `client/hello` after the hello exchange.

Initial state:
- No initial `client/state` sent within the timeout.
- An initial `client/state` missing the required top-level `available` field.
- A player initial state with no player object, missing required timing fields (`static_delay_ms`, `required_lead_time_ms`, `min_buffer_ms`), or missing `volume`/`muted` when the matching command was declared.

Any `client/state`:
- The legacy top-level `state` field instead of `available`.
- The legacy nested `player.state` instead of top-level `available`.
- `volume` or `muted` sent without declaring the matching command.
- State or command objects sent for a role that is not active.
- An unsolicited `management/result` with no request in flight.

`stream/request-format`:
- A player format not in the client's declared `supported_formats`.
- Non-positive artwork `media_width`/`media_height`, or an unknown artwork channel.
- Non-positive visualizer `rate_max`/`buffer_capacity`, or a `buffer_capacity` field (not defined there by the spec).

Two related behaviors do not reject the client but change under the flag. The legacy `visualizer@_draft_r1` wire is dropped from role negotiation (underscore-prefixed draft versions are allowed by the spec, so the client stays connected on its `v1` roles). And the `pitch` visualizer extension (spec-reserved binary type 21, gated by `visualizer_pitch_enabled`) is dropped: a client offering other types keeps them, while a pitch-only client gets no visualizer stream at all. The client stays connected either way.

A future version of `aiosendspin` will default the flag to `False`, and a later one will remove it along with all backwards-compat paths.

#245 will be updated to make use of this option after this PR is merged.
