### PR TITLE
Preserve playback server selection across restarts

### DIFF
--- a/aiosendspin/client/client.py
+++ b/aiosendspin/client/client.py
@@ -466,8 +466,13 @@ class SendspinClient:
             self._provisional_connections.discard(connection)
 
         # Hold the lock only for the admit decision, not for start()/pairing.
-        async with self._admission_lock:
-            await self._admit_connection(connection)
+        try:
+            async with self._admission_lock:
+                await self._admit_connection(connection)
+        except BaseException:
+            # Bring-up already dropped it from _provisional_connections, so nothing else owns it.
+            await connection.disconnect()
+            raise
         await connection.start()
 
     async def attach_websocket(
@@ -502,12 +507,17 @@ class SendspinClient:
             self._provisional_connections.discard(connection)
 
         # Hold the lock only for the admit/reject decision, not for start()/pairing.
-        async with self._admission_lock:
-            await self._ensure_last_playback_loaded()
-            if not self._should_admit_connection(connection):
-                await self._reject_connection(connection)
-                return
-            await self._admit_connection(connection)
+        try:
+            async with self._admission_lock:
+                await self._ensure_last_playback_loaded()
+                if not self._should_admit_connection(connection):
+                    await self._reject_connection(connection)
+                    return
+                await self._admit_connection(connection)
+        except BaseException:
+            # Bring-up already dropped it from _provisional_connections, so nothing else owns it.
+            await connection.disconnect()
+            raise
         try:
             await connection.start()
         except (PairingError, OSError, RuntimeError, TimeoutError) as exc:

--- a/aiosendspin/client/client.py
+++ b/aiosendspin/client/client.py
@@ -566,9 +566,9 @@ class SendspinClient:
         """Load the persisted last-playback server once, seeding the discovery tiebreak."""
         if self._last_playback_loaded:
             return
-        self._last_playback_loaded = True
         if self.last_playback_server_id is None:
             self.last_playback_server_id = await self._pairing_store.get_last_playback_server_id()
+        self._last_playback_loaded = True
 
     async def _admit_connection(self, connection: SendspinConnection) -> None:
         """Make ``connection`` the admitted one, displacing any prior holder."""

--- a/aiosendspin/client/client.py
+++ b/aiosendspin/client/client.py
@@ -245,6 +245,7 @@ class SendspinClient:
 
         self._provisional_connections = set()
         self._admission_lock = asyncio.Lock()
+        self._last_playback_loaded = False
 
         # Initialize callback lists
         self._metadata_callbacks = []
@@ -502,6 +503,7 @@ class SendspinClient:
 
         # Hold the lock only for the admit/reject decision, not for start()/pairing.
         async with self._admission_lock:
+            await self._ensure_last_playback_loaded()
             if not self._should_admit_connection(connection):
                 await self._reject_connection(connection)
                 return
@@ -560,25 +562,35 @@ class SendspinClient:
             )
         return True
 
+    async def _ensure_last_playback_loaded(self) -> None:
+        """Load the persisted last-playback server once, seeding the discovery tiebreak."""
+        if self._last_playback_loaded:
+            return
+        self._last_playback_loaded = True
+        if self.last_playback_server_id is None:
+            self.last_playback_server_id = await self._pairing_store.get_last_playback_server_id()
+
     async def _admit_connection(self, connection: SendspinConnection) -> None:
         """Make ``connection`` the admitted one, displacing any prior holder."""
         previous = self._admitted_connection
         if previous is connection:
             return
         self._admitted_connection = connection
-        self.note_playback_activity(connection)
+        await self.note_playback_activity(connection)
         if previous is not None:
             await self._dismiss_connection(previous, GoodbyeReason.ANOTHER_SERVER)
             await previous.disconnect()
 
-    def note_playback_activity(self, connection: SendspinConnection) -> None:
+    async def note_playback_activity(self, connection: SendspinConnection) -> None:
         """Record the admitted server as last-playback when it carries the playback activity."""
         if (
             connection is self._admitted_connection
             and Activity.PLAYBACK in connection.activities
             and connection.server_id is not None
+            and connection.server_id != self.last_playback_server_id
         ):
             self.last_playback_server_id = connection.server_id
