### PR TITLE
Add pairing abort notifications for clients

### DIFF
--- a/aiosendspin/client/client.py
+++ b/aiosendspin/client/client.py
@@ -80,6 +80,9 @@ AudioChunkCallback = Callable[[int, bytes, AudioFormat], None]
 # Callback invoked when the client disconnects from the server.
 DisconnectCallback = Callable[[], None]
 
+# Callback invoked with the abort reason when a non-closing pairing attempt ends.
+PairingAbortCallback = Callable[[PairAbortReason], None]
+
 # Callback invoked when server sends player commands (volume, mute).
 ServerCommandCallback = Callable[[ServerCommandPayload], None]
 
@@ -162,6 +165,8 @@ class SendspinClient:
     """Callbacks invoked when audio chunks are received."""
     _disconnect_callbacks: list[DisconnectCallback]
     """Callbacks invoked when the client disconnects."""
+    _pairing_abort_callbacks: list[PairingAbortCallback]
+    """Callbacks invoked when a non-closing pairing attempt ends with an abort reason."""
     _server_command_callbacks: list[ServerCommandCallback]
     """Callbacks invoked when server sends player commands."""
     _visualizer_callbacks: list[VisualizerCallback]
@@ -256,6 +261,7 @@ class SendspinClient:
         self._stream_clear_callbacks = []
         self._audio_chunk_callbacks = []
         self._disconnect_callbacks = []
+        self._pairing_abort_callbacks = []
         self._server_command_callbacks = []
         self._visualizer_callbacks = []
         self._artwork_callbacks = []
@@ -788,6 +794,19 @@ class SendspinClient:
             else None
         )
 
+    def add_pairing_abort_listener(self, callback: PairingAbortCallback) -> Callable[[], None]:
+        """Add a listener for non-closing pairing aborts.
+
+        Returns:
+            A function that removes this listener when called.
+        """
+        self._pairing_abort_callbacks.append(callback)
+        return lambda: (
+            self._pairing_abort_callbacks.remove(callback)
+            if callback in self._pairing_abort_callbacks
+            else None
+        )
+
     def add_server_command_listener(self, callback: ServerCommandCallback) -> Callable[[], None]:
         """Add a listener for server command events.
 
@@ -891,6 +910,14 @@ class SendspinClient:
                 callback()
             except Exception:
                 logger.exception("Error in disconnect callback %s", callback)
+
+    def notify_pairing_abort_callback(self, reason: PairAbortReason) -> None:
+        """Dispatch a non-closing pairing abort to the registered listeners."""
+        for callback in list(self._pairing_abort_callbacks):
+            try:
+                callback(reason)
+            except Exception:
+                logger.exception("Error in pairing abort callback %s", callback)
 
     def notify_server_command_callback(self, payload: ServerCommandPayload) -> None:
         """Dispatch a server/command to the registered listeners."""

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -493,6 +493,7 @@ class SendspinConnection:
                     logger.info(
                         "Pairing attempt with %s ended: %s", self._server_id, err.reason.value
                     )
+                    self._client.notify_pairing_abort_callback(err.reason)
                 return
             if (reason := await self._apply_activation(activate)) is not None:
                 await self._goodbye_and_disconnect(reason)

--- a/tests/client/test_pairing_abort_surface.py
+++ b/tests/client/test_pairing_abort_surface.py
@@ -1,0 +1,24 @@
+"""Non-closing pairing aborts are surfaced to registered SDK listeners."""
+
+from __future__ import annotations
+
+from aiosendspin.client.connection import SendspinConnection
+from aiosendspin.models.types import PairAbortReason, Roles
+from aiosendspin.noise.pairing import RemotePairingAbortError
+from tests.conftest import make_sdk_client
+
+
+async def test_non_closing_pairing_abort_notifies_listener() -> None:
+    """A non-closing abort during pairing reaches the pairing-abort listener with its reason."""
+    sdk = make_sdk_client(client_name="c", roles=[Roles.CONTROLLER])
+    reasons: list[PairAbortReason] = []
+    sdk.add_pairing_abort_listener(reasons.append)
+    connection = SendspinConnection(sdk)
+
+    async def _abort() -> str | None:
+        raise RemotePairingAbortError(PairAbortReason.LOCKED_OUT)
+
+    connection._run_pairing_protocol = _abort  # type: ignore[method-assign]  # noqa: SLF001
+    await connection._pair()  # noqa: SLF001
+
+    assert reasons == [PairAbortReason.LOCKED_OUT]

--- a/tests/client/test_pairing_abort_surface.py
+++ b/tests/client/test_pairing_abort_surface.py
@@ -16,9 +16,9 @@ async def test_non_closing_pairing_abort_notifies_listener() -> None:
     connection = SendspinConnection(sdk)
 
     async def _abort() -> str | None:
-        raise RemotePairingAbortError(PairAbortReason.LOCKED_OUT)
+        raise RemotePairingAbortError(PairAbortReason.USER_CANCELLED)
 
     connection._run_pairing_protocol = _abort  # type: ignore[method-assign]  # noqa: SLF001
     await connection._pair()  # noqa: SLF001
 
-    assert reasons == [PairAbortReason.LOCKED_OUT]
+    assert reasons == [PairAbortReason.USER_CANCELLED]


### PR DESCRIPTION
Non-closing pairing aborts previously left SDK consumers without a signal explaining why pairing stopped. Add a listener that reports the abort reason while preserving the connection for another pairing attempt.