### PR TITLE
Fix stalled client connections and allow AES-GCM

### DIFF
--- a/aiosendspin/client/client.py
+++ b/aiosendspin/client/client.py
@@ -32,6 +32,7 @@ from aiosendspin.models.visualizer import ClientHelloVisualizerSupport, Visualiz
 from aiosendspin.noise.driver import HandshakeAbortedError
 from aiosendspin.noise.keys import Identity
 from aiosendspin.noise.pairing import PairingError
+from aiosendspin.noise.session import NoiseCipherSuite
 from aiosendspin.noise.trust_store import ClientPairingStore, ResolvedPsk
 
 from .connection import DECODABLE_CODECS, UNSYNCED_PLAY_LEAD_US, SendspinConnection
@@ -202,6 +203,7 @@ class SendspinClient:
         pin_display: Callable[[str | None], Awaitable[None]] | None = None,
         pairing_window: Callable[[], Awaitable[None]] | None = None,
         clock: Clock | None = None,
+        cipher_suite: NoiseCipherSuite = NoiseCipherSuite.CHACHAPOLY,
     ) -> None:
         """Create a new Sendspin client instance."""
         self._identity = identity
@@ -213,6 +215,7 @@ class SendspinClient:
         self._pin_display = pin_display
         self._pairing_window = pairing_window
         self._clock: Clock = clock or RawMonotonicClock()
+        self._cipher_suite = cipher_suite
 
         # Validate and store player support
         if Roles.PLAYER in self._roles:
@@ -273,6 +276,11 @@ class SendspinClient:
     def identity(self) -> Identity:
         """This client's static public X25519 identity."""
         return self._identity
+
+    @property
+    def cipher_suite(self) -> NoiseCipherSuite:
+        """Noise cipher suite this client picks for its handshakes."""
+        return self._cipher_suite
 
     @property
     def client_name(self) -> str:

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -92,7 +92,6 @@ from aiosendspin.noise.pairing import (
     run_pairing_psk_client,
     run_static_pin_client,
 )
-from aiosendspin.noise.session import NoiseCipherSuite
 from aiosendspin.noise.trust_store import PskCategory, ResolvedPsk
 from aiosendspin.noise.wire import EncryptedWebSocket
 
@@ -343,7 +342,7 @@ class SendspinConnection:
             result = await run_handshake_client(
                 raw_ws,
                 local_identity=self._client.identity,
-                suite=NoiseCipherSuite.CHACHAPOLY,
+                suite=self._client.cipher_suite,
                 psk_resolver=self._resolve_psk,
                 expected_server_id=expected_server_id,
             )

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -125,8 +125,8 @@ _ManagementRequest = (
     | ManagementSetPairingConfigMessage
 )
 
-# A provisional (incoming) connection must complete bring-up through its first
-# server/activate within this window or be dropped (spec: multi-server admission).
+# A provisional connection must complete bring-up through its first server/activate
+# within this window or be dropped (spec: multi-server admission).
 PROVISIONAL_CONNECTION_TIMEOUT_S: float = 30.0
 
 # Backstop for the post-pairing transition (re-handshake → hello → activate); the per-message
@@ -300,13 +300,21 @@ class SendspinConnection:
         self, raw_ws: ClientWebSocketResponse, *, expected_server_id: str | None
     ) -> None:
         """Run the handshake over a client-initiated ``raw_ws`` and bring the connection up."""
-        await self._run_noise_handshake(raw_ws, expected_server_id=expected_server_id)
-        await self._run_inner_handshake()
+        await self._bring_up(raw_ws, expected_server_id=expected_server_id)
 
     async def attach_websocket(
         self, ws: web.WebSocketResponse, *, expected_server_id: str | None
     ) -> None:
         """Run the handshake over an incoming ``ws`` and bring the connection up."""
