### PR TITLE
Log non-compliant client deviations once at `warning`

### DIFF
--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -144,15 +144,14 @@ class SendspinClient:
     def flag_noncompliance(self, reason: str) -> None:
         """Log a tolerated spec violation once per connection, or reject when strict."""
         if not self._server.allow_noncompliant_clients:
+            self._logger.error("rejecting non-compliant client: %s", reason)
             raise ClientComplianceError(reason)
         # Recurring deviations (e.g. per client/state) would otherwise log every
         # message, so log each distinct reason once until the client reconnects.
         if reason in self._noncompliance_logged:
             return
         self._noncompliance_logged.add(reason)
-        # Logged at info while implementers migrate. Bump to warning once they have
-        # had time to fix these, then drop the backwards-compat paths altogether.
-        self._logger.info("non-compliant client: %s", reason)
+        self._logger.warning("non-compliant client: %s", reason)
 
     @property
     def client_id(self) -> str:

--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -133,7 +133,7 @@ class SendspinClient:
         # Built when roles are attached for cached lookup in _send_binary_frame().
         self._binary_handling_cache: dict[int, tuple[BinaryHandling, Role]] = {}
 
-        # Reasons already logged for the current connection (reset on each attach).
+        # Reasons already logged, deduped for the client's lifetime.
         self._noncompliance_logged: set[str] = set()
 
         # Pending cleanup handle (scheduled via loop.call_soon/call_later on disconnect)
@@ -142,12 +142,12 @@ class SendspinClient:
         self._cleanup_on_mdns_removal: bool = False
 
     def flag_noncompliance(self, reason: str) -> None:
-        """Log a tolerated spec violation once per connection, or reject when strict."""
+        """Log a tolerated spec violation once, or reject it when the server is strict."""
         if not self._server.allow_noncompliant_clients:
             self._logger.error("rejecting non-compliant client: %s", reason)
             raise ClientComplianceError(reason)
         # Recurring deviations (e.g. per client/state) would otherwise log every
-        # message, so log each distinct reason once until the client reconnects.
+        # message, so log each distinct reason only once.
         if reason in self._noncompliance_logged:
             return
         self._noncompliance_logged.add(reason)
@@ -463,9 +463,6 @@ class SendspinClient:
         """Attach a new WebSocket connection to this client."""
         # Cancel pending cleanup if client reconnected before cleanup fired
         self._cancel_cleanup()
-
-        # Fresh connection: re-log each tolerated deviation once for this session.
-        self._noncompliance_logged.clear()
 
         if self._connection is not None and self._connection is not connection:
             # Replace an existing connection for the same device.

--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -133,18 +133,26 @@ class SendspinClient:
         # Built when roles are attached for cached lookup in _send_binary_frame().
         self._binary_handling_cache: dict[int, tuple[BinaryHandling, Role]] = {}
 
+        # Reasons already logged for the current connection (reset on each attach).
+        self._noncompliance_logged: set[str] = set()
+
         # Pending cleanup handle (scheduled via loop.call_soon/call_later on disconnect)
         self._cleanup_handle: asyncio.Handle | None = None
         # True when we intentionally retain a disconnected client after ANOTHER_SERVER goodbye.
         self._cleanup_on_mdns_removal: bool = False
 
     def flag_noncompliance(self, reason: str) -> None:
-        """Log a tolerated spec violation, or reject it when the server is strict."""
+        """Log a tolerated spec violation once per connection, or reject when strict."""
+        if not self._server.allow_noncompliant_clients:
+            raise ClientComplianceError(reason)
+        # Recurring deviations (e.g. per client/state) would otherwise log every
+        # message, so log each distinct reason once until the client reconnects.
+        if reason in self._noncompliance_logged:
+            return
+        self._noncompliance_logged.add(reason)
         # Logged at info while implementers migrate. Bump to warning once they have
         # had time to fix these, then drop the backwards-compat paths altogether.
         self._logger.info("non-compliant client: %s", reason)
