### PR TITLE
fix(models): coerce int-typed fields to integers on serialization

### DIFF
--- a/aiosendspin/models/artwork.py
+++ b/aiosendspin/models/artwork.py
@@ -10,14 +10,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from mashumaro.config import BaseConfig
-from mashumaro.mixins.orjson import DataClassORJSONMixin
-
+from .base import SendspinConfig, SendspinModel
 from .types import ArtworkSource, PictureFormat
 
 
 @dataclass
-class ArtworkChannel(DataClassORJSONMixin):
+class ArtworkChannel(SendspinModel):
     """Configuration for a single artwork channel."""
 
     source: ArtworkSource
@@ -39,7 +37,7 @@ class ArtworkChannel(DataClassORJSONMixin):
 
 # Client -> Server: client/hello artwork support object
 @dataclass
-class ClientHelloArtworkSupport(DataClassORJSONMixin):
+class ClientHelloArtworkSupport(SendspinModel):
     """Artwork support configuration - only if artwork role is set."""
 
     channels: list[ArtworkChannel]
@@ -52,7 +50,7 @@ class ClientHelloArtworkSupport(DataClassORJSONMixin):
 
 
 @dataclass
-class StreamArtworkChannelConfig(DataClassORJSONMixin):
+class StreamArtworkChannelConfig(SendspinModel):
     """Configuration for an artwork channel in stream/start."""
 
     source: ArtworkSource
@@ -67,7 +65,7 @@ class StreamArtworkChannelConfig(DataClassORJSONMixin):
 
 # Server -> Client: stream/start artwork object
 @dataclass
-class StreamStartArtwork(DataClassORJSONMixin):
+class StreamStartArtwork(SendspinModel):
     """
     Artwork object in stream/start message.
 
@@ -80,7 +78,7 @@ class StreamStartArtwork(DataClassORJSONMixin):
 
 # Client -> Server: stream/request-format artwork object
 @dataclass
-class StreamRequestFormatArtwork(DataClassORJSONMixin):
+class StreamRequestFormatArtwork(SendspinModel):
     """Request the server to change artwork format for a specific channel."""
 
     channel: int
@@ -99,7 +97,7 @@ class StreamRequestFormatArtwork(DataClassORJSONMixin):
         if not 0 <= self.channel <= 3:
             raise ValueError(f"channel must be 0-3, got {self.channel}")
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_none = True

--- a/aiosendspin/models/base.py
+++ b/aiosendspin/models/base.py
@@ -1,15 +1,7 @@
-"""
-Shared serialization base for Sendspin protocol models.
+"""Shared serialization behavior for Sendspin protocol models.
 
-The spec types most numeric wire fields as `integer`, and a strict client rejects a field
-whose JSON type does not match: sendspin-cpp logs `Ignoring field 'track_duration':
-expected integer in [0, 4294967295]` and drops the field entirely. Python does not enforce
-`int` annotations at runtime and mashumaro passes primitives through unchanged, so a float
-handed to a model by a caller would otherwise reach the wire verbatim as `217000.0`.
-
-`SendspinConfig` closes that gap for every model that uses it, by coercing `int`-typed
-fields as they are serialized. Deserialization already coerces through mashumaro's built-in
-`int()` handling, so only the outbound direction needs this.
+The protocol types `int`-annotated wire fields as integers, but Python does not enforce
+annotations at runtime. This module keeps those fields integer-typed during serialization.
 """
 
 from __future__ import annotations
@@ -23,27 +15,16 @@ from mashumaro.mixins.orjson import DataClassORJSONMixin
 
 
 def int_to_wire(value: Any) -> int:
-    """
-    Coerce a value annotated as `int` into a real `int` for the wire.
+    """Coerce numeric values to wire integers.
 
-    Exact integers pass through by value, including `IntEnum` and anything else
-    implementing `__index__` (NumPy integer scalars, for instance). Floats are rounded to
-    the nearest integer: every integer field in the protocol carries a quantized unit
-    (milliseconds, microseconds, hertz, counts), so a fractional part is finer than the
-    wire can represent. Rounding rather than truncating keeps float-arithmetic artifacts
-    such as `2.9 * 1000 == 2899.9999999999995` from losing a whole unit.
-
-    `bool` is rejected even though it is a subclass of `int`, so a mistyped field fails
-    here rather than reaching the wire as a plausible `1` or `0` that no client will
-    question. Rounding a float preserves the caller's numeric intent; turning `True` into
-    a one-millisecond duration invents it. Type checkers accept a `bool` wherever an `int`
-    is annotated, so this is the only place the mistake can be caught.
+    Indexable values preserve their integer value. Finite floats are rounded so arithmetic
+    artifacts do not lose a unit, while booleans are rejected rather than becoming plausible
+    1 or 0 values on the wire.
 
     Raises:
-        TypeError: If the value is a `bool`, or is not a number at all.
-        ValueError: If the value is a NaN or an infinity, which have no integer form.
+        TypeError: If the value is a boolean or is not numeric.
+        ValueError: If the value is not finite.
     """
-    # Must precede operator.index(), which accepts bools and would make this unreachable.
     if isinstance(value, bool):
         msg = f"expected an integer, got bool: {value!r}"
         raise TypeError(msg)
@@ -65,14 +46,9 @@ def int_to_wire(value: Any) -> int:
 
 
 class SendspinConfig(BaseConfig):
-    """
-    Base mashumaro config for every Sendspin model.
+    """Base mashumaro config for Sendspin models.
 
-    A model's `Config` must derive from this rather than from `BaseConfig` directly:
-    mashumaro resolves `Config` by lookup, so a `Config(BaseConfig)` on a subclass
-    replaces this one outright and silently drops the integer coercion. The
-    `test_every_json_model_uses_sendspin_config` test in
-    `tests/models/test_wire_int_coercion.py` checks every model for this.
+    Model configs must derive from this class to retain integer coercion.
     """
 
     serialization_strategy = {int: {"serialize": int_to_wire}}  # noqa: RUF012

--- a/aiosendspin/models/base.py
+++ b/aiosendspin/models/base.py
@@ -26,17 +26,28 @@ def int_to_wire(value: Any) -> int:
     """
     Coerce a value annotated as `int` into a real `int` for the wire.
 
-    Exact integers pass through by value, including `bool`, `IntEnum`, and anything else
+    Exact integers pass through by value, including `IntEnum` and anything else
     implementing `__index__` (NumPy integer scalars, for instance). Floats are rounded to
     the nearest integer: every integer field in the protocol carries a quantized unit
     (milliseconds, microseconds, hertz, counts), so a fractional part is finer than the
     wire can represent. Rounding rather than truncating keeps float-arithmetic artifacts
     such as `2.9 * 1000 == 2899.9999999999995` from losing a whole unit.
 
+    `bool` is rejected even though it is a subclass of `int`, so a mistyped field fails
+    here rather than reaching the wire as a plausible `1` or `0` that no client will
+    question. Rounding a float preserves the caller's numeric intent; turning `True` into
+    a one-millisecond duration invents it. Type checkers accept a `bool` wherever an `int`
+    is annotated, so this is the only place the mistake can be caught.
+
     Raises:
-        TypeError: If the value is not a number at all.
+        TypeError: If the value is a `bool`, or is not a number at all.
         ValueError: If the value is a NaN or an infinity, which have no integer form.
     """
+    # Must precede operator.index(), which accepts bools and would make this unreachable.
+    if isinstance(value, bool):
+        msg = f"expected an integer, got bool: {value!r}"
+        raise TypeError(msg)
+
     try:
         return operator.index(value)
     except TypeError:

