### PR TITLE
Correct outdated comments about stream send-ahead

### DIFF
--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -702,9 +702,10 @@ class PushStream:
         self._clock = clock
         self._group = group
         self._is_stopped = False
-        # Whether the audio source is realtime (live) vs buffered. Live sources
-        # honor min_buffer_ms at startup since the queue cannot grow after
-        # playback begins. Buffered sources skip the min_buffer startup wait.
+        # Whether the audio source is realtime (live) vs buffered. Both honor
+        # min_buffer_ms at startup; buffered sources may raise that floor to
+        # required_lead_time_ms, since only a buffered queue can keep growing
+        # after playback begins and absorb the extra lead.
         # Default to buffered; callers opt into live via set_live_source(True).
         self._is_live: bool = False
         # Monotonic lifecycle token used to invalidate in-flight commit work on stop().
@@ -848,10 +849,11 @@ class PushStream:
     def set_live_source(self, is_live: bool) -> None:  # noqa: FBT001
         """Configure whether subsequent stream startups treat audio as live or buffered.
 
-        Buffered (default): startup uses only required_lead_time_ms since the
-        queue can grow naturally after playback begins. Live: startup waits for
-        min_buffer_ms so the jitter buffer is filled before playback, since a
-        realtime source cannot grow the queue after start.
+        Both wait for min_buffer_ms at startup so the jitter buffer is filled
+        before playback. Buffered (default) raises that floor to
+        required_lead_time_ms when it is larger, which costs no lasting latency
+        because the queue keeps growing after playback begins; a live source
+        cannot grow its queue, so the extra lead would be permanent.
 
         Call before the first commit_audio of a new stream session so the startup
         anchor uses the right floor.


### PR DESCRIPTION
Two comments in `push_stream.py` still describe how send-ahead worked before the spec correctness fixes. They claim buffered sources skip the `min_buffer_ms` startup wait, which is not what the code does — both live and buffered sources floor at `min_buffer_ms`. The stale text was the main evidence in a recent latency investigation that reached the wrong conclusion.

Comments only, no behaviour change.

Changes:

- Constructor comment on `_is_live` now states both modes honour `min_buffer_ms`, and that buffered may raise that floor to `required_lead_time_ms`.
- `set_live_source` docstring updated to match, explaining why only a buffered queue can absorb the longer lead.