-        if not self._server.allow_noncompliant_clients:
-            raise ClientComplianceError(reason)
 
     @property
     def client_id(self) -> str:
@@ -456,6 +464,9 @@ class SendspinClient:
         """Attach a new WebSocket connection to this client."""
         # Cancel pending cleanup if client reconnected before cleanup fired
         self._cancel_cleanup()
+
+        # Fresh connection: re-log each tolerated deviation once for this session.
+        self._noncompliance_logged.clear()
 
         if self._connection is not None and self._connection is not connection:
             # Replace an existing connection for the same device.

--- a/aiosendspin/server/compliance.py
+++ b/aiosendspin/server/compliance.py
@@ -3,7 +3,7 @@
 The server tolerates a range of non-spec-compliant client behavior for
 backwards compatibility. Every such tolerance is funnelled through
 ``SendspinClient.flag_noncompliance`` / ``SendspinConnection._flag_noncompliance``,
-which log the deviation (once per connection in lenient mode) and, when the server runs with
+which log the deviation (once per reason in lenient mode) and, when the server runs with
 ``allow_noncompliant_clients=False``, raise ``ClientComplianceError`` to reject
 the client. Grep for those helpers to enumerate the workarounds.
 """

--- a/aiosendspin/server/compliance.py
+++ b/aiosendspin/server/compliance.py
@@ -3,7 +3,7 @@
 The server tolerates a range of non-spec-compliant client behavior for
 backwards compatibility. Every such tolerance is funnelled through
 ``SendspinClient.flag_noncompliance`` / ``SendspinConnection._flag_noncompliance``,
-which log the deviation and, when the server runs with
+which log the deviation (once per connection in lenient mode) and, when the server runs with
 ``allow_noncompliant_clients=False``, raise ``ClientComplianceError`` to reject
 the client. Grep for those helpers to enumerate the workarounds.
 """

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -945,9 +945,10 @@ class SendspinConnection:
         if self._client is not None:
             self._client.flag_noncompliance(reason)
             return
-        self._logger.info("non-compliant client: %s", reason)
         if not self._server.allow_noncompliant_clients:
+            self._logger.error("rejecting non-compliant client: %s", reason)
             raise ClientComplianceError(reason)
+        self._logger.warning("non-compliant client: %s", reason)
 
     async def _ingest_client_hello(self, text: str) -> bool:
         """Validate and record the client/hello, attaching the client; False if rejected."""

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -1616,9 +1616,9 @@ class SendspinConnection:
         except asyncio.CancelledError:
             cancelled = True
             self._logger.debug("Message loop cancelled")
-        except ClientComplianceError as exc:
+        except ClientComplianceError:
             # Strict mode: hard-reject (no warm reconnect). Cleanup reads _closing.
-            self._logger.info("Rejecting non-compliant client: %s", exc)
+            # flag_noncompliance already logged the reason at error before raising.
             self._closing = True
         except Exception:
             self._logger.exception("Unexpected error inside websocket API")