--- a/aiosendspin/models/base.py
+++ b/aiosendspin/models/base.py
@@ -1,0 +1,74 @@
+"""
+Shared serialization base for Sendspin protocol models.
+
+The spec types most numeric wire fields as `integer`, and a strict client rejects a field
+whose JSON type does not match: sendspin-cpp logs `Ignoring field 'track_duration':
+expected integer in [0, 4294967295]` and drops the field entirely. Python does not enforce
+`int` annotations at runtime and mashumaro passes primitives through unchanged, so a float
+handed to a model by a caller would otherwise reach the wire verbatim as `217000.0`.
+
+`SendspinConfig` closes that gap for every model that uses it, by coercing `int`-typed
+fields as they are serialized. Deserialization already coerces through mashumaro's built-in
+`int()` handling, so only the outbound direction needs this.
+"""
+
+from __future__ import annotations
+
+import math
+import operator
+from typing import Any
+
+from mashumaro.config import BaseConfig
+from mashumaro.mixins.orjson import DataClassORJSONMixin
+
+
+def int_to_wire(value: Any) -> int:
+    """
+    Coerce a value annotated as `int` into a real `int` for the wire.
+
+    Exact integers pass through by value, including `bool`, `IntEnum`, and anything else
+    implementing `__index__` (NumPy integer scalars, for instance). Floats are rounded to
+    the nearest integer: every integer field in the protocol carries a quantized unit
+    (milliseconds, microseconds, hertz, counts), so a fractional part is finer than the
+    wire can represent. Rounding rather than truncating keeps float-arithmetic artifacts
+    such as `2.9 * 1000 == 2899.9999999999995` from losing a whole unit.
+
+    Raises:
+        TypeError: If the value is not a number at all.
+        ValueError: If the value is a NaN or an infinity, which have no integer form.
+    """
+    try:
+        return operator.index(value)
+    except TypeError:
+        pass
+
+    if isinstance(value, float) or hasattr(value, "__float__"):
+        as_float = float(value)
+        if not math.isfinite(as_float):
+            msg = f"cannot serialize non-finite value {value!r} as an integer"
+            raise ValueError(msg)
+        return round(as_float)
+
+    msg = f"expected an integer, got {type(value).__name__}: {value!r}"
+    raise TypeError(msg)
+
+
+class SendspinConfig(BaseConfig):
+    """
+    Base mashumaro config for every Sendspin model.
+
+    A model's `Config` must derive from this rather than from `BaseConfig` directly:
+    mashumaro resolves `Config` by lookup, so a `Config(BaseConfig)` on a subclass
+    replaces this one outright and silently drops the integer coercion. The
+    `test_every_json_model_uses_sendspin_config` test in
+    `tests/models/test_wire_int_coercion.py` checks every model for this.
+    """
+
+    serialization_strategy = {int: {"serialize": int_to_wire}}  # noqa: RUF012
+
+
+class SendspinModel(DataClassORJSONMixin):
+    """Base class for Sendspin protocol models. Applies `SendspinConfig` by default."""
+
+    class Config(SendspinConfig):
+        """Config for parsing json messages."""

--- a/aiosendspin/models/color.py
+++ b/aiosendspin/models/color.py
@@ -10,9 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import ClassVar
 
-from mashumaro.config import BaseConfig
-from mashumaro.mixins.orjson import DataClassORJSONMixin
-
+from .base import SendspinConfig, SendspinModel
 from .types import UndefinedField, undefined_field
 
 _RGB = tuple[int, int, int]
@@ -29,7 +27,7 @@ def _validate_rgb(name: str, value: _RGB) -> None:
 
 # Server -> Client: server/state color object
 @dataclass
-class SessionUpdateColor(DataClassORJSONMixin):
+class SessionUpdateColor(SendspinModel):
     """Color object in server/state message."""
 
     _RGB_FIELDS: ClassVar[tuple[str, ...]] = (
@@ -68,7 +66,7 @@ class SessionUpdateColor(DataClassORJSONMixin):
         """Build a SessionUpdateColor that explicitly clears all color fields."""
         return cls(timestamp=timestamp, **dict.fromkeys(cls._RGB_FIELDS))
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_default = True

--- a/aiosendspin/models/controller.py
+++ b/aiosendspin/models/controller.py
@@ -10,15 +10,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from mashumaro.config import BaseConfig
-from mashumaro.mixins.orjson import DataClassORJSONMixin
-
+from .base import SendspinConfig, SendspinModel
 from .types import MediaCommand, RepeatMode
 
 
 # Client -> Server: client/command controller object
 @dataclass
-class ControllerCommandPayload(DataClassORJSONMixin):
+class ControllerCommandPayload(SendspinModel):
     """Control the group that's playing."""
 
     command: MediaCommand
@@ -73,7 +71,7 @@ class ControllerCommandPayload(DataClassORJSONMixin):
                     f"offset_ms should not be provided for command '{self.command.value}'"
                 )
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_none = True
@@ -81,7 +79,7 @@ class ControllerCommandPayload(DataClassORJSONMixin):
 
 # Server -> Client: server/state controller object
 @dataclass
-class ControllerStatePayload(DataClassORJSONMixin):
+class ControllerStatePayload(SendspinModel):
     """Controller state object in server/state message."""
 
     supported_commands: list[MediaCommand]
@@ -114,7 +112,7 @@ class ControllerStatePayload(DataClassORJSONMixin):
         data.setdefault("shuffle", False)
         return data
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for serializing state messages."""
 
         omit_none = True

--- a/aiosendspin/models/core.py
+++ b/aiosendspin/models/core.py
@@ -11,8 +11,6 @@ from __future__ import annotations
 from dataclasses import dataclass, field, fields, is_dataclass
 from typing import Annotated, Any, ClassVar, Literal
 
-from mashumaro.config import BaseConfig
-from mashumaro.mixins.orjson import DataClassORJSONMixin
 from mashumaro.types import Alias
 
 from .artwork import (
@@ -20,6 +18,7 @@ from .artwork import (
     StreamRequestFormatArtwork,
     StreamStartArtwork,
 )
+from .base import SendspinConfig, SendspinModel
 from .color import SessionUpdateColor
 from .controller import ControllerCommandPayload, ControllerStatePayload
 from .metadata import SessionUpdateMetadata
@@ -88,7 +87,7 @@ def _merge_optional_dataclass_fields(existing: Any, incoming: Any) -> Any:
 
 
 @dataclass
-class DeviceInfo(DataClassORJSONMixin):
+class DeviceInfo(SendspinModel):
     """Optional information about the device."""
 
     product_name: str | None = None
@@ -100,14 +99,14 @@ class DeviceInfo(DataClassORJSONMixin):
     mac_address: str | None = None
     """MAC address of the connection's network interface, lowercase colon-separated."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_none = True
 
 
 @dataclass
-class PairMethodDescriptor(DataClassORJSONMixin):
+class PairMethodDescriptor(SendspinModel):
     """A pairing method a client offers in client/hello."""
 
     method: PairMethod
@@ -119,14 +118,14 @@ class PairMethodDescriptor(DataClassORJSONMixin):
     min_pin_length: int | None = None
     """For dynamic_pin only: shortest PIN length in digits the client will accept (4-12)."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Omit method-specific fields where they do not apply."""
 
         omit_none = True
 
 
 @dataclass
-class UnpairedAccess(DataClassORJSONMixin):
+class UnpairedAccess(SendspinModel):
     """Whether the client currently admits unpaired access."""
 
     enabled: bool = False
@@ -134,7 +133,7 @@ class UnpairedAccess(DataClassORJSONMixin):
 
 # Client -> Server: client/hello
 @dataclass
-class ClientHelloPayload(DataClassORJSONMixin):
+class ClientHelloPayload(SendspinModel):
     """Information about a connected client."""
 
     name: str
@@ -256,7 +255,7 @@ class ClientHelloPayload(DataClassORJSONMixin):
         # Overwrite so a client cannot spoof the record via the wire.
         self.unlisted_support_roles = unlisted or None
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_none = True
@@ -273,7 +272,7 @@ class ClientHelloMessage(ClientMessage):
 
 # Client -> Server: client/time
 @dataclass
-class ClientTimePayload(DataClassORJSONMixin):
+class ClientTimePayload(SendspinModel):
     """Timing information from the client."""
 
     client_transmitted: int
@@ -290,7 +289,7 @@ class ClientTimeMessage(ClientMessage):
 
 # Client -> Server: client/state
 @dataclass
-class ClientStatePayload(DataClassORJSONMixin):
+class ClientStatePayload(SendspinModel):
     """Client sends state updates to the server."""
 
     available: bool | None = None
