### PR TITLE
Fix legacy connection and time-filter guidance

### DIFF
--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -874,6 +874,7 @@ class SendspinConnection:
         assert transport is not None
 
         if not self.is_encrypted:
+            # Non-spec transition path: the legacy hello replaces server/hello plus activate.
             assert self._pending_first_text is not None
             client_hello_text = self._pending_first_text
             self._pending_first_text = None

--- a/aiosendspin/server/server.py
+++ b/aiosendspin/server/server.py
@@ -167,7 +167,9 @@ class SendspinServer:
             server_name: Human-readable name advertised to clients.
             client_session: Shared aiohttp session, or None to create and own one.
             pairing_store: Persistent store for pairing records and config.
-            allow_unencrypted: Accept legacy unencrypted clients (transition mode).
+            allow_unencrypted: Accept legacy unencrypted clients over the non-spec
+                transition-mode hello, off by default. Enable it only to bridge
+                pre-encryption clients during migration.
             allow_noncompliant_clients: Tolerate and log deviations from clients
                 built against pre-1.0 spec drafts when True, reject the client when
                 False. Tolerance is transitional and will be removed in a future

--- a/scripts/compare_time_filter.py
+++ b/scripts/compare_time_filter.py
@@ -9,8 +9,9 @@ scripts/cpp_reference_sha.txt.
 Pipeline:
 
 1. Clone https://github.com/Sendspin-Protocol/time-filter into /tmp/time-filter-ref
-   (or pass --cpp-ref-dir). The SHA pinned in scripts/cpp_reference_sha.txt is
-   what the Python port was last reconciled against.
+   (or pass --cpp-ref-dir) and check out the SHA recorded in
+   scripts/cpp_reference_sha.txt, the commit the port was last reconciled against.
+   The harness compiles whatever is checked out and does not read or enforce that SHA.
 2. Compile a tiny C++ harness around sendspin_time_filter.cpp that reads
    ``measurement,max_error,time_added`` lines on stdin and prints
    ``offset,drift,offset_covariance,drift_covariance,server_time(sample_t)``


### PR DESCRIPTION
The existing documentation could imply that unencrypted clients use the standard handshake and that the time-filter harness enforces the recorded reference SHA. Clarify that unencrypted hello handling is a temporary non-spec migration path and that the harness compiles whichever reference checkout the user supplies.