### PR TITLE
Fix pairing record replacement and PIN validation

### DIFF
--- a/aiosendspin/noise/pairing.py
+++ b/aiosendspin/noise/pairing.py
@@ -477,7 +477,7 @@ async def _finalize_client(
     if isinstance(reply, str):
         return reply  # server left pairing without finalizing; nothing stored
     if record is not None:
-        await store.store_record(record)
+        await store.replace_record_for_server_id(record)
     return None
 
 

--- a/aiosendspin/noise/pairing.py
+++ b/aiosendspin/noise/pairing.py
@@ -408,7 +408,9 @@ async def run_static_pin_server(
     """
     sid = _pake_sid(handshake_hash, pairing_index)
     async with asyncio.timeout(_SERVER_GESTURE_TIMEOUT_S):
-        await _receive_pair_init(ws, pairing_index)
+        init = await _receive_pair_init(ws, pairing_index)
+    if init.payload.commit_B is not None:
+        raise PairingError("client/pair-init carries commit_B for static PIN")
     async with asyncio.timeout(_SERVER_ATTEMPT_TIMEOUT_S):
         pin = await pin_provider()
         if not pin_mod.is_valid_static_pin(pin):
@@ -440,6 +442,8 @@ async def run_static_pin_server(
         )
 
         confirm = await _receive_pairing(ws, ClientPairConfirmMessage)
+        if confirm.payload.nonce_B is not None:
+            raise PairingError("client/pair-confirm carries nonce_B for static PIN")
         if not cpace.verify(
             _decode_field(confirm.payload.client_kc, "client_kc", expect_len=_KC_TAG_SIZE)
         ):

--- a/aiosendspin/noise/trust_store.py
+++ b/aiosendspin/noise/trust_store.py
@@ -479,6 +479,22 @@ class ClientPairingStore(ABC):
         """Return whether the record at ``psk_id`` may be removed (not record_mode-referenced)."""
         return not await self._record_mode_references(psk_id)
 
+    async def replace_record_for_server_id(self, record: ClientPairingRecord) -> None:
+        """Persist ``record``, dropping any prior removable record bound to the same server."""
+        stale = (
+            [
+                existing.psk_id
+                for existing in await self.list_records()
+                if existing.server_id == record.server_id and existing.psk_id != record.psk_id
+            ]
+            if record.server_id is not None
+            else []
+        )
+        await self.store_record(record)
+        for psk_id in stale:
+            if await self.can_remove_record(psk_id):
+                await self.remove_record(psk_id)
+
 
 class _ServerPairingStoreBase(ServerPairingStore):
     """Shared query/mutation logic for server pairing stores; subclasses add persistence."""

--- a/tests/noise/test_pairing.py
+++ b/tests/noise/test_pairing.py
@@ -196,6 +196,32 @@ async def test_static_pin_server_rejects_non_8_digit_operator_pin() -> None:
     assert await server_store.record_by_client_id("client-X") is None
 
 
+async def test_static_pin_server_rejects_dynamic_only_commit_b() -> None:
+    """A static-PIN pair-init carrying commit_B is a protocol error."""
+    client_ews, server_ews, _client_raw, server_raw = _paired_encrypted_ws()
+    server_store = InMemoryServerPairingStore()
+
+    await client_ews.send_str(
+        ClientPairInitMessage(
+            payload=ClientPairInitPayload(
+                pairing_index=0,
+                commit_B=b64url_encode(pin_mod.commit(pin_mod.generate_nonce())),
+            )
+        ).to_json(),
+    )
+    with pytest.raises(PairingError, match="commit_B for static PIN"):
+        await run_static_pin_server(
+            server_ews,
+            handshake_hash=_HANDSHAKE_HASH,
+            pairing_index=0,
+            pin_provider=_pin,
+            client_id="client-X",
+            store=server_store,
+        )
+    assert server_raw.sent == []
+    assert await server_store.record_by_client_id("client-X") is None
+
+
 async def test_dynamic_pin_server_times_out_mid_attempt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -715,7 +741,9 @@ async def test_static_pin_malformed_client_share_raises() -> None:
     assert await server_store.record_by_client_id("client-A") is None
 
 
-async def _honest_pake_to_finalize(client_ews: EncryptedWebSocket) -> None:
+async def _honest_pake_to_finalize(
+    client_ews: EncryptedWebSocket, *, nonce_b: str | None = None
+) -> None:
     """Drive an honest static-PIN PAKE round, stopping just before ``client/pair-finalize``."""
     sid = b"sendspin-pair-pake-v1" + _HANDSHAKE_HASH + (0).to_bytes(4, "big")
     await client_ews.send_str(
@@ -734,9 +762,33 @@ async def _honest_pake_to_finalize(client_ews: EncryptedWebSocket) -> None:
     await client_ews.receive()  # server/pair-confirm
     await client_ews.send_str(
         ClientPairConfirmMessage(
-            payload=ClientPairConfirmPayload(client_kc=b64url_encode(cpace.tag())),
+            payload=ClientPairConfirmPayload(client_kc=b64url_encode(cpace.tag()), nonce_B=nonce_b),
         ).to_json(),
     )
+
+
+async def test_static_pin_server_rejects_dynamic_only_nonce_b() -> None:
+    """A static-PIN pair-confirm carrying nonce_B is a protocol error."""
+    client_ews, server_ews, _client_raw, _server_raw = _paired_encrypted_ws()
+    server_store = InMemoryServerPairingStore()
+
+    async def provide() -> str:
+        return _STATIC_PIN
+
+    with pytest.raises(PairingError, match="nonce_B for static PIN"):
+        await asyncio.gather(
+            run_static_pin_server(
+                server_ews,
+                handshake_hash=_HANDSHAKE_HASH,
+                pairing_index=0,
+                pin_provider=provide,
+                client_id="client-A",
+                store=server_store,
+            ),
+            _honest_pake_to_finalize(client_ews, nonce_b=b64url_encode(pin_mod.generate_nonce())),
+        )
+
+    assert await server_store.record_by_client_id("client-A") is None
 
 
 @pytest.mark.parametrize(

--- a/tests/noise/test_trust_store.py
+++ b/tests/noise/test_trust_store.py
@@ -416,6 +416,32 @@ async def test_client_store_remove_and_list(client_store: ClientPairingStore) ->
     await client_store.remove_record("absent")
 
 
+async def test_client_store_replace_record_drops_prior_for_server(
+    client_store: ClientPairingStore,
+) -> None:
+    """Re-pairing a server leaves a single record, keyed by the newest psk_id."""
+    old = _client_record(server_id="server-X")
+    await client_store.store_record(old)
+    new = _client_record(server_id="server-X")
+    await client_store.replace_record_for_server_id(new)
+    for_server = [r for r in await client_store.list_records() if r.server_id == "server-X"]
+    assert for_server == [new]
+    assert await client_store.record_by_psk_id(old.psk_id) is None
+
+
+async def test_client_store_replace_record_keeps_shared_records(
+    client_store: ClientPairingStore,
+) -> None:
+    """A shared record binds to no server, so replacing one leaves the others alone."""
+    existing = _shared_record()
+    await client_store.store_record(existing)
+
+    await client_store.replace_record_for_server_id(_shared_record())
+
+    assert await client_store.record_by_psk_id(existing.psk_id) == existing
+
+
+
 async def test_client_store_reports_no_storage_accounting_by_default(
     client_store: ClientPairingStore,
 ) -> None:

--- a/tests/noise/test_trust_store.py
+++ b/tests/noise/test_trust_store.py
@@ -441,7 +441,6 @@ async def test_client_store_replace_record_keeps_shared_records(
     assert await client_store.record_by_psk_id(existing.psk_id) == existing
 
 
-
 async def test_client_store_reports_no_storage_accounting_by_default(
     client_store: ClientPairingStore,
 ) -> None:


### PR DESCRIPTION
Re-pairing could leave superseded server credentials usable alongside their replacements. Replace prior per-server records while preserving shared records, and reject dynamic-PIN-only fields in static-PIN exchanges.