@@ -317,7 +316,7 @@ class ClientStatePayload(DataClassORJSONMixin):
         d["legacy_state_used"] = legacy_state or None
         return d
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_none = True
@@ -333,13 +332,13 @@ class ClientStateMessage(ClientMessage):
 
 # Client -> Server: client/command
 @dataclass
-class ClientCommandPayload(DataClassORJSONMixin):
+class ClientCommandPayload(SendspinModel):
     """Client sends commands to the server."""
 
     controller: ControllerCommandPayload | None = None
     """Controller commands - only if client has controller role."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_none = True
@@ -355,7 +354,7 @@ class ClientCommandMessage(ClientMessage):
 
 # Client -> Server: client/goodbye
 @dataclass
-class ClientGoodbyePayload(DataClassORJSONMixin):
+class ClientGoodbyePayload(SendspinModel):
     """Payload for client goodbye message."""
 
     reason: GoodbyeReason
@@ -372,7 +371,7 @@ class ClientGoodbyeMessage(ClientMessage):
 
 # Server -> Client: server/hello
 @dataclass
-class ServerHelloPayload(DataClassORJSONMixin):
+class ServerHelloPayload(SendspinModel):
     """Information about the server."""
 
     name: str
@@ -394,7 +393,7 @@ class ServerHelloMessage(ServerMessage):
 # serializes and sends it; our own client always speaks the encrypted path and so
 # never deserializes it.
 @dataclass
-class LegacyServerHelloPayload(DataClassORJSONMixin):
+class LegacyServerHelloPayload(SendspinModel):
     """Server identity for a legacy unencrypted connection (no server/activate)."""
 
     server_id: str
@@ -410,14 +409,14 @@ class LegacyServerHelloPayload(DataClassORJSONMixin):
     selected_pair_method: PairMethod | None = None
     """Pairing method the server picked; present when connection_reason is 'pairing'."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_none = True
 
 
 @dataclass
-class LegacyServerHelloMessage(DataClassORJSONMixin):
+class LegacyServerHelloMessage(SendspinModel):
     """Legacy server/hello for transition-mode (unencrypted) clients."""
 
     payload: LegacyServerHelloPayload
@@ -426,7 +425,7 @@ class LegacyServerHelloMessage(DataClassORJSONMixin):
 
 # Server -> Client: server/activate
 @dataclass
-class ServerActivatePayload(DataClassORJSONMixin):
+class ServerActivatePayload(SendspinModel):
     """Declares the server's current purpose on this connection."""
 
     activities: list[Activity]
@@ -438,7 +437,7 @@ class ServerActivatePayload(DataClassORJSONMixin):
     selected_pair_method: PairMethod | None = None
     """Pairing method the server picked. Required when 'pairing' is in activities."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_none = True
@@ -454,7 +453,7 @@ class ServerActivateMessage(ServerMessage):
 
 # Server -> Client: server/time
 @dataclass
-class ServerTimePayload(DataClassORJSONMixin):
+class ServerTimePayload(SendspinModel):
     """Timing information from the server."""
 
     client_transmitted: int
@@ -475,7 +474,7 @@ class ServerTimeMessage(ServerMessage):
 
 # Server -> Client: server/state
 @dataclass
-class ServerStatePayload(DataClassORJSONMixin):
+class ServerStatePayload(SendspinModel):
     """Server sends state updates to the client."""
 
     metadata: SessionUpdateMetadata | None | UndefinedField = field(default_factory=undefined_field)
@@ -487,7 +486,7 @@ class ServerStatePayload(DataClassORJSONMixin):
     color: SessionUpdateColor | None | UndefinedField = field(default_factory=undefined_field)
     """Color state - only sent to clients with color role."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_default = True
@@ -510,7 +509,7 @@ class ServerStateMessage(ServerMessage):
 
 # Server -> Client: group/update
 @dataclass
-class GroupUpdateServerPayload(DataClassORJSONMixin):
+class GroupUpdateServerPayload(SendspinModel):
     """State update of the group this client is part of."""
 
     playback_state: PlaybackStateType | None = None
@@ -520,7 +519,7 @@ class GroupUpdateServerPayload(DataClassORJSONMixin):
     group_name: str | None = None
     """Friendly name of the group."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_none = True
@@ -544,13 +543,13 @@ class GroupUpdateServerMessage(ServerMessage):
 
 # Server -> Client: server/command
 @dataclass
-class ServerCommandPayload(DataClassORJSONMixin):
+class ServerCommandPayload(SendspinModel):
     """Server sends commands to the client."""
 
     player: PlayerCommandPayload | None = None
     """Player commands - only sent to clients with player role."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_none = True
@@ -602,7 +601,7 @@ def _deserialize_stream_start_visualizer(
 
 # Server -> Client: stream/start
 @dataclass
-class StreamStartPayload(DataClassORJSONMixin):
+class StreamStartPayload(SendspinModel):
     """Information about an active streaming session."""
 
     server_transmitted: int = 0
@@ -628,7 +627,7 @@ class StreamStartPayload(DataClassORJSONMixin):
     get the draft schema. Roles emit whichever matches their negotiated wire.
     """
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_none = True
@@ -651,7 +650,7 @@ STREAM_END_ROLE_FAMILIES = frozenset({"player", "artwork", "visualizer"})
 
 # Server -> Client: stream/clear
 @dataclass
-class StreamClearPayload(DataClassORJSONMixin):
+class StreamClearPayload(SendspinModel):
     """Instructs clients to clear buffers without ending the stream."""
 
     server_transmitted: int = 0
@@ -675,7 +674,7 @@ class StreamClearPayload(DataClassORJSONMixin):
                     f"application roles, got invalid roles: {invalid}"
                 )
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_none = True
@@ -691,7 +690,7 @@ class StreamClearMessage(ServerMessage):
 
 # Client -> Server: stream/request-format
 @dataclass
-class StreamRequestFormatPayload(DataClassORJSONMixin):
+class StreamRequestFormatPayload(SendspinModel):
     """Request different stream format (upgrade or downgrade)."""
 
     player: StreamRequestFormatPlayer | None = None
@@ -701,7 +700,7 @@ class StreamRequestFormatPayload(DataClassORJSONMixin):
     visualizer: StreamRequestFormatVisualizer | None = None
     """Visualizer format request (only for clients with visualizer role)."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_none = True
@@ -717,7 +716,7 @@ class StreamRequestFormatMessage(ClientMessage):
 
 # Server -> Client: stream/end
 @dataclass
-class StreamEndPayload(DataClassORJSONMixin):
+class StreamEndPayload(SendspinModel):
     """Payload for stream/end message."""
 
     server_transmitted: int = 0
@@ -741,7 +740,7 @@ class StreamEndPayload(DataClassORJSONMixin):
                     f"application roles, got invalid roles: {invalid}"
                 )
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_none = True

