### PR TITLE
Fix audio dropouts after a player rejoins or reconnects

### DIFF
--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -998,11 +998,11 @@ class PushStream:
     ) -> int:
         """Return a safe minimum playback timestamp for late-join replay."""
         now_us = self._clock.now_us()
-        delay_us = role.get_static_delay_us() if role is not None else 0
-        effective_lead_us = max(0, min_lead_us)
         if role is not None:
-            effective_lead_us = max(effective_lead_us, role.get_required_lead_time_us())
-        target_us = now_us + effective_lead_us + delay_us
+            effective_lead_us = max(min_lead_us, self._role_send_ahead_us(role))
+        else:
+            effective_lead_us = max(0, min_lead_us)
+        target_us = now_us + effective_lead_us
         if align_to_channel_tail and channel_id is not None and channel_id in self._channel_timing:
             # For channels that currently have no other subscribers, anchor catch-up
             # to that channel's own live tail when it is near real time. If that tail

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -272,8 +272,8 @@ async def test_late_join_target_includes_player_static_delay() -> None:
 
     stream = PushStream(loop=loop, clock=clock, group=group)
 
-    # now + max(LATE_JOINER_MIN_LEAD_US=100ms, required_lead=250ms) + static_delay=5s
-    assert stream.get_late_join_target_timestamp_us(role=role) == 6_250_000
+    # now + max(min_buffer=500ms, required_lead=250ms) + static_delay=5s
+    assert stream.get_late_join_target_timestamp_us(role=role) == 6_500_000
 
 
 @pytest.mark.asyncio
@@ -305,12 +305,37 @@ async def test_late_join_target_uses_required_lead_time() -> None:
     role = client.role("player@v1")
     assert role is not None
     role.static_delay_ms = 5_000
-    role.required_lead_time_ms = 400  # > 100ms default floor
+    role.required_lead_time_ms = 400
+    role.min_buffer_ms = 100  # below required_lead, so required_lead is the binding floor
 
     stream = PushStream(loop=loop, clock=clock, group=group)
 
-    # now + max(100ms, 400ms required_lead) + 5s static_delay
+    # now + max(100ms min_buffer, 400ms required_lead) + 5s static_delay
     assert stream.get_late_join_target_timestamp_us(role=role) == 6_400_000
+
+
+@pytest.mark.asyncio
+async def test_late_join_target_matches_fresh_start_floor() -> None:
+    """A rejoin gets the buffer horizon the client advertised, same as a fresh start.
+
+    Anchoring late joins at required_lead_time alone left a regrouped or reconnected
+    player with a fraction of the jitter headroom the same client gets on a fresh
+    start, so ordinary network jitter pushed chunks past their play deadline.
+    """
+    loop = asyncio.get_running_loop()
+    clock = ManualClock(now_us_value=1_000_000)
+    group = _DummyGroup(clients=[])
+    client, _ = _make_connected_player(loop, group, "p1", clock=clock)
+    role = client.role("player@v1")
+    assert role is not None
+    role.static_delay_ms = 0
+    role.required_lead_time_ms = 250
+    role.min_buffer_ms = 1_000
+
+    stream = PushStream(loop=loop, clock=clock, group=group)
+
+    # now + max(1s min_buffer, 250ms required_lead)
+    assert stream.get_late_join_target_timestamp_us(role=role) == 2_000_000
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes a regression from #293, which adopted the `min_buffer` floor in the fresh-start path only and left the late-join path on the earlier `required_lead + static` rule, first shipping in 7.0.0.

`get_late_join_target_timestamp_us` anchored late joins at `max(100ms, required_lead_time_ms)` and ignored `min_buffer_ms`, so a player that rejoined, regrouped or reconnected replayed its catch-up burst with only its lead time of buffer instead of the buffer horizon it advertised, leaving ordinary network jitter enough room to push those chunks past their play deadline. The deficit lasts until the joiner catches up to the live tail and then recovers on its own, so it costs the joiner audio at the start of a session rather than throughout it. The spec schedules the first chunk at least `min_buffer_ms + static_delay_ms` ahead, which the fresh-start path already does via `_role_send_ahead_us`.

Related:
- https://github.com/music-assistant/support/issues/5926