--- a/tests/server/test_compliance.py
+++ b/tests/server/test_compliance.py
@@ -40,24 +40,30 @@ async def test_allow_noncompliant_clients_defaults_to_true() -> None:
 async def test_flag_noncompliance_lenient_dedups_per_reason(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Lenient mode logs each distinct reason once, not on every occurrence."""
+    """Lenient mode logs each distinct reason once at warning, not on every occurrence."""
     server = _make_server()
     client = server.get_or_create_client("dev")
     with caplog.at_level(logging.INFO):
         client.flag_noncompliance("legacy thing")
         client.flag_noncompliance("legacy thing")
         client.flag_noncompliance("other thing")
-    messages = [r.message for r in caplog.records if "non-compliant client" in r.message]
-    assert messages == [
+    hits = [r for r in caplog.records if "non-compliant client" in r.message]
+    assert [r.message for r in hits] == [
         "non-compliant client: legacy thing",
         "non-compliant client: other thing",
     ]
+    assert all(r.levelno == logging.WARNING for r in hits)
 
 
 @pytest.mark.asyncio
-async def test_flag_noncompliance_strict_raises() -> None:
-    """Strict mode raises ClientComplianceError."""
+async def test_flag_noncompliance_strict_raises_and_logs_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Strict mode logs the reason at error and raises ClientComplianceError."""
     server = _make_server(allow_noncompliant_clients=False)
     client = server.get_or_create_client("dev")
-    with pytest.raises(ClientComplianceError, match="legacy thing"):
+    with caplog.at_level(logging.INFO), pytest.raises(ClientComplianceError, match="legacy thing"):
         client.flag_noncompliance("legacy thing")
+    hits = [r for r in caplog.records if "non-compliant client" in r.message]
+    assert len(hits) == 1
+    assert hits[0].levelno == logging.ERROR

--- a/tests/server/test_compliance.py
+++ b/tests/server/test_compliance.py
@@ -37,14 +37,33 @@ async def test_allow_noncompliant_clients_defaults_to_true() -> None:
 
 
 @pytest.mark.asyncio
-async def test_flag_noncompliance_lenient_logs_every_time(
+async def test_flag_noncompliance_lenient_dedups_per_reason(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Lenient mode logs each occurrence (no dedup)."""
+    """Lenient mode logs each distinct reason once, not on every occurrence."""
     server = _make_server()
     client = server.get_or_create_client("dev")
     with caplog.at_level(logging.INFO):
         client.flag_noncompliance("legacy thing")
+        client.flag_noncompliance("legacy thing")
+        client.flag_noncompliance("other thing")
+    messages = [r.message for r in caplog.records if "non-compliant client" in r.message]
+    assert messages == [
+        "non-compliant client: legacy thing",
+        "non-compliant client: other thing",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_flag_noncompliance_relogs_after_reconnect(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A new connection re-logs a reason already seen on the previous one."""
+    server = _make_server()
+    client = server.get_or_create_client("dev")
+    with caplog.at_level(logging.INFO):
+        client.flag_noncompliance("legacy thing")
+        client._noncompliance_logged.clear()  # attach_connection resets this  # noqa: SLF001
         client.flag_noncompliance("legacy thing")
     hits = [r for r in caplog.records if "non-compliant client: legacy thing" in r.message]
     assert len(hits) == 2

--- a/tests/server/test_compliance.py
+++ b/tests/server/test_compliance.py
@@ -55,21 +55,6 @@ async def test_flag_noncompliance_lenient_dedups_per_reason(
 
 
 @pytest.mark.asyncio
-async def test_flag_noncompliance_relogs_after_reconnect(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """A new connection re-logs a reason already seen on the previous one."""
-    server = _make_server()
-    client = server.get_or_create_client("dev")
-    with caplog.at_level(logging.INFO):
-        client.flag_noncompliance("legacy thing")
-        client._noncompliance_logged.clear()  # attach_connection resets this  # noqa: SLF001
-        client.flag_noncompliance("legacy thing")
-    hits = [r for r in caplog.records if "non-compliant client: legacy thing" in r.message]
-    assert len(hits) == 2
-
-
-@pytest.mark.asyncio
 async def test_flag_noncompliance_strict_raises() -> None:
     """Strict mode raises ClientComplianceError."""
     server = _make_server(allow_noncompliant_clients=False)


### PR DESCRIPTION
#298 funnels every tolerated spec deviation through `flag_noncompliance`, which logged at info on every call. Deviations that recur on each `client/state` message (legacy `state`, nested `player.state`) flooded the logs whenever `allow_noncompliant_clients` is on.

Each distinct reason now logs once for the client's lifetime and at `warning` rather than info. When strict mode rejects a client, the reason is now logged at `error` instead of info. The pre-attach path in `SendspinConnection` is aligned to the same levels.

Follow-up to #298.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A64dDRkE8yHzCVHFRoy8fC)_