### PR TITLE
Fix role cleanup during client disconnects

### DIFF
--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -532,7 +532,7 @@ class SendspinClient:
                 role.on_connect()
             roles[role.role_id] = role
         if self._roles_attached:
-            for dropped_role in self._roles.values():
+            for dropped_role in reversed(self._roles.values()):
                 dropped_role.on_disconnect()
         self._roles = roles
 
@@ -547,7 +547,8 @@ class SendspinClient:
                 self._rebuild_binary_handling_cache()
             return
 
-        for role_id in list(self._roles):
+        # Tear down in reverse attach order: the controller unwinds before the player it reads.
+        for role_id in reversed(list(self._roles)):
             if role_id not in desired_set:
                 deactivated_role = self._roles.pop(role_id)
                 deactivated_role.on_deactivate()
@@ -657,7 +658,7 @@ class SendspinClient:
 
     def _retire_roles_warm(self) -> None:
         """Run role disconnect hooks but keep instances alive for warm reuse on reconnect."""
-        for role in self._roles.values():
+        for role in reversed(self._roles.values()):
             role.on_disconnect()
         self._binary_handling_cache.clear()
         self._roles_warm_disconnected = True
@@ -726,7 +727,7 @@ class SendspinClient:
     def _hard_detach_roles(self, *, call_disconnect_hooks: bool = True) -> None:
         """Run role disconnect hooks and clear role-related caches."""
         if call_disconnect_hooks:
-            for role in self._roles.values():
+            for role in reversed(self._roles.values()):
                 role.on_disconnect()
         self._roles.clear()
         self._active_roles = None

--- a/tests/server/test_client_multi_role.py
+++ b/tests/server/test_client_multi_role.py
@@ -197,3 +197,26 @@ class TestClientRoles:
         client = SendspinClient(server, client_id="test")
 
         assert client.active_roles == ()
+
+    def test_roles_torn_down_in_reverse_attach_order(self, mock_loop: Any) -> None:
+        """Deactivating drops the controller before the player it reads from."""
+        server = _DummyServer(loop=mock_loop, clock=LoopClock(mock_loop))
+        client = SendspinClient(server, client_id="test")
+        client._group = MagicMock()  # noqa: SLF001
+        order: list[str] = []
+
+        def _fake_role(role_id: str) -> MagicMock:
+            role = MagicMock()
+            role.role_id = role_id
+            role.on_deactivate.side_effect = lambda: order.append(role_id)
+            return role
+
+        # Attach order is player then controller, so teardown must mirror it in reverse.
+        client._roles = {  # noqa: SLF001
+            "player@v1": _fake_role("player@v1"),
+            "controller@v1": _fake_role("controller@v1"),
+        }
+
+        client.set_active_roles([])
+
+        assert order == ["controller@v1", "player@v1"]


### PR DESCRIPTION
Roles were torn down in attachment order, allowing controller cleanup to observe a player role that had already been removed. Unwinding roles in reverse order preserves lifecycle dependencies across deactivation, reconnect, and disconnect paths.