+            await self._pairing_store.set_last_playback_server_id(connection.server_id)
 
     async def _reject_connection(self, connection: SendspinConnection) -> None:
         """Refuse an incoming connection that lost arbitration."""

--- a/aiosendspin/client/client.py
+++ b/aiosendspin/client/client.py
@@ -575,22 +575,26 @@ class SendspinClient:
         previous = self._admitted_connection
         if previous is connection:
             return
+        await self._record_last_playback(connection)
         self._admitted_connection = connection
-        await self.note_playback_activity(connection)
         if previous is not None:
             await self._dismiss_connection(previous, GoodbyeReason.ANOTHER_SERVER)
             await previous.disconnect()
 
     async def note_playback_activity(self, connection: SendspinConnection) -> None:
         """Record the admitted server as last-playback when it carries the playback activity."""
+        if connection is self._admitted_connection:
+            await self._record_last_playback(connection)
+
+    async def _record_last_playback(self, connection: SendspinConnection) -> None:
+        """Persist the last-playback server before caching it, so a failed write retries."""
         if (
-            connection is self._admitted_connection
-            and Activity.PLAYBACK in connection.activities
+            Activity.PLAYBACK in connection.activities
             and connection.server_id is not None
             and connection.server_id != self.last_playback_server_id
         ):
-            self.last_playback_server_id = connection.server_id
             await self._pairing_store.set_last_playback_server_id(connection.server_id)
+            self.last_playback_server_id = connection.server_id
 
     async def _reject_connection(self, connection: SendspinConnection) -> None:
         """Refuse an incoming connection that lost arbitration."""

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -442,7 +442,7 @@ class SendspinConnection:
         if payload.active_roles is not None:
             self._active_roles = payload.active_roles
         self._selected_pair_method = payload.selected_pair_method
-        self._client.note_playback_activity(self)
+        await self._client.note_playback_activity(self)
         return None
 
     async def start(self) -> None:

--- a/aiosendspin/noise/trust_store.py
+++ b/aiosendspin/noise/trust_store.py
@@ -429,6 +429,14 @@ class ClientPairingStore(ABC):
     async def is_pin_locked_out(self, method: PairMethod) -> bool:
         """Return whether ``method`` is in terminal lockout (count past the threshold)."""
 
+    @abstractmethod
+    async def get_last_playback_server_id(self) -> str | None:
+        """Return the persisted last-playback server id, if one is stored."""
+
+    @abstractmethod
+    async def set_last_playback_server_id(self, server_id: str | None) -> None:
+        """Persist the last-playback server id."""
+
     async def can_store_record(self) -> bool:
         """Return whether the store can persist another record (default: unlimited)."""
         return True
@@ -478,13 +486,6 @@ class ClientPairingStore(ABC):
     async def can_remove_record(self, psk_id: str) -> bool:
         """Return whether the record at ``psk_id`` may be removed (not record_mode-referenced)."""
         return not await self._record_mode_references(psk_id)
-
-    async def get_last_playback_server_id(self) -> str | None:
-        """Return the persisted last-playback server id, if the store tracks one."""
-        return None
-
-    async def set_last_playback_server_id(self, server_id: str | None) -> None:  # noqa: B027
-        """Persist the last-playback server id for stores that track one."""
 
 
 class _ServerPairingStoreBase(ServerPairingStore):

--- a/aiosendspin/noise/trust_store.py
+++ b/aiosendspin/noise/trust_store.py
@@ -479,6 +479,13 @@ class ClientPairingStore(ABC):
         """Return whether the record at ``psk_id`` may be removed (not record_mode-referenced)."""
         return not await self._record_mode_references(psk_id)
 
+    async def get_last_playback_server_id(self) -> str | None:
+        """Return the persisted last-playback server id, if the store tracks one."""
+        return None
+
+    async def set_last_playback_server_id(self, server_id: str | None) -> None:  # noqa: B027
+        """Persist the last-playback server id for stores that track one."""
+
 
 class _ServerPairingStoreBase(ServerPairingStore):
     """Shared query/mutation logic for server pairing stores; subclasses add persistence."""