--- a/aiosendspin/models/management.py
+++ b/aiosendspin/models/management.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
-from mashumaro.config import BaseConfig
-from mashumaro.mixins.orjson import DataClassORJSONMixin
-
+from .base import SendspinConfig, SendspinModel
 from .core import UnpairedAccess
 from .types import (
     ClientMessage,
@@ -18,7 +16,7 @@ from .types import (
 
 # Server -> Client: server/unpair
 @dataclass
-class ServerUnpairPayload(DataClassORJSONMixin):
+class ServerUnpairPayload(SendspinModel):
     """Empty ``server/unpair`` payload."""
 
 
@@ -32,7 +30,7 @@ class ServerUnpairMessage(ServerMessage):
 
 # Server -> Client: management/list-records
 @dataclass
-class ManagementListRecordsPayload(DataClassORJSONMixin):
+class ManagementListRecordsPayload(SendspinModel):
     """Empty ``management/list-records`` payload."""
 
 
@@ -46,7 +44,7 @@ class ManagementListRecordsMessage(ServerMessage):
 
 # Server -> Client: management/add-record
 @dataclass
-class ManagementAddRecordPayload(DataClassORJSONMixin):
+class ManagementAddRecordPayload(SendspinModel):
     """A pairing record to add directly."""
 
     psk: str
@@ -54,7 +52,7 @@ class ManagementAddRecordPayload(DataClassORJSONMixin):
     server_id: str | None = None
     """Present for stored-pubkey records, absent for shared-PSK records."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Omit the absent server_id for shared-PSK records."""
 
         omit_none = True
@@ -70,7 +68,7 @@ class ManagementAddRecordMessage(ServerMessage):
 
 # Server -> Client: management/remove-record
 @dataclass
-class ManagementRemoveRecordPayload(DataClassORJSONMixin):
+class ManagementRemoveRecordPayload(SendspinModel):
     """Identifies the record to remove."""
 
     psk_id: str
@@ -86,7 +84,7 @@ class ManagementRemoveRecordMessage(ServerMessage):
 
 # Pairing config (shared wire shapes for get/set-pairing-config)
 @dataclass
-class RecordModeConfig(DataClassORJSONMixin):
+class RecordModeConfig(SendspinModel):
     """The client-wide record mode on the wire."""
 
     psk_id: str
@@ -95,7 +93,7 @@ class RecordModeConfig(DataClassORJSONMixin):
 
 # Server -> Client: management/get-pairing-config
 @dataclass
-class ManagementGetPairingConfigPayload(DataClassORJSONMixin):
+class ManagementGetPairingConfigPayload(SendspinModel):
     """Empty ``management/get-pairing-config`` payload."""
 
 
@@ -111,21 +109,21 @@ class ManagementGetPairingConfigMessage(ServerMessage):
 
 # Server -> Client: management/set-pairing-config
 @dataclass
-class SetPairingPskConfig(DataClassORJSONMixin):
+class SetPairingPskConfig(SendspinModel):
     """Patch for the Pairing PSK method; absent fields are left unchanged."""
 
     enabled: bool | None = None
     psk: str | None = None
     """43-char base64url 32-byte PSK; replaces the configured Pairing PSK."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Absent (omitted) fields mean 'leave unchanged'."""
 
         omit_none = True
 
 
 @dataclass
-class SetStaticPinConfig(DataClassORJSONMixin):
+class SetStaticPinConfig(SendspinModel):
     """Patch for the static-PIN method; absent fields are left unchanged."""
 
     enabled: bool | None = None
@@ -134,14 +132,14 @@ class SetStaticPinConfig(DataClassORJSONMixin):
     locked_out: bool | None = None
     """Only ``false`` is accepted; clears terminal lockout."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Absent (omitted) fields mean 'leave unchanged'."""
 
         omit_none = True
 
 
 @dataclass
-class SetDynamicPinConfig(DataClassORJSONMixin):
+class SetDynamicPinConfig(SendspinModel):
     """Patch for the dynamic-PIN method; absent fields are left unchanged."""
 
     enabled: bool | None = None
@@ -150,26 +148,26 @@ class SetDynamicPinConfig(DataClassORJSONMixin):
     min_pin_length: int | None = None
     """Shortest PIN length in digits the client will accept; must be in 4-12."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Absent (omitted) fields mean 'leave unchanged'."""
 
         omit_none = True
 
 
 @dataclass
-class SetUnpairedAccessConfig(DataClassORJSONMixin):
+class SetUnpairedAccessConfig(SendspinModel):
     """Patch for unpaired access; absent fields are left unchanged."""
 
     enabled: bool | None = None
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Absent (omitted) fields mean 'leave unchanged'."""
 
         omit_none = True
 
 
 @dataclass
-class ManagementSetPairingConfigPayload(DataClassORJSONMixin):
+class ManagementSetPairingConfigPayload(SendspinModel):
     """Partial patch over the client's pairing config; absent method objects are unchanged."""
 
     pairing_psk: SetPairingPskConfig | None = None
@@ -178,7 +176,7 @@ class ManagementSetPairingConfigPayload(DataClassORJSONMixin):
     record_mode: RecordModeConfig | None = None
     unpaired_access: SetUnpairedAccessConfig | None = None
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Absent (omitted) objects mean 'leave unchanged'."""
 
         omit_none = True
@@ -194,7 +192,7 @@ class ManagementSetPairingConfigMessage(ServerMessage):
 
 # Client -> Server: management/result
 @dataclass(kw_only=True)
-class RecordSummary(DataClassORJSONMixin):
+class RecordSummary(SendspinModel):
     """One entry in a list-records result."""
 
     psk_id: str
@@ -203,14 +201,14 @@ class RecordSummary(DataClassORJSONMixin):
     used: bool
     """``True`` once a server has authenticated a session with this record's PSK."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Omit the absent server_id for shared-PSK records."""
 
         omit_none = True
 
 
 @dataclass
-class PairingMethodConfig(DataClassORJSONMixin):
+class PairingMethodConfig(SendspinModel):
     """A method's config in a get-pairing-config result."""
 
     enabled: bool
@@ -219,14 +217,14 @@ class PairingMethodConfig(DataClassORJSONMixin):
     min_pin_length: int | None = None
     """For dynamic_pin only: shortest PIN length in digits the client will accept (4-12)."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Omit method-specific fields where they do not apply."""
 
         omit_none = True
 
 
 @dataclass
-class ManagementResultData(DataClassORJSONMixin):
+class ManagementResultData(SendspinModel):
     """Operation-specific data for a management/result; present only on ``ok``."""
 
     records: list[RecordSummary] | None = None
@@ -242,14 +240,14 @@ class ManagementResultData(DataClassORJSONMixin):
     unpaired_access: UnpairedAccess | None = None
     """Present for get-pairing-config."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Omit fields not relevant to the answered request."""
 
         omit_none = True
 
 
 @dataclass
-class StorageAccounting(DataClassORJSONMixin):
+class StorageAccounting(SendspinModel):
     """Record-storage accounting on a management/result.
 
     ``free`` is always present; ``capacity`` and the per-kind costs accompany it only on
@@ -261,21 +259,21 @@ class StorageAccounting(DataClassORJSONMixin):
     cost_individual: int | None = None
     cost_shared: int | None = None
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Omit the static fields on results that carry only ``free``."""
 
         omit_none = True
 
 
 @dataclass
-class ManagementResultPayload(DataClassORJSONMixin):
+class ManagementResultPayload(SendspinModel):
     """Result code and optional data for a management request."""
 
     result: ManagementResult
     data: ManagementResultData | None = None
     storage: StorageAccounting | None = None
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Omit absent optional fields (data, storage)."""
 
         omit_none = True

--- a/aiosendspin/models/metadata.py
+++ b/aiosendspin/models/metadata.py
@@ -10,14 +10,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-from mashumaro.config import BaseConfig
-from mashumaro.mixins.orjson import DataClassORJSONMixin
-
+from .base import SendspinConfig, SendspinModel
 from .types import RepeatMode, UndefinedField, undefined_field
 
 
 @dataclass
-class Progress(DataClassORJSONMixin):
+class Progress(SendspinModel):
     """Playback progress information."""
 
     track_progress: int
@@ -41,7 +39,7 @@ class Progress(DataClassORJSONMixin):
         if self.playback_speed < 0:
             raise ValueError(f"playback_speed must be non-negative, got {self.playback_speed}")
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_default = True
@@ -49,7 +47,7 @@ class Progress(DataClassORJSONMixin):
 
 # Server -> Client: server/state metadata object
 @dataclass
-class SessionUpdateMetadata(DataClassORJSONMixin):
+class SessionUpdateMetadata(SendspinModel):
     """Metadata object in server/state message."""
 
     timestamp: int
@@ -88,7 +86,7 @@ class SessionUpdateMetadata(DataClassORJSONMixin):
         ):
             raise ValueError(f"track must be positive, got {self.track}")
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_default = True

--- a/aiosendspin/models/player.py
+++ b/aiosendspin/models/player.py
@@ -11,15 +11,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from mashumaro.config import BaseConfig
-from mashumaro.mixins.orjson import DataClassORJSONMixin
-
+from .base import SendspinConfig, SendspinModel
 from .types import AudioCodec, PlayerCommand
 
 
 # Client -> Server client/hello player support object
 @dataclass
-class SupportedAudioFormat(DataClassORJSONMixin):
+class SupportedAudioFormat(SendspinModel):
     """Supported audio format configuration."""
 
     codec: AudioCodec
@@ -42,7 +40,7 @@ class SupportedAudioFormat(DataClassORJSONMixin):
 
 
 @dataclass
-class ClientHelloPlayerSupport(DataClassORJSONMixin):
+class ClientHelloPlayerSupport(SendspinModel):
     """Player support configuration - only if player role is set."""
 
     supported_formats: list[SupportedAudioFormat]
@@ -69,7 +67,7 @@ class ClientHelloPlayerSupport(DataClassORJSONMixin):
 
 # Client -> Server: client/state player object
 @dataclass
-class PlayerStatePayload(DataClassORJSONMixin):
+class PlayerStatePayload(SendspinModel):
     """Player object in client/state message."""
 
     # DEPRECATED(before-spec-pr-50): Remove once all clients send state at client level.
@@ -125,7 +123,7 @@ class PlayerStatePayload(DataClassORJSONMixin):
             if invalid:
                 raise ValueError(f"Invalid state-level supported_commands: {invalid}")
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_none = True
@@ -133,7 +131,7 @@ class PlayerStatePayload(DataClassORJSONMixin):
 
 # Server -> Client: server/command player object
 @dataclass
-class PlayerCommandPayload(DataClassORJSONMixin):
+class PlayerCommandPayload(SendspinModel):
     """Player object in server/command message."""
 
     command: PlayerCommand
@@ -178,7 +176,7 @@ class PlayerCommandPayload(DataClassORJSONMixin):
                 f"static_delay_ms should not be provided for command '{self.command.value}'"
             )
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_none = True
@@ -186,7 +184,7 @@ class PlayerCommandPayload(DataClassORJSONMixin):
 
 # Client -> Server stream/request-format player object
 @dataclass
-class StreamRequestFormatPlayer(DataClassORJSONMixin):
+class StreamRequestFormatPlayer(SendspinModel):
     """Request different player stream format (upgrade or downgrade)."""
 
     codec: AudioCodec | None = None
@@ -198,7 +196,7 @@ class StreamRequestFormatPlayer(DataClassORJSONMixin):
     bit_depth: int | None = None
     """Requested bit depth."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_none = True
@@ -206,7 +204,7 @@ class StreamRequestFormatPlayer(DataClassORJSONMixin):
 
 # Server -> Client stream/start player object
 @dataclass
-class StreamStartPlayer(DataClassORJSONMixin):
+class StreamStartPlayer(SendspinModel):
     """Player object in stream/start message."""
 
     codec: AudioCodec
@@ -220,7 +218,7 @@ class StreamStartPlayer(DataClassORJSONMixin):
     codec_header: str | None = None
     """Base64 encoded codec header (if necessary; e.g., FLAC)."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         omit_none = True

--- a/aiosendspin/models/types.py
+++ b/aiosendspin/models/types.py
@@ -5,31 +5,31 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 
-from mashumaro.config import BaseConfig
-from mashumaro.mixins.orjson import DataClassORJSONMixin
 from mashumaro.types import Discriminator
+
+from .base import SendspinConfig, SendspinModel
 
 
 # Base message classes
 @dataclass
-class ClientMessage(DataClassORJSONMixin):
+class ClientMessage(SendspinModel):
     """Base class for client messages."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         discriminator = Discriminator(field="type", include_subtypes=True)
 
 
 @dataclass
-class ServerMessage(DataClassORJSONMixin):
+class ServerMessage(SendspinModel):
     """Base class for server messages."""
 
     def merge(self, _other: ServerMessage) -> ServerMessage | None:
         """Merge two messages of the same type when safe, else return None."""
         return None
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         discriminator = Discriminator(field="type", include_subtypes=True)
@@ -37,7 +37,7 @@ class ServerMessage(DataClassORJSONMixin):
 
 # Helpers for discerning between null and undefined fields in messages
 @dataclass
-class UndefinedField(DataClassORJSONMixin):
+class UndefinedField(SendspinModel):
     """Marker type to indicate undefined fields in messages."""
 
 

--- a/aiosendspin/models/visualizer.py
+++ b/aiosendspin/models/visualizer.py
@@ -6,8 +6,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Literal, cast
 
-from mashumaro.config import BaseConfig
-from mashumaro.mixins.orjson import DataClassORJSONMixin
+from .base import SendspinConfig, SendspinModel
 
 VisualizerType = Literal["loudness", "f_peak", "spectrum", "beat", "peak", "pitch"]
 SupportedVisualizerType = Literal["loudness", "f_peak", "spectrum", "beat", "peak", "pitch"]
@@ -42,7 +41,7 @@ class BeatAvailability(Enum):
 
 # Client -> Server: client/hello visualizer support object
 @dataclass(frozen=True)
-class ClientHelloVisualizerSpectrum(DataClassORJSONMixin):
+class ClientHelloVisualizerSpectrum(SendspinModel):
     """Spectrum configuration from client/hello visualizer support."""
 
     n_disp_bins: int
@@ -63,14 +62,14 @@ class ClientHelloVisualizerSpectrum(DataClassORJSONMixin):
         """Serialize to stream/start visualizer.spectrum payload."""
         return self.to_dict()
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for json serialization."""
 
         omit_none = True
 
 
 @dataclass
-class ClientHelloVisualizerSupport(DataClassORJSONMixin):
+class ClientHelloVisualizerSupport(SendspinModel):
     """Visualizer support payload for client/hello visualizer negotiation."""
 
     buffer_capacity: int
@@ -105,7 +104,7 @@ class ClientHelloVisualizerSupport(DataClassORJSONMixin):
         if "spectrum" in self.types and self.spectrum is None:
             raise ValueError("visualizer support must include 'spectrum' object")
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for json serialization."""
 
         omit_none = True
@@ -113,7 +112,7 @@ class ClientHelloVisualizerSupport(DataClassORJSONMixin):
 
 # Server -> Client: stream/start visualizer object
 @dataclass(frozen=True)
-class StreamStartVisualizer(DataClassORJSONMixin):
+class StreamStartVisualizer(SendspinModel):
     """Negotiated visualizer stream config returned in stream/start."""
 
     types: tuple[SupportedVisualizerType, ...]
@@ -150,7 +149,7 @@ class StreamStartVisualizer(DataClassORJSONMixin):
         """Serialize to stream/start payload format."""
         return self.to_dict()
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for json serialization."""
 
         omit_none = True
@@ -158,7 +157,7 @@ class StreamStartVisualizer(DataClassORJSONMixin):
 
 # Client -> Server: stream/request-format visualizer object
 @dataclass
-class StreamRequestFormatVisualizer(DataClassORJSONMixin):
+class StreamRequestFormatVisualizer(SendspinModel):
     """Visualizer stream format renegotiation payload.
 
     All fields optional; omitted fields keep the prior value.
@@ -169,7 +168,7 @@ class StreamRequestFormatVisualizer(DataClassORJSONMixin):
     buffer_capacity: int | None = None
     spectrum: ClientHelloVisualizerSpectrum | None = None
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for json serialization."""
 
         omit_none = True

--- a/aiosendspin/models/visualizer_draft_r1.py
+++ b/aiosendspin/models/visualizer_draft_r1.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal, cast
 
-from mashumaro.config import BaseConfig
-from mashumaro.mixins.orjson import DataClassORJSONMixin
+from .base import SendspinConfig, SendspinModel
 
 VisualizerType = Literal["loudness", "f_peak", "spectrum", "beat"]
 SupportedVisualizerType = Literal["loudness", "f_peak", "spectrum"]
@@ -18,7 +17,7 @@ _SUPPORTED_TYPES: tuple[SupportedVisualizerType, ...] = ("loudness", "f_peak", "
 
 # Client -> Server: client/hello visualizer support object
 @dataclass(frozen=True)
-class ClientHelloVisualizerSpectrum(DataClassORJSONMixin):
+class ClientHelloVisualizerSpectrum(SendspinModel):
     """Spectrum configuration from client/hello visualizer support."""
 
     n_disp_bins: int
@@ -42,14 +41,14 @@ class ClientHelloVisualizerSpectrum(DataClassORJSONMixin):
         """Serialize to stream/start visualizer.spectrum payload."""
         return self.to_dict()
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for json serialization."""
 
         omit_none = True
 
 
 @dataclass
-class ClientHelloVisualizerSupport(DataClassORJSONMixin):
+class ClientHelloVisualizerSupport(SendspinModel):
     """Visualizer support payload for client/hello draft-r1 negotiation."""
 
     buffer_capacity: int
@@ -84,7 +83,7 @@ class ClientHelloVisualizerSupport(DataClassORJSONMixin):
         if self.types is not None and "spectrum" in self.types and self.spectrum is None:
             raise ValueError("visualizer support must include 'spectrum' object")
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for json serialization."""
 
         omit_none = True
@@ -92,7 +91,7 @@ class ClientHelloVisualizerSupport(DataClassORJSONMixin):
 
 # Server -> Client: stream/start visualizer object
 @dataclass(frozen=True)
-class StreamStartVisualizer(DataClassORJSONMixin):
+class StreamStartVisualizer(SendspinModel):
     """Negotiated draft visualizer stream config returned in stream/start."""
 
     types: tuple[SupportedVisualizerType, ...]
@@ -122,7 +121,7 @@ class StreamStartVisualizer(DataClassORJSONMixin):
         """Serialize to stream/start payload format."""
         return self.to_dict()
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for json serialization."""
 
         omit_none = True
@@ -130,14 +129,14 @@ class StreamStartVisualizer(DataClassORJSONMixin):
 
 # Client -> Server: stream/request-format visualizer object
 @dataclass
-class StreamRequestFormatVisualizer(DataClassORJSONMixin):
+class StreamRequestFormatVisualizer(SendspinModel):
     """Draft visualizer format request payload."""
 
     types: list[VisualizerType] | None = None
     batch_max: int | None = None
     spectrum: ClientHelloVisualizerSpectrum | None = None
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for json serialization."""
 
         omit_none = True

--- a/aiosendspin/noise/models.py
+++ b/aiosendspin/noise/models.py
@@ -5,15 +5,14 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
-from mashumaro.config import BaseConfig
-from mashumaro.mixins.orjson import DataClassORJSONMixin
 from mashumaro.types import Discriminator
 
+from aiosendspin.models.base import SendspinConfig, SendspinModel
 from aiosendspin.models.types import PairAbortReason, ServerMessage
 
 
 @dataclass
-class ClientInitPayload(DataClassORJSONMixin):
+class ClientInitPayload(SendspinModel):
     """Cleartext ``client/init`` payload — the client opens the conversation."""
 
     client_id: str
@@ -25,7 +24,7 @@ class ClientInitPayload(DataClassORJSONMixin):
 
 
 @dataclass
-class ClientInitMessage(DataClassORJSONMixin):
+class ClientInitMessage(SendspinModel):
     """Envelope for ``ClientInitPayload``."""
 
     payload: ClientInitPayload
@@ -33,7 +32,7 @@ class ClientInitMessage(DataClassORJSONMixin):
 
 
 @dataclass
-class ServerInitPayload(DataClassORJSONMixin):
+class ServerInitPayload(SendspinModel):
     """Cleartext ``server/init`` payload — server's response with its identity."""
 
     server_id: str
@@ -43,7 +42,7 @@ class ServerInitPayload(DataClassORJSONMixin):
 
 
 @dataclass
-class ServerInitMessage(DataClassORJSONMixin):
+class ServerInitMessage(SendspinModel):
     """Envelope for ``ServerInitPayload``."""
 
     payload: ServerInitPayload
@@ -51,7 +50,7 @@ class ServerInitMessage(DataClassORJSONMixin):
 
 
 @dataclass
-class NoiseHandshakePayload(DataClassORJSONMixin):
+class NoiseHandshakePayload(SendspinModel):
     """Carries one Noise handshake message (base64url-encoded ciphertext)."""
 
     data: str
@@ -67,7 +66,7 @@ class NoiseHandshakeMessage(ServerMessage):
 
 
 @dataclass
-class NoiseMsg1Payload(DataClassORJSONMixin):
+class NoiseMsg1Payload(SendspinModel):
     """Plaintext payload encrypted *inside* Noise handshake message 1 (server → client)."""
 
     psk_id: str
@@ -75,22 +74,22 @@ class NoiseMsg1Payload(DataClassORJSONMixin):
 
 
 @dataclass
-class NoiseMsg2Payload(DataClassORJSONMixin):
+class NoiseMsg2Payload(SendspinModel):
     """Plaintext payload encrypted *inside* Noise handshake message 2 (client → server)."""
 
 
 @dataclass
-class PairingMessage(DataClassORJSONMixin):
+class PairingMessage(SendspinModel):
     """Discriminated base for pairing envelopes, keyed on the ``type`` field."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Config for parsing json messages."""
 
         discriminator = Discriminator(field="type", include_subtypes=True)
 
 
 @dataclass
-class ClientPairFinalizePayload(DataClassORJSONMixin):
+class ClientPairFinalizePayload(SendspinModel):
     """Encrypted ``client/pair-finalize`` payload — the client delivers the long-term PSK."""
 
     long_term_psk: str | None = None
@@ -98,7 +97,7 @@ class ClientPairFinalizePayload(DataClassORJSONMixin):
     wrapped_psk: str | None = None
     """The PSK sealed under the CPace-derived wrap key (64-char base64url). PIN flows only."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Omit the field the flow doesn't use."""
 
         omit_none = True
@@ -113,7 +112,7 @@ class ClientPairFinalizeMessage(PairingMessage):
 
 
 @dataclass
-class ServerPairFinalizePayload(DataClassORJSONMixin):
+class ServerPairFinalizePayload(SendspinModel):
     """Encrypted ``server/pair-finalize`` payload — empty ack that the server persisted."""
 
 
@@ -126,7 +125,7 @@ class ServerPairFinalizeMessage(PairingMessage):
 
 
 @dataclass
-class PairAbortPayload(DataClassORJSONMixin):
+class PairAbortPayload(SendspinModel):
     """``pair/abort`` payload — aborts a pairing attempt; sender closes after sending."""
 
     reason: PairAbortReason
@@ -142,7 +141,7 @@ class PairAbortMessage(PairingMessage):
 
 
 @dataclass
-class ClientPairInitPayload(DataClassORJSONMixin):
+class ClientPairInitPayload(SendspinModel):
     """``client/pair-init`` payload — signals readiness for the PIN-pairing flow."""
 
     pairing_index: int
@@ -150,7 +149,7 @@ class ClientPairInitPayload(DataClassORJSONMixin):
     commit_B: str | None = None  # noqa: N815 - spec wire field name
     """``SHA-256(nonce_B)`` (43-char base64url). Present in dynamic PIN; absent in static."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Omit the optional commitment when absent (static PIN)."""
 
         omit_none = True
@@ -165,7 +164,7 @@ class ClientPairInitMessage(PairingMessage):
 
 
 @dataclass
-class ServerPairInitPayload(DataClassORJSONMixin):
+class ServerPairInitPayload(SendspinModel):
     """``server/pair-init`` payload — the server's nonce contribution (dynamic PIN)."""
 
     nonce_A: str  # noqa: N815 - spec wire field name
@@ -183,7 +182,7 @@ class ServerPairInitMessage(PairingMessage):
 
 
 @dataclass
-class ServerPairAuthPayload(DataClassORJSONMixin):
+class ServerPairAuthPayload(SendspinModel):
     """``server/pair-auth`` payload — the server's CPace public share."""
 
     pake_msg_1: str
@@ -199,7 +198,7 @@ class ServerPairAuthMessage(PairingMessage):
 
 
 @dataclass
-class ClientPairAuthPayload(DataClassORJSONMixin):
+class ClientPairAuthPayload(SendspinModel):
     """``client/pair-auth`` payload — the client's CPace public share."""
 
     pake_msg_2: str
@@ -215,7 +214,7 @@ class ClientPairAuthMessage(PairingMessage):
 
 
 @dataclass
-class ServerPairConfirmPayload(DataClassORJSONMixin):
+class ServerPairConfirmPayload(SendspinModel):
     """``server/pair-confirm`` payload — the server's MCF confirmation tag."""
 
     server_kc: str
@@ -231,7 +230,7 @@ class ServerPairConfirmMessage(PairingMessage):
 
 
 @dataclass
-class ClientPairConfirmPayload(DataClassORJSONMixin):
+class ClientPairConfirmPayload(SendspinModel):
     """``client/pair-confirm`` payload — the client's MCF tag and commitment opening."""
 
     client_kc: str
@@ -239,7 +238,7 @@ class ClientPairConfirmPayload(DataClassORJSONMixin):
     nonce_B: str | None = None  # noqa: N815 - spec wire field name
     """Preimage of ``commit_B`` (43-char base64url). Present in dynamic PIN only."""
 
-    class Config(BaseConfig):
+    class Config(SendspinConfig):
         """Omit the optional nonce opening when absent (static PIN)."""
 
         omit_none = True

--- a/tests/models/test_wire_int_coercion.py
+++ b/tests/models/test_wire_int_coercion.py
@@ -1,0 +1,179 @@
+"""Tests that fields the spec types as `integer` always reach the wire as integers."""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import inspect
+import json
+import pkgutil
+from enum import IntEnum
+from typing import Any
+
+import pytest
+from mashumaro.mixins.orjson import DataClassORJSONMixin
+
+import aiosendspin.models as models_package
+from aiosendspin.models.base import SendspinConfig, int_to_wire
+from aiosendspin.models.metadata import Progress, SessionUpdateMetadata
+from aiosendspin.models.player import StreamStartPlayer
+from aiosendspin.models.types import AudioCodec
+
+
+class _Level(IntEnum):
+    LOUD = 11
+
+
+class _Indexable:
+    """Stands in for an exact-integer scalar such as `numpy.int64`."""
+
+    def __index__(self) -> int:
+        return 7
+
+
+def _json_types(value: Any) -> list[type]:
+    """Collect the Python type of every scalar in a parsed JSON structure."""
+    if isinstance(value, dict):
+        return [t for v in value.values() for t in _json_types(v)]
+    if isinstance(value, list):
+        return [t for v in value for t in _json_types(v)]
+    return [type(value)]
+
+
+# int_to_wire semantics
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (217000, 217000),
+        (0, 0),
+        (-5, -5),
+        (True, 1),
+        (False, 0),
+        (_Level.LOUD, 11),
+        (_Indexable(), 7),
+        (217000.0, 217000),
+        (-217000.0, -217000),
+        # 2.9 * 1000 is 2899.9999999999995; truncating would lose a whole millisecond.
+        (2.9 * 1000, 2900),
+        (217000.4, 217000),
+        (217000.6, 217001),
+    ],
+)
+def test_int_to_wire_coerces(value: Any, expected: int) -> None:
+    """Exact integers pass through and floats round to the nearest integer."""
+    result = int_to_wire(value)
+    assert result == expected
+    assert type(result) is int
+
+
+@pytest.mark.parametrize("value", ["217000", None, b"1", [1]])
+def test_int_to_wire_rejects_non_numbers(value: Any) -> None:
+    """A value that is not a number has no defensible integer form."""
+    with pytest.raises(TypeError, match="expected an integer"):
+        int_to_wire(value)
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])
+def test_int_to_wire_rejects_non_finite(value: float) -> None:
+    """NaN and the infinities cannot be represented as integers."""
+    with pytest.raises(ValueError, match="non-finite"):
+        int_to_wire(value)
+
+
+# The reported regression
+
+
+def test_float_track_duration_serializes_as_integer() -> None:
+    """A float track_duration must not reach the wire as `217000.0`.
+
+    sendspin-cpp validates against the wire type and drops a mistyped field, so a float
+    here means the duration silently goes missing on every strict client.
+    """
+    payload = json.loads(
+        Progress(track_progress=1000, track_duration=217000.0, playback_speed=1000).to_json()
+    )
+    assert payload["track_duration"] == 217000
+    assert type(payload["track_duration"]) is int
+
+
+def test_metadata_role_path_emits_integers() -> None:
+    """The whole metadata update, including the nested Progress, is integer-typed."""
+    update = SessionUpdateMetadata(
+        timestamp=1.5e6,
+        year=2020.0,
+        track=3.0,
+        progress=Progress(track_progress=1000.0, track_duration=217000.0, playback_speed=1000.0),
+    )
+    payload = json.loads(update.to_json())
+
+    assert payload["timestamp"] == 1_500_000
+    assert payload["year"] == 2020
+    assert payload["track"] == 3
+    assert payload["progress"] == {
+        "track_progress": 1000,
+        "track_duration": 217000,
+        "playback_speed": 1000,
+    }
+    assert float not in _json_types(payload)
+
+
+def test_undefined_and_null_union_members_still_work() -> None:
+    """Coercion must not disturb the undefined/null distinction on union fields."""
+    assert "year" not in json.loads(SessionUpdateMetadata(timestamp=0).to_json())
+    assert json.loads(SessionUpdateMetadata(timestamp=0, year=None).to_json())["year"] is None
+
+
+def test_plain_int_fields_are_coerced() -> None:
+    """Non-union int fields are covered too, not just the metadata ones."""
+    payload = json.loads(
+        StreamStartPlayer(
+            codec=AudioCodec.PCM,
+            codec_header=None,
+            sample_rate=48000.0,
+            channels=2.0,
+            bit_depth=16.0,
+        ).to_json()
+    )
+    assert payload["sample_rate"] == 48000
+    assert float not in _json_types(payload)
+
+
+# Structural guard against new models regressing
+
+
+def _json_model_classes() -> list[type]:
+    """Every model dataclass that is serialized to JSON."""
+    found: dict[str, type] = {}
+    for module_info in pkgutil.iter_modules(models_package.__path__):
+        module = importlib.import_module(f"aiosendspin.models.{module_info.name}")
+        for obj in vars(module).values():
+            if (
+                inspect.isclass(obj)
+                and dataclasses.is_dataclass(obj)
+                and issubclass(obj, DataClassORJSONMixin)
+                and obj.__module__.startswith("aiosendspin.models")
+            ):
+                found[f"{obj.__module__}.{obj.__qualname__}"] = obj
+    return list(found.values())
+
+
+def test_every_json_model_uses_sendspin_config() -> None:
+    """Every JSON model must resolve to a SendspinConfig.
+
+    mashumaro resolves `Config` by lookup, so a model declaring `Config(BaseConfig)`
+    replaces the inherited config outright and silently loses the integer coercion.
+    """
+    classes = _json_model_classes()
+    assert classes, "no model classes discovered; the discovery helper is broken"
+
+    offenders = [
+        f"{cls.__module__}.{cls.__qualname__}"
+        for cls in classes
+        if not issubclass(getattr(cls, "Config", object), SendspinConfig)
+    ]
+    assert not offenders, (
+        "these models do not use SendspinConfig, so their int fields are not coerced: "
+        f"{offenders}. Derive their Config from SendspinConfig rather than BaseConfig."
+    )

