### PR TITLE
Add missing model module exports

### DIFF
--- a/aiosendspin/models/__init__.py
+++ b/aiosendspin/models/__init__.py
@@ -19,8 +19,10 @@ __all__ = [
     "ServerMessage",
     "UndefinedField",
     "artwork",
+    "color",
     "controller",
     "core",
+    "management",
     "metadata",
     "pack_binary_header",
     "pack_binary_header_raw",
@@ -29,11 +31,23 @@ __all__ = [
     "undefined_field",
     "unpack_binary_header",
     "visualizer",
+    "visualizer_draft_r1",
 ]
 import struct
 from typing import NamedTuple
 
-from . import artwork, controller, core, metadata, player, types, visualizer
+from . import (
+    artwork,
+    color,
+    controller,
+    core,
+    management,
+    metadata,
+    player,
+    types,
+    visualizer,
+    visualizer_draft_r1,
+)
 from .core import DeviceInfo
 from .types import (
     AudioCodec,

--- a/tests/models/test_package_exports.py
+++ b/tests/models/test_package_exports.py
@@ -1,0 +1,12 @@
+"""The models package surfaces every model submodule."""
+
+from __future__ import annotations
+
+from aiosendspin import models
+
+
+def test_all_model_submodules_are_exported() -> None:
+    """color, management, and visualizer_draft_r1 are exported like their siblings."""
+    for name in ("color", "management", "visualizer_draft_r1"):
+        assert name in models.__all__
+        assert hasattr(models, name)


### PR DESCRIPTION
The `color`, `management`, and `visualizer_draft_r1` model modules were not exposed through `aiosendspin.models` like the other model modules. Exporting them as package attributes and through `__all__` makes package-level access, wildcard imports, and API discovery consistent.