@@ -605,9 +612,21 @@ class _ClientPairingStoreBase(ClientPairingStore):
         self._static_pin: str | None = None
         self._pin_failures: dict[PairMethod, int] = {}
         self._pairing_config: ClientPairingConfig | None = None
+        self._last_playback_server_id: str | None = None
 
     async def _save(self) -> None:
         """Flush mutated state to durable storage; a no-op for non-persistent stores."""
+
+    async def get_last_playback_server_id(self) -> str | None:
+        """Return the persisted last-playback server id, if any."""
+        return self._last_playback_server_id
+
+    async def set_last_playback_server_id(self, server_id: str | None) -> None:
+        """Persist the last-playback server id."""
+        if server_id == self._last_playback_server_id:
+            return
+        self._last_playback_server_id = server_id
+        await self._save()
 
     async def resolve_by_psk_id(self, psk_id: str) -> ResolvedPsk | None:
         """Resolve a ``psk_id`` (long-term record first, then the accepted Pairing PSK)."""
@@ -767,6 +786,7 @@ class FileClientPairingStore(_ClientPairingStoreBase):
                     raise TypeError(msg)
                 failures[PairMethod(str(method_value))] = count
         self._pin_failures = failures
+        self._last_playback_server_id = _opt_str(data, "last_playback_server_id")
 
     async def _seed(self) -> None:
         """Provision the default pre-provisioned shared-PSK fallback record (spec §Record mode)."""
@@ -786,6 +806,7 @@ class FileClientPairingStore(_ClientPairingStoreBase):
                 "pairing_psk": self._pairing_psk.to_dict() if self._pairing_psk else None,
                 "static_pin": self._static_pin,
                 "pin_failures": {m.value: c for m, c in self._pin_failures.items()},
+                "last_playback_server_id": self._last_playback_server_id,
             }
             await asyncio.to_thread(_atomic_write_json, self._path, payload)
 

--- a/aiosendspin/noise/trust_store.py
+++ b/aiosendspin/noise/trust_store.py
@@ -626,8 +626,13 @@ class _ClientPairingStoreBase(ClientPairingStore):
         """Persist the last-playback server id."""
         if server_id == self._last_playback_server_id:
             return
+        previous_server_id = self._last_playback_server_id
         self._last_playback_server_id = server_id
-        await self._save()
+        try:
+            await self._save()
+        except BaseException:
+            self._last_playback_server_id = previous_server_id
+            raise
 
     async def resolve_by_psk_id(self, psk_id: str) -> ResolvedPsk | None:
         """Resolve a ``psk_id`` (long-term record first, then the accepted Pairing PSK)."""