--- a/tests/models/test_wire_int_coercion.py
+++ b/tests/models/test_wire_int_coercion.py
@@ -49,8 +49,6 @@ def _json_types(value: Any) -> list[type]:
         (217000, 217000),
         (0, 0),
         (-5, -5),
-        (True, 1),
-        (False, 0),
         (_Level.LOUD, 11),
         (_Indexable(), 7),
         (217000.0, 217000),
@@ -73,6 +71,24 @@ def test_int_to_wire_rejects_non_numbers(value: Any) -> None:
     """A value that is not a number has no defensible integer form."""
     with pytest.raises(TypeError, match="expected an integer"):
         int_to_wire(value)
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_int_to_wire_rejects_bool(value: bool) -> None:  # noqa: FBT001
+    """A bool must not become a plausible 1/0 on the wire.
+
+    `bool` subclasses `int`, so type checkers accept it wherever an `int` is annotated
+    and `operator.index` would happily convert it. Coercing it would turn a caller bug
+    into a wire-valid value no client would reject.
+    """
+    with pytest.raises(TypeError, match="got bool"):
+        int_to_wire(value)
+
+
+def test_bool_typed_fields_are_unaffected() -> None:
+    """Rejecting bool for int fields must not disturb genuinely bool-typed fields."""
+    payload = json.loads(SessionUpdateMetadata(timestamp=0, shuffle=True).to_json())
+    assert payload["shuffle"] is True
 
 
 @pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf")])