+        await self._bring_up(ws, expected_server_id=expected_server_id)
+
+    async def _bring_up(
+        self,
+        ws: ClientWebSocketResponse | web.WebSocketResponse,
+        *,
+        expected_server_id: str | None,
+    ) -> None:
+        """Reach the first server/activate under a bring-up timeout, closing on stall."""
         try:
             async with asyncio.timeout(PROVISIONAL_CONNECTION_TIMEOUT_S):
                 await self._run_noise_handshake(ws, expected_server_id=expected_server_id)

--- a/tests/client/test_cipher_suite.py
+++ b/tests/client/test_cipher_suite.py
@@ -1,0 +1,35 @@
+"""The client's configured Noise cipher suite drives its handshake."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from aiosendspin.client.connection import SendspinConnection
+from aiosendspin.models.types import Roles
+from aiosendspin.noise.session import NoiseCipherSuite
+from aiosendspin.noise.trust_store import PskCategory
+from tests.conftest import make_sdk_client
+
+if TYPE_CHECKING:
+    import pytest
+
+
+async def test_handshake_uses_configured_cipher_suite(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-default cipher suite is passed through to the Noise handshake."""
+    sdk = make_sdk_client(
+        client_name="c", roles=[Roles.CONTROLLER], cipher_suite=NoiseCipherSuite.AESGCM
+    )
+    connection = SendspinConnection(sdk)
+    captured: dict[str, NoiseCipherSuite] = {}
+
+    async def fake_handshake(_raw_ws: object, *, suite: NoiseCipherSuite, **_: object) -> MagicMock:
+        captured["suite"] = suite
+        result = MagicMock()
+        result.psk.category = PskCategory.SENTINEL
+        return result
+
+    monkeypatch.setattr("aiosendspin.client.connection.run_handshake_client", fake_handshake)
+    await connection._run_noise_handshake(MagicMock(), expected_server_id=None)  # noqa: SLF001
+
+    assert captured["suite"] is NoiseCipherSuite.AESGCM

--- a/tests/test_client_admission.py
+++ b/tests/test_client_admission.py
@@ -469,10 +469,11 @@ async def test_provisional_connection_times_out_during_bringup(
     assert connection._closed.is_set()
 
 
-async def test_client_initiated_connection_has_no_bringup_deadline(
+async def test_client_initiated_connection_times_out_during_bringup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A client-initiated dial imposes no internal bring-up deadline."""
+    """A client-initiated dial drops itself if bring-up never reaches server/activate."""
+    monkeypatch.setattr("aiosendspin.client.connection.PROVISIONAL_CONNECTION_TIMEOUT_S", 0.02)
     client = _client()
     connection = SendspinConnection(client)
 
@@ -481,18 +482,14 @@ async def test_client_initiated_connection_has_no_bringup_deadline(
         connection._ws = raw_ws  # type: ignore[assignment]
 
     async def fake_inner() -> None:
-        await asyncio.Event().wait()
+        await asyncio.Event().wait()  # never reaches server/activate
 
     monkeypatch.setattr(connection, "_run_noise_handshake", fake_handshake)
     monkeypatch.setattr(connection, "_run_inner_handshake", fake_inner)
 
     with pytest.raises(TimeoutError):
-        await asyncio.wait_for(
-            connection.connect(_BlockingWebSocket(), expected_server_id=None),  # type: ignore[arg-type]
-            0.1,
-        )
-    # The deadline came from wait_for, not an internal timeout: still live.
-    assert not connection._closed.is_set()
+        await connection.connect(_BlockingWebSocket(), expected_server_id=None)  # type: ignore[arg-type]
+    assert connection._closed.is_set()
 
 
 async def test_client_seeds_last_playback_server_from_store() -> None:


### PR DESCRIPTION
Client-initiated connections could wait indefinitely when a server stalled before activation, leaving the socket and provisional connection state open. Apply the existing 30-second bring-up deadline to both connection directions and clean up whichever transport stage was reached on timeout. Allow clients to select either AES-GCM or ChaChaPoly for Noise encryption while retaining ChaChaPoly as the default.