### PR TITLE
Keep the connection open on `method_not_supported` pair/abort

### DIFF
--- a/aiosendspin/models/types.py
+++ b/aiosendspin/models/types.py
@@ -256,9 +256,7 @@ class PairAbortReason(Enum):
 
 
 # The sender closes the connection after these abort reasons; every other reason keeps it open.
-CLOSING_ABORT_REASONS: frozenset[PairAbortReason] = frozenset(
-    {PairAbortReason.CONCURRENT_ATTEMPT, PairAbortReason.METHOD_NOT_SUPPORTED}
-)
+CLOSING_ABORT_REASONS: frozenset[PairAbortReason] = frozenset({PairAbortReason.CONCURRENT_ATTEMPT})
 
 
 class ManagementResult(Enum):

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -1147,17 +1147,14 @@ class SendspinConnection:
         try:
             if not await self._rehandshake_for_pairing_if_needed(transport):
                 return False
-            assert self._client_info is not None
-            offered = {d.method for d in (self._client_info.supported_pair_methods or [])}
-            chosen = (
+            method = (
                 self._pairing_attempt.method
                 if self._pairing_attempt is not None
                 else PairMethod.PAIRING_PSK
             )
-            method = chosen if chosen in offered else None
-            if method is None:
-                # Client doesn't offer the requested method — close silently per spec.
-                return False
+            # No gate on the hello-advertised methods: the advertisement may lag the client's
+            # live pairing config (management can change it mid-connection). The client
+            # arbitrates, aborting an unsupported method with ``method_not_supported``.
             await transport.send_str(
                 ServerActivateMessage(
                     payload=ServerActivatePayload(
@@ -1240,7 +1237,11 @@ class SendspinConnection:
             ),
             None,
         )
-        client_min = descriptor.min_pin_length if descriptor is not None else None
+        if descriptor is None:
+            # Method enabled after hello (management): no advertised floor, so use our own and
+            # let the client arbitrate via ``pin_length_unacceptable``.
+            return self._server.min_pin_length
+        client_min = descriptor.min_pin_length
         if client_min is None or not MIN_PIN_DIGITS <= client_min <= MAX_PIN_DIGITS:
             raise PairingError("client does not (correctly) offer dynamic PIN pairing")
         # Both floors are validated to [MIN_PIN_DIGITS, MAX_PIN_DIGITS], so the max stays in range.

--- a/tests/integration/test_noise_pairing_flow.py
+++ b/tests/integration/test_noise_pairing_flow.py
@@ -567,6 +567,86 @@ async def test_live_pairing_dynamic_pin_server_floor_raises_length() -> None:
             await client.disconnect()
 
 
+async def test_live_pairing_method_enabled_after_hello() -> None:
+    """A method enabled after the hello (e.g. via management) pairs; no advertised PIN floor."""
+    server_store = InMemoryServerPairingStore()
+    server = _make_server(server_store)
+    client_identity = Identity.generate()
+    client_store = InMemoryClientPairingStore()
+    config = await client_store.get_pairing_config()
+    await client_store.store_pairing_config(replace(config, dynamic_pin_enabled=False))
+
+    shown: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+
+    async def display(pin: str | None) -> None:
+        if pin is not None and not shown.done():
+            shown.set_result(pin)
+
+    async def provide() -> str:
+        return await shown
+
+    async with _serve(server) as url:
+        client = make_sdk_client(
+            identity=client_identity,
+            pairing_store=client_store,
+            client_name="c",
+            roles=[Roles.CONTROLLER],
+            pin_display=display,
+        )
+        try:
+            await client.connect(url)
+            conn = await _find_connection_by_client_id(server, client_identity.peer_id)
+            assert conn._client_info is not None  # noqa: SLF001
+            offered = {d.method for d in (conn._client_info.supported_pair_methods or [])}  # noqa: SLF001
+            assert PairMethod.DYNAMIC_PIN not in offered
+
+            config = await client_store.get_pairing_config()
+            await client_store.store_pairing_config(replace(config, dynamic_pin_enabled=True))
+            await conn.initiate_pairing(
+                PairingAttempt(method=PairMethod.DYNAMIC_PIN, pin_provider=provide)
+            )
+            await _await_long_term_record(client_store, server.id)
+            # No advertised client floor, so the server's own floor (6) sets the length.
+            assert len(shown.result()) == 6
+        finally:
+            await client.disconnect()
+
+
+async def test_live_pairing_method_disabled_after_hello_aborts() -> None:
+    """A method disabled after the hello is refused by the client, not silently by the server."""
+    server_store = InMemoryServerPairingStore()
+    server = _make_server(server_store)
+    client_identity = Identity.generate()
+    client_store = InMemoryClientPairingStore()
+
+    async def display(_pin: str | None) -> None:
+        return
+
+    async def provide() -> str:
+        return "000000"
+
+    async with _serve(server) as url:
+        client = make_sdk_client(
+            identity=client_identity,
+            pairing_store=client_store,
+            client_name="c",
+            roles=[Roles.CONTROLLER],
+            pin_display=display,
+        )
+        try:
+            await client.connect(url)
+            conn = await _find_connection_by_client_id(server, client_identity.peer_id)
+            config = await client_store.get_pairing_config()
+            await client_store.store_pairing_config(replace(config, dynamic_pin_enabled=False))
+            with pytest.raises(PairingAbortError) as exc_info:
+                await conn.initiate_pairing(
+                    PairingAttempt(method=PairMethod.DYNAMIC_PIN, pin_provider=provide)
+                )
+            assert exc_info.value.reason is PairAbortReason.METHOD_NOT_SUPPORTED
+        finally:
+            await client.disconnect()
+
+
 async def _await_left_pairing(client: SdkClient) -> None:
     async with asyncio.timeout(2):
         while Activity.PAIRING in client.activities:  # noqa: ASYNC110

--- a/tests/integration/test_noise_pairing_flow.py
+++ b/tests/integration/test_noise_pairing_flow.py
@@ -613,17 +613,20 @@ async def test_live_pairing_method_enabled_after_hello() -> None:
 
 
 async def test_live_pairing_method_disabled_after_hello_aborts() -> None:
-    """A method disabled after the hello is refused by the client, not silently by the server."""
+    """A method disabled after the hello is refused without closing; a retry can succeed."""
     server_store = InMemoryServerPairingStore()
     server = _make_server(server_store)
     client_identity = Identity.generate()
     client_store = InMemoryClientPairingStore()
 
-    async def display(_pin: str | None) -> None:
-        return
+    shown: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+
+    async def display(pin: str | None) -> None:
+        if pin is not None and not shown.done():
+            shown.set_result(pin)
 
     async def provide() -> str:
-        return "000000"
+        return await shown
 
     async with _serve(server) as url:
         client = make_sdk_client(
@@ -643,6 +646,11 @@ async def test_live_pairing_method_disabled_after_hello_aborts() -> None:
                     PairingAttempt(method=PairMethod.DYNAMIC_PIN, pin_provider=provide)
                 )
             assert exc_info.value.reason is PairAbortReason.METHOD_NOT_SUPPORTED
+            await client_store.store_pairing_config(replace(config, dynamic_pin_enabled=True))
+            await conn.initiate_pairing(
+                PairingAttempt(method=PairMethod.DYNAMIC_PIN, pin_provider=provide)
+            )
+            await _await_long_term_record(client_store, server.id)
         finally:
             await client.disconnect()
 


### PR DESCRIPTION
Keep the connection open on `method_not_supported` pair/abort.

Implements: https://github.com/Sendspin/spec/pull/123

Also gate pairing methods only on the client, as it is the authoritative party in that regard.