--- a/tests/models/test_wire_int_coercion.py
+++ b/tests/models/test_wire_int_coercion.py
@@ -14,6 +14,7 @@ import pytest
 from mashumaro.mixins.orjson import DataClassORJSONMixin
 
 import aiosendspin.models as models_package
+import aiosendspin.noise.models as noise_models
 from aiosendspin.models.base import SendspinConfig, int_to_wire
 from aiosendspin.models.metadata import Progress, SessionUpdateMetadata
 from aiosendspin.models.player import StreamStartPlayer
@@ -162,14 +163,18 @@ def test_plain_int_fields_are_coerced() -> None:
 def _json_model_classes() -> list[type]:
     """Every model dataclass that is serialized to JSON."""
     found: dict[str, type] = {}
-    for module_info in pkgutil.iter_modules(models_package.__path__):
-        module = importlib.import_module(f"aiosendspin.models.{module_info.name}")
+    modules = [noise_models]
+    modules.extend(
+        importlib.import_module(f"aiosendspin.models.{module_info.name}")
+        for module_info in pkgutil.iter_modules(models_package.__path__)
+    )
+    for module in modules:
         for obj in vars(module).values():
             if (
                 inspect.isclass(obj)
                 and dataclasses.is_dataclass(obj)
                 and issubclass(obj, DataClassORJSONMixin)
-                and obj.__module__.startswith("aiosendspin.models")
+                and obj.__module__.startswith(("aiosendspin.models", "aiosendspin.noise.models"))
             ):
                 found[f"{obj.__module__}.{obj.__qualname__}"] = obj
     return list(found.values())