--- a/tests/client/test_attach_bringup.py
+++ b/tests/client/test_attach_bringup.py
@@ -41,3 +41,35 @@ async def test_attach_websocket_unexpected_failure_disconnects(
 
     assert len(disconnects) == 1
     assert not sdk._provisional_connections  # noqa: SLF001
+
+
+async def test_admission_failure_disconnects_incoming_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An admission failure disconnects the incoming connection instead of orphaning it."""
+    sdk = make_sdk_client(client_name="c", roles=[Roles.CONTROLLER])
+    disconnects: list[SendspinConnection] = []
+
+    async def bring_up(
+        self: SendspinConnection,  # noqa: ARG001
+        ws: web.WebSocketResponse,  # noqa: ARG001
+        *,
+        expected_server_id: str | None = None,  # noqa: ARG001
+    ) -> None:
+        return
+
+    async def boom() -> None:
+        raise OSError("store unavailable")
+
+    async def record_disconnect(self: SendspinConnection) -> None:
+        disconnects.append(self)
+
+    monkeypatch.setattr(SendspinConnection, "attach_websocket", bring_up)
+    monkeypatch.setattr(SendspinConnection, "disconnect", record_disconnect)
+    monkeypatch.setattr(sdk, "_ensure_last_playback_loaded", boom)
+
+    with pytest.raises(OSError, match="store unavailable"):
+        await sdk.attach_websocket(MagicMock())
+
+    assert len(disconnects) == 1
+    assert not sdk._provisional_connections  # noqa: SLF001

--- a/tests/noise/test_trust_store.py
+++ b/tests/noise/test_trust_store.py
@@ -310,6 +310,16 @@ async def test_file_client_store_persists_state(tmp_path: Path) -> None:
     assert await reloaded.pin_failure_count(PairMethod.DYNAMIC_PIN) == 1
 
 
+async def test_file_client_store_persists_last_playback_server(tmp_path: Path) -> None:
+    """The last-playback server id survives a reload."""
+    path = tmp_path / "client.json"
+    store = await FileClientPairingStore.open(path)
+    await store.set_last_playback_server_id("server-X")
+
+    reloaded = await FileClientPairingStore.open(path)
+    assert await reloaded.get_last_playback_server_id() == "server-X"
+
+
 async def test_file_client_store_pairing_outcome_generates_per_server_record(
     tmp_path: Path,
 ) -> None:

--- a/tests/noise/test_trust_store.py
+++ b/tests/noise/test_trust_store.py
@@ -320,6 +320,31 @@ async def test_file_client_store_persists_last_playback_server(tmp_path: Path) -
     assert await reloaded.get_last_playback_server_id() == "server-X"
 
 
+async def test_last_playback_server_write_retries_after_save_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed save leaves the prior value intact so the same write can retry."""
+    store = InMemoryClientPairingStore()
+    save_attempts = 0
+
+    async def fail_once() -> None:
+        nonlocal save_attempts
+        save_attempts += 1
+        if save_attempts == 1:
+            raise OSError("store unavailable")
+
+    monkeypatch.setattr(store, "_save", fail_once)
+
+    with pytest.raises(OSError, match="store unavailable"):
+        await store.set_last_playback_server_id("server-X")
+    assert await store.get_last_playback_server_id() is None
+
+    await store.set_last_playback_server_id("server-X")
+
+    assert save_attempts == 2
+    assert await store.get_last_playback_server_id() == "server-X"
+
+
 async def test_file_client_store_pairing_outcome_generates_per_server_record(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_client_admission.py
+++ b/tests/test_client_admission.py
@@ -318,6 +318,54 @@ async def test_note_playback_activity_persists_later_activation() -> None:
     assert await store.get_last_playback_server_id() == "server-A"
 
 
+async def test_failed_last_playback_write_retries_on_next_activation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed store write leaves the cached pointer stale so a later activation retries."""
+    store = InMemoryClientPairingStore()
+    client = make_sdk_client(client_name="c", roles=[Roles.CONTROLLER], pairing_store=store)
+    admitted = _FakeConnection(server_id="server-A", activities=[Activity.PLAYBACK], client=client)
+    client._admitted_connection = admitted  # type: ignore[assignment]
+    written: list[str | None] = []
+
+    async def flaky(server_id: str | None) -> None:
+        written.append(server_id)
+        if len(written) == 1:
+            raise OSError("store unavailable")
+
+    monkeypatch.setattr(store, "set_last_playback_server_id", flaky)
+
+    with pytest.raises(OSError, match="store unavailable"):
+        await client.note_playback_activity(admitted)  # type: ignore[arg-type]
+    assert client.last_playback_server_id is None
+
+    await client.note_playback_activity(admitted)  # type: ignore[arg-type]
+
+    assert written == ["server-A", "server-A"]
+
+
+async def test_failed_last_playback_write_leaves_admission_unpublished(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed store write during admission keeps the previous connection admitted."""
+    store = InMemoryClientPairingStore()
+    client = make_sdk_client(client_name="c", roles=[Roles.CONTROLLER], pairing_store=store)
+    previous = _FakeConnection(server_id="server-A", activities=[], client=client)
+    client._admitted_connection = previous  # type: ignore[assignment]
+    incoming = _FakeConnection(server_id="server-B", activities=[Activity.PLAYBACK], client=client)
+
+    async def boom(_server_id: str | None) -> None:
+        raise OSError("store unavailable")
+
+    monkeypatch.setattr(store, "set_last_playback_server_id", boom)
+
+    with pytest.raises(OSError, match="store unavailable"):
+        await client._admit_connection(incoming)  # type: ignore[arg-type]
+
+    assert client._admitted_connection is previous
+    assert not previous.disconnected
+
+
 # --- on_connection_closed ---
 
 

--- a/tests/test_client_admission.py
+++ b/tests/test_client_admission.py
@@ -10,6 +10,7 @@ import pytest
 from aiosendspin.client.client import SendspinClient
 from aiosendspin.client.connection import SendspinConnection
 from aiosendspin.models.types import Activity, GoodbyeReason, PairAbortReason, Roles
+from aiosendspin.noise.trust_store import InMemoryClientPairingStore
 
 from .conftest import make_sdk_client
 
@@ -299,9 +300,22 @@ async def test_note_playback_activity_ignores_non_admitted() -> None:
     client._admitted_connection = admitted  # type: ignore[assignment]
     other = _FakeConnection(server_id="server-B", activities=[Activity.PLAYBACK], client=client)
 
-    client.note_playback_activity(other)  # type: ignore[arg-type]
+    await client.note_playback_activity(other)  # type: ignore[arg-type]
 
     assert client.last_playback_server_id is None
+
+
+async def test_note_playback_activity_persists_later_activation() -> None:
+    """A server/activate that adds playback after admission is persisted, not just cached."""
+    store = InMemoryClientPairingStore()
+    client = make_sdk_client(client_name="c", roles=[Roles.CONTROLLER], pairing_store=store)
+    admitted = _FakeConnection(server_id="server-A", activities=[], client=client)
+    client._admitted_connection = admitted  # type: ignore[assignment]
+    admitted.activities = [Activity.PLAYBACK]  # a later activate declares playback
+
+    await client.note_playback_activity(admitted)  # type: ignore[arg-type]
+
+    assert await store.get_last_playback_server_id() == "server-A"
 
 
 # --- on_connection_closed ---
@@ -404,3 +418,14 @@ async def test_client_initiated_connection_has_no_bringup_deadline(
         )
     # The deadline came from wait_for, not an internal timeout: still live.
     assert not connection._closed.is_set()
+
+
+async def test_client_seeds_last_playback_server_from_store() -> None:
+    """The client seeds its last-playback tiebreak from the persisted store value."""
+    store = InMemoryClientPairingStore()
+    await store.set_last_playback_server_id("server-Z")
+    sdk = make_sdk_client(client_name="c", roles=[Roles.CONTROLLER], pairing_store=store)
+
+    await sdk._ensure_last_playback_loaded()
+
+    assert sdk.last_playback_server_id == "server-Z"

--- a/tests/test_client_admission.py
+++ b/tests/test_client_admission.py
@@ -366,6 +366,33 @@ async def test_failed_last_playback_write_leaves_admission_unpublished(
     assert not previous.disconnected
 
 
+async def test_failed_last_playback_read_retries_on_next_admission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed store read leaves the loader armed so a later admission retries it."""
+    store = InMemoryClientPairingStore()
+    await store.set_last_playback_server_id("server-Z")
+    client = make_sdk_client(client_name="c", roles=[Roles.CONTROLLER], pairing_store=store)
+    original = store.get_last_playback_server_id
+    reads: list[None] = []
+
+    async def flaky() -> str | None:
+        reads.append(None)
+        if len(reads) == 1:
+            raise OSError("store unavailable")
+        return await original()
+
+    monkeypatch.setattr(store, "get_last_playback_server_id", flaky)
+
+    with pytest.raises(OSError, match="store unavailable"):
+        await client._ensure_last_playback_loaded()
+    assert client.last_playback_server_id is None
+
+    await client._ensure_last_playback_loaded()
+
+    assert client.last_playback_server_id == "server-Z"
+
+
 # --- on_connection_closed ---
 
 


### PR DESCRIPTION
Persist the most recently admitted playback server so idle connection arbitration remains stable across client restarts. Persistence completes before admission is published, failed reads and writes remain retryable, and admission failures close incoming transports without displacing the current connection. This is technically a breaking change for custom `ClientPairingStore` subclasses, which must implement the new last-playback getter and setter.