--- a/tests/noise/test_models.py
+++ b/tests/noise/test_models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from aiosendspin.noise.models import (
     ClientInitMessage,
     ClientInitPayload,
@@ -41,6 +43,20 @@ def test_server_init_has_no_suite_field() -> None:
     raw = msg.to_json()
     assert "suite" not in raw
     assert '"type":"server/init"' in raw
+
+
+def test_noise_integer_fields_serialize_as_integers() -> None:
+    """Noise messages emit integer-typed wire fields."""
+    msg = ClientInitMessage(
+        payload=ClientInitPayload(
+            client_id="GFsV9tLaSQm9HcFWpKsgYQOr7wFTvNUtkmFwuVz3zoo",
+            version=1.0,
+            suite="25519_ChaChaPoly_SHA256",
+        ),
+    )
+    version = json.loads(msg.to_json())["payload"]["version"]
+    assert version == 1
+    assert type(version) is int
 
 
 def test_noise_handshake_message_round_trip() -> None:

--- a/tests/server/roles/metadata/test_state.py
+++ b/tests/server/roles/metadata/test_state.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from aiosendspin.server.roles.metadata.state import Metadata
 
 
@@ -19,3 +21,26 @@ def test_equals_detects_drift_at_normal_speed() -> None:
     later = Metadata(track_progress=42_000, playback_speed=1000, timestamp_us=2_000_000)
 
     assert not first.equals(later)
+
+
+def test_float_duration_from_caller_reaches_the_wire_as_an_integer() -> None:
+    """A caller computing `duration_s * 1000` must not put a float on the wire.
+
+    Music Assistant hands durations in as floats. The spec types track_duration as an
+    integer and strict clients drop a mistyped field, so the coercion has to survive the
+    whole Metadata -> SessionUpdateMetadata path, not just direct model construction.
+    """
+    metadata = Metadata(
+        track_progress=1000.0,
+        track_duration=217.0 * 1000,
+        playback_speed=1000,
+        year=2020.0,
+        track=3.0,
+    )
+
+    for update in (metadata.diff_update(None, timestamp=1_000_000), metadata.snapshot_update(1)):
+        payload = json.loads(update.to_json())
+        assert payload["progress"]["track_duration"] == 217_000
+        assert type(payload["progress"]["track_duration"]) is int
+        assert type(payload["year"]) is int
+        assert type(payload["track"]) is int


### PR DESCRIPTION
https://github.com/Sendspin/sendspin-cpp/issues/102 reports an issue with track duration being rejected (not the root cause of the issue there, but it did show up). This happens if the value is out of bounds or if it is a floating point value (I haven't confirmed from the user how this actually happened).

This PR tries to fix the floating point case by ensuring that non-integer values never hit the wire. **This is purely vibe-coded, so throw it away if this is the wrong approach!**

**Claude's cliams about problematic MA providers:** An audit of all 118 Music Assistant providers turned up two confirmed float sources: `bandcamp`, whose `BCTrack.duration` is genuinely `float | None` and is assigned uncast, and `bluesound`, which wraps a real `pyblu` float in a `typing.cast()` — a no-op at runtime. `bandcamp` is a music provider, so it poisons the queue item and reaches any player; `bluesound` is a player provider, so it would only reach a Sendspin client through grouping. Neither is confirmed to be what the sendspin-cpp reporter actually hit, and roughly 17 further sites pass raw JSON values into duration fields with no coercion at all — their live API types are unknown. So the float route to the wire is real, but the specific cause of that report is still unidentified.

## Technical Description of Changes

The spec types most numeric wire fields as `integer`, and models did not guarantee it. Python does not enforce `int` annotations at runtime and mashumaro passes primitives through unchanged, so a float handed to a model by a caller reached the wire verbatim:

    >>> Progress(track_progress=1000, track_duration=217000.0,
    ...          playback_speed=1000).to_json()
    {"track_progress":1000,"track_duration":217000.0,"playback_speed":1000}

This was not specific to `track_duration`: 42 plain `int` fields serialized whatever they were given, including `str` and `bool`, while the 36 union fields (`int | None | UndefinedField`) instead crashed with `InvalidFieldValue` because mashumaro's union packer type-checks each variant. Both are wrong, and a strict client is right to reject the result.

Since aiosendspin owns the wire format and cannot audit its callers, the invariant belongs here regardless of which caller misbehaves. The gap is closed at the serialization boundary rather than field by field: `SendspinConfig` carries a `serialization_strategy` that coerces every `int`-typed field, and all 85 JSON models now derive from it, which covers unions, `list[int]` and `dict[str, int]`. Deserialization already coerced via mashumaro's built-in `int()` handling, so only the outbound direction needed this.

Coercion semantics:

- **Integers pass through by value**, including `IntEnum` and anything implementing `__index__` (NumPy integer scalars, for instance).
- **Floats round to the nearest integer.** Every integer field in the protocol carries a quantized unit (milliseconds, microseconds, hertz, counts), so a fractional part is finer than the wire can represent. Rounding rather than truncating keeps artifacts such as `2.9 * 1000 == 2899.9999999999995` from losing a whole unit.
- **Strings, `bool`, and other non-numbers raise `TypeError`; non-finite floats raise `ValueError`.** Both are caught by the union packer, so the null/undefined distinction is preserved.

Rejecting rather than coercing matters for the cases where coercion would invent data instead of preserving it. Rounding a float keeps the caller's numeric intent, since the float-ness is an arithmetic artifact — but `int("217" * 1000)` would happily produce a 3000-digit integer, and `True` does not mean "one millisecond". `bool` is the subtle one: it subclasses `int`, so `mypy --strict` accepts `timestamp=True` and `operator.index()` would convert it to `1`. That is worse than the status quo — on `main` a bool reaches the wire as JSON `true`, which is exactly the mistyped field a strict client rejects loudly, whereas `1` is wire-valid and no client would ever question it. Serialization is the only place that mistake can be caught. Genuinely `bool`-typed fields such as `shuffle` are unaffected, because mashumaro resolves serialization strategies by exact declared type rather than by subclass.

Binary-only frames (`VisualizerFrame`, `BeatTiming`) are left alone: they have no JSON path and their ints go to `struct.pack`, which already fails loudly on a float.

mashumaro resolves `Config` by lookup, so a future model declaring `Config(BaseConfig)` would silently drop the coercion for itself. `test_every_json_model_uses_sendspin_config` walks every JSON model and asserts its `Config` derives from `SendspinConfig` to catch that; it was verified to fail (naming the offending model) by temporarily reverting one model's `Config`.

Note this only addresses the floating point case. The out-of-bounds case from the linked issue is untouched — nothing here range-checks against the `uint32` millisecond ceiling.
