### PR TITLE
Improve PIN pairing window

### DIFF
--- a/aiosendspin/client/__init__.py
+++ b/aiosendspin/client/__init__.py
@@ -11,7 +11,7 @@ from .client import (
     VisualizerCallback,
 )
 from .listener import ClientListener
-from .models import AudioFormat, PCMFormat, ServerInfo
+from .models import AudioFormat, PairingSupport, PCMFormat, ServerInfo
 from .source import SourceCapture
 from .time_sync import SendspinTimeFilter
 
@@ -23,6 +23,7 @@ __all__ = [
     "GroupUpdateCallback",
     "MetadataCallback",
     "PCMFormat",
+    "PairingSupport",
     "SendspinClient",
     "SendspinTimeFilter",
     "ServerInfo",

--- a/aiosendspin/client/client.py
+++ b/aiosendspin/client/client.py
@@ -37,10 +37,12 @@ from aiosendspin.noise.session import NoiseCipherSuite
 from aiosendspin.noise.trust_store import ClientPairingStore, ResolvedPsk
 
 from .connection import DECODABLE_CODECS, UNSYNCED_PLAY_LEAD_US, SendspinConnection
-from .models import AudioFormat, ServerInfo
+from .models import AudioFormat, PairingSupport, ServerInfo
 from .source import SourceCapture
 
 logger = logging.getLogger(__name__)
+
+_PAIRING_WINDOW_LIFETIME_S: float = 300.0
 
 
 def _validate_decodable_formats(player_support: ClientHelloPlayerSupport) -> None:
@@ -149,6 +151,15 @@ class SendspinClient:
     _admission_lock: asyncio.Lock
     """Serializes the admit/displace decision across concurrent connections."""
 
+    _pairing_support: PairingSupport | None
+    """Operator wiring whose presence enables the PIN methods, if configured."""
+    _pairing_window_opened: asyncio.Event
+    """Set when a pairing window opens; wakes a gated attempt's wait."""
+    _pairing_window_deadline: float | None = None
+    """Loop-time deadline of the open pairing window, if one is open."""
+    _pairing_window_waiters: int = 0
+    """Gated attempts currently waiting for a window; refcounts the gesture prompt."""
+
     last_playback_server_id: str | None = None
     """server_id of the last server admitted with the playback activity; the discovery tiebreak."""
 
@@ -205,8 +216,7 @@ class SendspinClient:
         initial_volume: int = 100,
         initial_muted: bool = False,
         state_supported_commands: list[PlayerCommand] | None = None,
-        pin_display: Callable[[str | None], Awaitable[None]] | None = None,
-        pairing_window: Callable[[], Awaitable[None]] | None = None,
+        pairing_support: PairingSupport | None = None,
         clock: Clock | None = None,
         cipher_suite: NoiseCipherSuite = NoiseCipherSuite.CHACHAPOLY,
     ) -> None:
@@ -217,8 +227,7 @@ class SendspinClient:
         self._device_info = device_info
         self._roles = list(roles)
         self._pairing_store = pairing_store
-        self._pin_display = pin_display
-        self._pairing_window = pairing_window
+        self._pairing_support = pairing_support
         self._clock: Clock = clock or RawMonotonicClock()
         self._cipher_suite = cipher_suite
 
@@ -266,6 +275,7 @@ class SendspinClient:
         self._provisional_connections = set()
         self._admission_lock = asyncio.Lock()
         self._last_playback_loaded = False
+        self._pairing_window_opened = asyncio.Event()
 
         # Initialize callback lists
         self._metadata_callbacks = []
@@ -349,27 +359,56 @@ class SendspinClient:
         Called with the PIN string when one is derived, and with ``None`` when the
         pairing exchange ends (success or failure) so the channel can clear.
         """
-        return self._pin_display
+        return self._pairing_support.pin_display if self._pairing_support is not None else None
 
     @property
-    def pairing_window(self) -> Callable[[], Awaitable[None]] | None:
-        """Gesture gate for static-PIN pairing, if configured.
+    def pairing_window_open(self) -> bool:
+        """Whether a pairing window is currently open."""
+        deadline = self._pairing_window_deadline
+        return deadline is not None and self._loop.time() < deadline
 
-        Awaited when a static-PIN attempt is selected; resolves once the operator
-        opens the pairing window, and is cancelled if the server ends the attempt
-        first. The callable owns the window lifetime: an expired window must not
-        resolve the wait. Its presence enables offering ``static_pin``.
+    async def await_pairing_window(self) -> None:
+        """Resolve once a pairing window is open, prompting for a gesture meanwhile."""
+        if self.pairing_window_open:
+            return
+        support = self._pairing_support
+        prompt = support.gesture_prompt if support is not None else None
+        self._pairing_window_waiters += 1
+        try:
+            if self._pairing_window_waiters == 1 and prompt is not None:
+                await prompt(True)  # noqa: FBT003
+            while not self.pairing_window_open:
+                self._pairing_window_opened.clear()
+                await self._pairing_window_opened.wait()
+        finally:
+            self._pairing_window_waiters -= 1
+            if self._pairing_window_waiters == 0 and prompt is not None:
+                await prompt(False)  # noqa: FBT003
+
+    def consume_pairing_window(self) -> None:
+        """Close the pairing window as a pairing attempt starts."""
+        self._pairing_window_deadline = None
+        self._pairing_window_opened.clear()
+
+    def open_pairing_window(self) -> None:
+        """Open a pairing window admitting one gesture-gated pairing attempt.
+
+        Called on an operator gesture, or by a paired server through
+        ``management/open-pairing-window``. A no-op while a window is already open.
         """
-        return self._pairing_window
+        if self.pairing_window_open:
+            return
+        self._pairing_window_deadline = self._loop.time() + _PAIRING_WINDOW_LIFETIME_S
+        self._pairing_window_opened.set()
 
     @property
     def implemented_pair_methods(self) -> frozenset[PairMethod]:
         """Pairing methods this client implements: each PIN method needs its wiring."""
         methods = {PairMethod.PAIRING_PSK}
-        if self._pairing_window is not None:
+        if self._pairing_support is not None:
             methods.add(PairMethod.STATIC_PIN)
-        if self._pin_display is not None:
-            methods.add(PairMethod.DYNAMIC_PIN)
+            if self._pairing_support.pin_display is not None:
+                methods.add(PairMethod.DYNAMIC_PIN)
         return frozenset(methods)
 
     @property

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -20,6 +20,7 @@ from aiosendspin.models import (
 )
 from aiosendspin.models.controller import ControllerCommandPayload
 from aiosendspin.models.core import (
+    ActivatePairing,
     ClientCommandMessage,
     ClientCommandPayload,
     ClientGoodbyeMessage,
@@ -52,6 +53,7 @@ from aiosendspin.models.management import (
     ManagementAddRecordMessage,
     ManagementGetPairingConfigMessage,
     ManagementListRecordsMessage,
+    ManagementOpenPairingWindowMessage,
     ManagementRemoveRecordMessage,
     ManagementResultMessage,
     ManagementResultPayload,
@@ -92,6 +94,8 @@ from aiosendspin.noise.driver import (
 )
 from aiosendspin.noise.keys import psk_id_for
 from aiosendspin.noise.models import (
+    ClientPairPendingMessage,
+    ClientPairPendingPayload,
     NoiseHandshakeMessage,
     PairAbortMessage,
     PairAbortPayload,
@@ -105,6 +109,7 @@ from aiosendspin.noise.pairing import (
     run_pairing_psk_client,
     run_static_pin_client,
 )
+from aiosendspin.noise.pin import MAX_PIN_DIGITS, MIN_PIN_DIGITS, SHORT_PIN_DIGITS
 from aiosendspin.noise.trust_store import PskCategory, ResolvedPsk
 from aiosendspin.noise.wire import EncryptedWebSocket
 
@@ -113,6 +118,7 @@ from .management import (
     handle_add_record,
     handle_get_pairing_config,
     handle_list_records,
+    handle_open_pairing_window,
     handle_remove_record,
     handle_set_pairing_config,
     handle_unpair,
@@ -135,6 +141,7 @@ _ManagementRequest = (
     | ManagementRemoveRecordMessage
     | ManagementGetPairingConfigMessage
     | ManagementSetPairingConfigMessage
+    | ManagementOpenPairingWindowMessage
 )
 
 # A provisional connection must complete bring-up through its first server/activate
@@ -147,9 +154,6 @@ POST_PAIRING_ACTIVATE_TIMEOUT_S: float = 60.0
 
 # Lead time applied to play-time estimates before clock sync converges.
 UNSYNCED_PLAY_LEAD_US: int = 500_000
-
-# PIN-pairing method families, subject to lockout and the locked_out descriptor.
-_PIN_METHODS: list[PairMethod] = [PairMethod.DYNAMIC_PIN, PairMethod.STATIC_PIN]
 
 # psk_id of the Sentinel PSK — the client matches it during PIN pairing / discovery.
 _SENTINEL_PSK_ID: str = psk_id_for(SENTINEL_PSK)
@@ -259,7 +263,7 @@ class SendspinConnection:
         self._reported_volume = client.initial_volume
         self._reported_muted = client.initial_muted
         self._reported_source_signal: SignalState | None = None
-        self._selected_pair_method: PairMethod | None = None
+        self._selected_pairing: ActivatePairing | None = None
         self._pairing_index = 0
         self._pairing_attempt_in_progress = False
         self._exchange_in_progress = False
@@ -474,7 +478,7 @@ class SendspinConnection:
             self._active_roles = payload.active_roles
             if source_dropped and self._source_stream_active and self.connected:
                 await self.send_client_stream_end()
-        self._selected_pair_method = payload.selected_pair_method
+        self._selected_pairing = payload.pairing
         await self._client.note_playback_activity(self)
         return None
 
@@ -549,9 +553,8 @@ class SendspinConnection:
         assert self._server_id is not None
         self._pairing_index += 1
         pairing_index = self._pairing_index
-        method = self._selected_pair_method
-        await self._validate_pair_method(method)
-        assert method is not None  # _validate_pair_method rejects None
+        pairing = await self._validate_pairing(self._selected_pairing)
+        method = pairing.method
         store = self._client.pairing_store
         if method is PairMethod.PAIRING_PSK:
             with self._attempt_in_progress():
@@ -559,13 +562,13 @@ class SendspinConnection:
                     self._ws, server_id=self._server_id, store=store
                 )
         assert self._handshake_hash is not None
-        if await store.is_pin_locked_out(method):
-            await self._abort_pairing(PairAbortReason.LOCKED_OUT)
         if method is PairMethod.STATIC_PIN:
             static_pin = await store.static_pin()
             assert static_pin is not None  # offered only when configured
-            if (leave := await self._await_pairing_window()) is not None:
+            # Every static-PIN attempt is gesture-gated.
+            if (leave := await self._gate_on_pairing_window(pairing_index)) is not None:
                 return leave
+            self._client.consume_pairing_window()
             with self._attempt_in_progress():
                 return await run_static_pin_client(
                     self._ws,
@@ -575,12 +578,20 @@ class SendspinConnection:
                     server_id=self._server_id,
                     store=store,
                 )
-        try:  # PairMethod.DYNAMIC_PIN
+        # PairMethod.DYNAMIC_PIN: gesture-gated only when escalated or the PIN is short.
+        pin_length = await self._validate_pin_length(pairing.pin_length)
+        if (await store.is_pin_escalated() or pin_length < SHORT_PIN_DIGITS) and (
+            leave := await self._gate_on_pairing_window(pairing_index)
+        ) is not None:
+            return leave
+        self._client.consume_pairing_window()
+        try:
             with self._attempt_in_progress():
                 return await run_dynamic_pin_client(
                     self._ws,
                     handshake_hash=self._handshake_hash,
                     pairing_index=pairing_index,
+                    pin_length=pin_length,
                     pin_emitter=self._emit_pin,
                     server_id=self._server_id,
                     store=store,
@@ -598,23 +609,31 @@ class SendspinConnection:
         finally:
             self._pairing_attempt_in_progress = False
 
-    async def _await_pairing_window(self) -> str | None:
-        """Wait for the operator gesture without leaving the socket unread.
+    async def _gate_on_pairing_window(self, pairing_index: int) -> str | None:
+        """Hold a gesture-gated attempt until a pairing window is open.
 
-        Returns the raw ``server/activate`` frame if the server leaves pairing before
-        an attempt started, else ``None`` once the gesture arrives.
-        Anything else received during the wait - the ``pair/abort`` withdrawing the
-        attempt, an unexpected frame, or a close - raises out of the pending receive.
+        With no window open, signals ``client/pair-pending`` first and waits without
+        leaving the socket unread. Returns the raw ``server/activate`` frame if the
+        server leaves pairing first, else ``None``.
         """
-        assert self._client.pairing_window is not None  # offered only when set
         assert self._ws is not None
-        window = asyncio.ensure_future(self._client.pairing_window())
+        if self._client.pairing_window_open:
+            return None
+        await self._ws.send_str(
+            ClientPairPendingMessage(
+                payload=ClientPairPendingPayload(pairing_index=pairing_index),
+            ).to_json(),
+        )
+        window = asyncio.ensure_future(self._client.await_pairing_window())
         receive = asyncio.create_task(receive_pairing_abort(self._ws))
         try:
             done, _ = await asyncio.wait((window, receive), return_when=asyncio.FIRST_COMPLETED)
         finally:
             window.cancel()
             receive.cancel()
+        if window not in done:
+            # Let the window wait finish unwinding (its cleanup clears the gesture prompt).
+            await asyncio.wait((window,))
         if receive not in done:
             # The cancelled receive must exit ws.receive() before anyone else may read.
             await asyncio.wait((receive,))
@@ -627,12 +646,12 @@ class SendspinConnection:
 
     async def _resolve_pairing_activate(self, leftover: str | None) -> ServerActivatePayload:
         """Resolve the server/activate that ends pairing, re-handshaking first if it finalized."""
-        method = self._selected_pair_method
-        assert method is not None
+        pairing = self._selected_pairing
+        assert pairing is not None
         async with asyncio.timeout(POST_PAIRING_ACTIVATE_TIMEOUT_S):
             if leftover is None:
                 # Server finalized and re-handshakes onto the new long-term PSK.
-                logger.info("Paired with server %s via %s", self._server_id, method.value)
+                logger.info("Paired with server %s via %s", self._server_id, pairing.method.value)
                 await self._rehandshake()
                 return await self._exchange_hellos()
             # Server left pairing without finalizing: apply the leave server/activate.
@@ -668,16 +687,26 @@ class SendspinConnection:
         """Whether the client currently admits unpaired access (from pairing config)."""
         return (await self._client.pairing_store.get_pairing_config()).unpaired_access_enabled
 
-    async def _validate_pair_method(self, method: PairMethod | None) -> None:
-        """Reject a pairing method the matched PSK disallows or the client did not offer."""
+    async def _validate_pairing(self, pairing: ActivatePairing | None) -> ActivatePairing:
+        """Reject a pairing whose method the matched PSK disallows or the client did not offer."""
         assert self._noise_psk is not None
+        method = pairing.method if pairing is not None else None
         # pairing_psk iff the matched PSK is the Pairing PSK; a PIN method otherwise.
         method_fits_psk = (method is PairMethod.PAIRING_PSK) == (
             self._noise_psk.category is PskCategory.PAIRING
         )
         supported = await self._supported_pair_methods()
-        if method is None or not method_fits_psk or method not in supported:
+        if pairing is None or not method_fits_psk or method not in supported:
             await self._abort_pairing(PairAbortReason.METHOD_NOT_SUPPORTED)
+        return pairing
+
+    async def _validate_pin_length(self, pin_length: int | None) -> int:
+        """Validate the activation's dynamic ``pin_length``, aborting when unacceptable."""
+        config = await self._client.pairing_store.get_pairing_config()
+        min_length = max(config.dynamic_pin_min_length, MIN_PIN_DIGITS)
+        if pin_length is None or not min_length <= pin_length <= MAX_PIN_DIGITS:
+            await self._abort_pairing(PairAbortReason.PIN_LENGTH_UNACCEPTABLE)
+        return pin_length
 
     async def _abort_pairing(self, reason: PairAbortReason) -> NoReturn:
         """Send ``pair/abort``; never returns (the abort raises)."""
@@ -950,20 +979,14 @@ class SendspinConnection:
         return ClientHelloMessage(payload=payload)
 
     async def _pair_method_descriptor(self, method: PairMethod) -> PairMethodDescriptor:
-        """Build the ``client/hello`` descriptor for ``method`` (lockout + out-channels)."""
-        if method not in _PIN_METHODS:
+        """Build the ``client/hello`` descriptor for ``method``."""
+        if method is not PairMethod.DYNAMIC_PIN:
             return PairMethodDescriptor(method=method)
-        min_pin_length = None
-        out_channels = None
-        if method is PairMethod.DYNAMIC_PIN:
-            out_channels = ["display"]
-            config = await self._client.pairing_store.get_pairing_config()
-            min_pin_length = config.dynamic_pin_min_length
+        config = await self._client.pairing_store.get_pairing_config()
         return PairMethodDescriptor(
             method=method,
-            out_channels=out_channels,
-            locked_out=await self._client.pairing_store.is_pin_locked_out(method),
-            min_pin_length=min_pin_length,
+            out_channels=["display"],
+            min_pin_length=config.dynamic_pin_min_length,
         )
 
     def _compute_trust(self) -> TrustLevel:
@@ -1089,6 +1112,7 @@ class SendspinConnection:
                 | ManagementRemoveRecordMessage()
                 | ManagementGetPairingConfigMessage()
                 | ManagementSetPairingConfigMessage()
+                | ManagementOpenPairingWindowMessage()
             ):
                 await self._handle_management_request(message)
             case _:
@@ -1338,6 +1362,12 @@ class SendspinConnection:
             case ManagementSetPairingConfigMessage(payload=request):
                 payload, effect = await handle_set_pairing_config(
                     store, request, implemented_pair_methods=self._client.implemented_pair_methods
+                )
+            case ManagementOpenPairingWindowMessage():
+                payload, effect = await handle_open_pairing_window(
+                    store,
+                    implemented_pair_methods=self._client.implemented_pair_methods,
+                    open_window=self._client.open_pairing_window,
                 )
             case _:
                 assert_never(message)

--- a/aiosendspin/client/management.py
+++ b/aiosendspin/client/management.py
@@ -32,7 +32,7 @@ from aiosendspin.noise.trust_store import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Container
+    from collections.abc import Callable, Container
 
     from aiosendspin.models.management import (
         ManagementAddRecordPayload,
@@ -136,23 +136,17 @@ async def handle_get_pairing_config(
     """Assemble the pairing-config view; secrets are never included."""
     config = await store.get_pairing_config()
     data = ManagementResultData(
-        pairing_psk=await _method_config(
-            store, PairMethod.PAIRING_PSK, enabled=config.pairing_psk_enabled, is_pin=False
-        ),
+        pairing_psk=PairingMethodConfig(enabled=config.pairing_psk_enabled),
         static_pin=(
-            await _method_config(
-                store, PairMethod.STATIC_PIN, enabled=config.static_pin_enabled, is_pin=True
-            )
+            PairingMethodConfig(enabled=config.static_pin_enabled)
             if PairMethod.STATIC_PIN in implemented_pair_methods
             else None
         ),
         dynamic_pin=(
-            await _method_config(
-                store,
-                PairMethod.DYNAMIC_PIN,
+            PairingMethodConfig(
                 enabled=config.dynamic_pin_enabled,
-                is_pin=True,
                 min_pin_length=config.dynamic_pin_min_length,
+                escalated=await store.is_pin_escalated(),
             )
             if PairMethod.DYNAMIC_PIN in implemented_pair_methods
             else None
@@ -178,7 +172,7 @@ async def handle_set_pairing_config(
     # 1. A patch on a method the client does not implement is invalid.
     if any(cfg is not None and method not in implemented_pair_methods for method, cfg in methods):
         return _result(ManagementResult.INVALID), ManagementEffect.NONE
-    # 2. Validate secrets, lockout, and record mode before mutating anything.
+    # 2. Validate secrets and record mode before mutating anything.
     psk_bytes: bytes | None = None
     if payload.pairing_psk is not None and payload.pairing_psk.psk is not None:
         psk_bytes = _decode_psk(payload.pairing_psk.psk)
@@ -190,7 +184,13 @@ async def handle_set_pairing_config(
         and not _valid_static_pin(payload.static_pin.pin)
     ):
         return _result(ManagementResult.INVALID), ManagementEffect.NONE
-    if _rejects_lockout(payload.static_pin) or _rejects_lockout(payload.dynamic_pin):
+    if (
+        payload.static_pin is not None
+        and payload.static_pin.enabled is True
+        and payload.static_pin.pin is None
+        and await store.static_pin() is None
+    ):
+        # Enabling static_pin with no static PIN configured is invalid.
         return _result(ManagementResult.INVALID), ManagementEffect.NONE
     if (
         payload.dynamic_pin is not None
@@ -233,10 +233,28 @@ async def handle_set_pairing_config(
         await store.set_pairing_psk(PairingPsk(psk_id=psk_id_for(psk_bytes), psk=psk_bytes))
     if payload.static_pin is not None and payload.static_pin.pin is not None:
         await store.set_static_pin(payload.static_pin.pin)
-    if payload.static_pin is not None and payload.static_pin.locked_out is False:
-        await store.reset_pin_failures(PairMethod.STATIC_PIN)
-    if payload.dynamic_pin is not None and payload.dynamic_pin.locked_out is False:
-        await store.reset_pin_failures(PairMethod.DYNAMIC_PIN)
+    return _result(ManagementResult.OK), ManagementEffect.NONE
+
+
+async def handle_open_pairing_window(
+    store: ClientPairingStore,
+    *,
+    implemented_pair_methods: Container[PairMethod],
+    open_window: Callable[[], None],
+) -> tuple[ManagementResultPayload, ManagementEffect]:
+    """Open a pairing window in place of the operator gesture.
+
+    Invalid when no PIN method is enabled; a no-op ``ok`` when a window is
+    already open (``open_window`` is expected to absorb that case).
+    """
+    config = await store.get_pairing_config()
+    static_enabled = PairMethod.STATIC_PIN in implemented_pair_methods and config.static_pin_enabled
+    dynamic_enabled = (
+        PairMethod.DYNAMIC_PIN in implemented_pair_methods and config.dynamic_pin_enabled
+    )
+    if not (static_enabled or dynamic_enabled):
+        return _result(ManagementResult.INVALID), ManagementEffect.NONE
+    open_window()
     return _result(ManagementResult.OK), ManagementEffect.NONE
 
 
@@ -265,22 +283,6 @@ async def with_storage(
     return replace(payload, storage=storage)
 
 
-async def _method_config(
-    store: ClientPairingStore,
-    method: PairMethod,
-    *,
-    enabled: bool,
-    is_pin: bool,
-    min_pin_length: int | None = None,
-) -> PairingMethodConfig:
-    """Project a method's stored state into its wire config (no secrets)."""
-    return PairingMethodConfig(
-        enabled=enabled,
-        locked_out=(await store.is_pin_locked_out(method)) if is_pin else None,
-        min_pin_length=min_pin_length,
-    )
-
-
 async def _is_shared_record(store: ClientPairingStore, psk_id: str) -> bool:
     """Return whether ``psk_id`` names a shared-PSK record (long-term, no counterparty)."""
     resolved = await store.resolve_by_psk_id(psk_id)
@@ -303,11 +305,6 @@ def _decode_psk(value: str) -> bytes | None:
 def _valid_static_pin(pin: str) -> bool:
     """Return whether ``pin`` is exactly 8 ASCII decimal digits."""
     return len(pin) == _STATIC_PIN_DIGITS and pin.isascii() and pin.isdigit()
-
-
-def _rejects_lockout(cfg: SetStaticPinConfig | SetDynamicPinConfig | None) -> bool:
-    """Return whether ``cfg`` sets ``locked_out`` to anything but ``false`` (only false clears)."""
-    return cfg is not None and cfg.locked_out is True
 
 
 def _merge_enabled(

--- a/aiosendspin/client/models.py
+++ b/aiosendspin/client/models.py
@@ -3,8 +3,29 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from aiosendspin.models.types import AudioCodec
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+
+@dataclass(frozen=True, slots=True)
+class PairingSupport:
+    """Operator wiring for PIN pairing: an operator can perform the pairing gesture here.
+
+    The gesture itself is reported by calling ``SendspinClient.open_pairing_window``.
+    Its presence enables offering ``static_pin``; ``pin_display`` additionally
+    enables ``dynamic_pin``.
+    """
+
+    gesture_prompt: Callable[[bool], Awaitable[None]] | None = None
+    """Optional operator prompt: awaited with ``True`` when a gated attempt starts
+    waiting for a pairing window, and with ``False`` when the wait ends."""
+    pin_display: Callable[[str | None], Awaitable[None]] | None = None
+    """Out-channel that surfaces a derived dynamic PIN; called with ``None`` when the
+    pairing exchange ends (success or failure) so the channel can clear."""
 
 
 @dataclass(slots=True)

--- a/aiosendspin/models/core.py
+++ b/aiosendspin/models/core.py
@@ -118,8 +118,6 @@ class PairMethodDescriptor(SendspinModel):
     """The pairing method identifier."""
     out_channels: list[str] | None = None
     """For dynamic_pin only: channels through which the PIN is conveyed to the operator."""
-    locked_out: bool | None = None
-    """For PIN methods only: True when the method is in terminal lockout."""
     min_pin_length: int | None = None
     """For dynamic_pin only: shortest PIN length in digits the client will accept (4-12)."""
 
@@ -445,6 +443,21 @@ class LegacyServerHelloMessage(SendspinModel):
 
 # Server -> Client: server/activate
 @dataclass
+class ActivatePairing(SendspinModel):
+    """Parameters of the pairing attempt a server/activate admits."""
+
+    method: PairMethod
+    """Pairing method the server picked, drawn from the client's supported_pair_methods."""
+    pin_length: int | None = None
+    """The dynamic PIN length for this session. Required for dynamic_pin; absent otherwise."""
+
+    class Config(SendspinConfig):
+        """Config for parsing json messages."""
+
+        omit_none = True
+
+
+@dataclass
 class ServerActivatePayload(SendspinModel):
     """Declares the server's current purpose on this connection."""
 
@@ -454,8 +467,8 @@ class ServerActivatePayload(SendspinModel):
     """Versioned role IDs active for this client (e.g., 'player@v1'). Required on
     connections capable of playback; absent otherwise. Persists across subsequent
     server/activate messages that omit it."""
-    selected_pair_method: PairMethod | None = None
-    """Pairing method the server picked. Required when 'pairing' is in activities."""
+    pairing: ActivatePairing | None = None
+    """Parameters of the admitted pairing attempt. Required when 'pairing' is in activities."""
 
     class Config(SendspinConfig):
         """Config for parsing json messages."""

--- a/aiosendspin/models/management.py
+++ b/aiosendspin/models/management.py
@@ -129,8 +129,6 @@ class SetStaticPinConfig(SendspinModel):
     enabled: bool | None = None
     pin: str | None = None
     """8 decimal digits; replaces the configured static PIN."""
-    locked_out: bool | None = None
-    """Only ``false`` is accepted; clears terminal lockout."""
 
     class Config(SendspinConfig):
         """Absent (omitted) fields mean 'leave unchanged'."""
@@ -143,8 +141,6 @@ class SetDynamicPinConfig(SendspinModel):
     """Patch for the dynamic-PIN method; absent fields are left unchanged."""
 
     enabled: bool | None = None
-    locked_out: bool | None = None
-    """Only ``false`` is accepted; clears terminal lockout."""
     min_pin_length: int | None = None
     """Shortest PIN length in digits the client will accept; must be in 4-12."""
 
@@ -190,6 +186,22 @@ class ManagementSetPairingConfigMessage(ServerMessage):
     type: Literal["management/set-pairing-config"] = "management/set-pairing-config"
 
 
+# Server -> Client: management/open-pairing-window
+@dataclass
+class ManagementOpenPairingWindowPayload(SendspinModel):
+    """Empty ``management/open-pairing-window`` payload."""
+
+
+@dataclass
+class ManagementOpenPairingWindowMessage(ServerMessage):
+    """Opens a pairing window on the client in place of the operator gesture."""
+
+    payload: ManagementOpenPairingWindowPayload = field(
+        default_factory=ManagementOpenPairingWindowPayload
+    )
+    type: Literal["management/open-pairing-window"] = "management/open-pairing-window"
+
+
 # Client -> Server: management/result
 @dataclass(kw_only=True)
 class RecordSummary(SendspinModel):
@@ -212,10 +224,10 @@ class PairingMethodConfig(SendspinModel):
     """A method's config in a get-pairing-config result."""
 
     enabled: bool
-    locked_out: bool | None = None
-    """Only present for PIN methods; ``true`` if locked out."""
     min_pin_length: int | None = None
     """For dynamic_pin only: shortest PIN length in digits the client will accept (4-12)."""
+    escalated: bool | None = None
+    """For dynamic_pin only: ``true`` when the failure counter escalated it to gesture-gating."""
 
     class Config(SendspinConfig):
         """Omit method-specific fields where they do not apply."""

--- a/aiosendspin/models/types.py
+++ b/aiosendspin/models/types.py
@@ -261,7 +261,6 @@ class PairAbortReason(Enum):
 
     ATTEMPT_TIMEOUT = "attempt_timeout"
     CONCURRENT_ATTEMPT = "concurrent_attempt"
-    LOCKED_OUT = "locked_out"
     METHOD_NOT_SUPPORTED = "method_not_supported"
     PIN_LENGTH_UNACCEPTABLE = "pin_length_unacceptable"
     PIN_MISMATCH = "pin_mismatch"

--- a/aiosendspin/noise/models.py
+++ b/aiosendspin/noise/models.py
@@ -141,6 +141,22 @@ class PairAbortMessage(PairingMessage):
 
 
 @dataclass
+class ClientPairPendingPayload(SendspinModel):
+    """``client/pair-pending`` payload — a gesture-gated attempt awaits a pairing window."""
+
+    pairing_index: int
+    """Pairing ``server/activate`` message count received since the last Noise handshake."""
+
+
+@dataclass
+class ClientPairPendingMessage(PairingMessage):
+    """Envelope for ``ClientPairPendingPayload``."""
+
+    payload: ClientPairPendingPayload
+    type: Literal["client/pair-pending"] = "client/pair-pending"
+
+
+@dataclass
 class ClientPairInitPayload(SendspinModel):
     """``client/pair-init`` payload — signals readiness for the PIN-pairing flow."""
 
@@ -169,8 +185,6 @@ class ServerPairInitPayload(SendspinModel):
 
     nonce_A: str  # noqa: N815 - spec wire field name
     """32 bytes from a CSPRNG, base64url-encoded (43 chars)."""
-    pin_length: int
-    """Negotiated PIN length in digits: ``max(client_min, server_min)`` clamped to 4-12."""
 
 
 @dataclass

--- a/aiosendspin/noise/pairing.py
+++ b/aiosendspin/noise/pairing.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
-from contextlib import suppress
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, NoReturn, Protocol, cast
+from typing import TYPE_CHECKING, NoReturn, Protocol, cast, overload
 
 from aiohttp import WSMsgType
 from cpace import CPace, CPaceError, CPaceRole
@@ -26,6 +26,7 @@ from .models import (
     ClientPairFinalizePayload,
     ClientPairInitMessage,
     ClientPairInitPayload,
+    ClientPairPendingMessage,
     PairAbortMessage,
     PairAbortPayload,
     PairingMessage,
@@ -41,7 +42,7 @@ from .session import NoiseCipherSuite
 from .trust_store import ServerPairingRecord
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import AsyncGenerator, Awaitable, Callable
 
     from .trust_store import ClientPairingStore, ServerPairingStore
     from .wire import EncryptedWebSocket
@@ -53,16 +54,22 @@ _PAKE_SHARE_SIZE = 32
 _KC_TAG_SIZE = 64
 _PSK_WRAP_LABEL = b"sendspin-pair-psk-wrap-v1"
 _PSK_WRAP_NONCE = bytes(12)
-_CLIENT_ATTEMPT_TIMEOUT_S = 120.0
-# Server bounds are local (expiry raises TimeoutError, nothing on the wire) and exceed the
-# client's attempt timeout so the client's in-band abort wins when both sides are live.
-_SERVER_ATTEMPT_TIMEOUT_S = 180.0
-_SERVER_FIRST_MESSAGE_TIMEOUT_S = 60.0
-_SERVER_GESTURE_TIMEOUT_S = 360.0
+_CLIENT_ATTEMPT_TIMEOUT_S: float = 120.0
+# Server bounds raise PairingTimeoutError, sending no pairing message: no pair/abort reason is
+# available to a server for its own timeout. They exceed the client's attempt timeout so the
+# client's in-band abort wins when both sides are live.
+# Public so operator UIs can mirror the enforced bounds (countdowns etc.).
+SERVER_ATTEMPT_TIMEOUT_S: float = 180.0
+SERVER_FIRST_MESSAGE_TIMEOUT_S: float = 60.0
+SERVER_GESTURE_TIMEOUT_S: float = 360.0
 
 
 class PairingError(Exception):
     """A pairing attempt could not complete (malformed message, early close, etc.)."""
+
+
+class PairingTimeoutError(PairingError):
+    """A server-side bound on waiting for a client pairing message expired."""
 
 
 class PairingAbortError(PairingError):
@@ -100,6 +107,8 @@ class PairingAttempt:
     """Required for the Pairing PSK method; the live PSK pasted from a token."""
     verify: bool = False
     """Re-verify an already-paired client instead of pairing anew."""
+    on_pair_pending: Callable[[], None] | None = None
+    """Called when the client reports the attempt gesture-gated."""
 
     def __post_init__(self) -> None:
         """Validate ``method`` / material agree."""
@@ -115,6 +124,9 @@ class PairingAttempt:
                 raise ValueError(msg)
             if self.verify:
                 msg = "PAIRING_PSK does not support verification"
+                raise ValueError(msg)
+            if self.on_pair_pending is not None:
+                msg = "PAIRING_PSK does not use on_pair_pending"
                 raise ValueError(msg)
         else:  # PIN methods (dynamic_pin, static_pin)
             if self.pin_provider is None:
@@ -139,11 +151,8 @@ async def run_pairing_psk_client(
 
     Returns ``None`` on finalize, else the raw ``server/activate`` leave frame.
     """
-    try:
-        async with asyncio.timeout(_CLIENT_ATTEMPT_TIMEOUT_S):
-            return await _finalize_client(ws, server_id=server_id, store=store)
-    except TimeoutError:
-        await abort_pairing(ws, PairAbortReason.ATTEMPT_TIMEOUT)
+    async with _client_timeout(ws):
+        return await _finalize_client(ws, server_id=server_id, store=store)
 
 
 async def run_pairing_psk_server(
@@ -153,7 +162,7 @@ async def run_pairing_psk_server(
     store: ServerPairingStore,
 ) -> ServerPairingRecord:
     """Run the server side of the Pairing PSK flow."""
-    async with asyncio.timeout(_SERVER_FIRST_MESSAGE_TIMEOUT_S):
+    async with _server_timeout(SERVER_FIRST_MESSAGE_TIMEOUT_S, "client/pair-finalize"):
         record = await _finalize_server(
             ws, client_id=client_id, store=store, method=PairMethod.PAIRING_PSK
         )
@@ -166,6 +175,7 @@ async def run_dynamic_pin_client(
     *,
     handshake_hash: bytes,
     pairing_index: int,
+    pin_length: int,
     pin_emitter: PinEmitter,
     server_id: str,
     store: ClientPairingStore,
@@ -176,71 +186,63 @@ async def run_dynamic_pin_client(
     """
     sid = _pake_sid(handshake_hash, pairing_index)
     nonce_b = pin_mod.generate_nonce()
-    try:
-        async with asyncio.timeout(_CLIENT_ATTEMPT_TIMEOUT_S):
-            await ws.send_str(
-                ClientPairInitMessage(
-                    payload=ClientPairInitPayload(
-                        pairing_index=pairing_index,
-                        commit_B=b64url_encode(pin_mod.commit(nonce_b)),
-                    ),
-                ).to_json(),
-            )
+    async with _client_timeout(ws):
+        await ws.send_str(
+            ClientPairInitMessage(
+                payload=ClientPairInitPayload(
+                    pairing_index=pairing_index,
+                    commit_B=b64url_encode(pin_mod.commit(nonce_b)),
+                ),
+            ).to_json(),
+        )
 
-            init = await _receive_pairing(ws, ServerPairInitMessage)
-            nonce_a = _decode_field(init.payload.nonce_A, "nonce_A", expect_len=pin_mod.NONCE_SIZE)
-            pin_length = init.payload.pin_length
-            configured_min = (await store.get_pairing_config()).dynamic_pin_min_length
-            min_length = max(configured_min, pin_mod.MIN_PIN_DIGITS)
-            if not min_length <= pin_length <= pin_mod.MAX_PIN_DIGITS:
-                await abort_pairing(ws, PairAbortReason.PIN_LENGTH_UNACCEPTABLE)
-            pin = pin_mod.derive_pin(handshake_hash, nonce_a, nonce_b, pin_length)
-            await pin_emitter(pin)
-            try:
-                cpace = CPace.start(
-                    role=CPaceRole.RESPONDER, prs=pin.encode("ascii"), sid=sid, ad=_PAKE_AD_CLIENT
-                )
-            except CPaceError as exc:
-                raise PairingError("CPace initialization failed") from exc
+        init = await _receive_pairing(ws, ServerPairInitMessage)
+        nonce_a = _decode_field(init.payload.nonce_A, "nonce_A", expect_len=pin_mod.NONCE_SIZE)
+        pin = pin_mod.derive_pin(handshake_hash, nonce_a, nonce_b, pin_length)
+        await pin_emitter(pin)
+        try:
+            cpace = CPace.start(
+                role=CPaceRole.RESPONDER, prs=pin.encode("ascii"), sid=sid, ad=_PAKE_AD_CLIENT
+            )
+        except CPaceError as exc:
+            raise PairingError("CPace initialization failed") from exc
 
-            auth = await _receive_pairing(ws, ServerPairAuthMessage)
-            await ws.send_str(
-                ClientPairAuthMessage(
-                    payload=ClientPairAuthPayload(pake_msg_2=b64url_encode(cpace.public_share)),
-                ).to_json(),
-            )
-            peer_share = _decode_field(
-                auth.payload.pake_msg_1, "pake_msg_1", expect_len=_PAKE_SHARE_SIZE
-            )
-            try:
-                cpace.derive(peer_share, _PAKE_AD_SERVER)
-            except CPaceError as exc:
-                raise PairingError("malformed pake_msg_1: invalid CPace share") from exc
+        auth = await _receive_pairing(ws, ServerPairAuthMessage)
+        await ws.send_str(
+            ClientPairAuthMessage(
+                payload=ClientPairAuthPayload(pake_msg_2=b64url_encode(cpace.public_share)),
+            ).to_json(),
+        )
+        peer_share = _decode_field(
+            auth.payload.pake_msg_1, "pake_msg_1", expect_len=_PAKE_SHARE_SIZE
+        )
+        try:
+            cpace.derive(peer_share, _PAKE_AD_SERVER)
+        except CPaceError as exc:
+            raise PairingError("malformed pake_msg_1: invalid CPace share") from exc
 
-            confirm = await _receive_pairing(ws, ServerPairConfirmMessage)
-            if not cpace.verify(
-                _decode_field(confirm.payload.server_kc, "server_kc", expect_len=_KC_TAG_SIZE)
-            ):
-                await store.record_pin_failure(PairMethod.DYNAMIC_PIN)
-                await abort_pairing(ws, PairAbortReason.PIN_MISMATCH)
-            await store.reset_pin_failures(PairMethod.DYNAMIC_PIN)
-            await ws.send_str(
-                ClientPairConfirmMessage(
-                    payload=ClientPairConfirmPayload(
-                        client_kc=b64url_encode(cpace.tag()),
-                        nonce_B=b64url_encode(nonce_b),
-                    ),
-                ).to_json(),
-            )
+        confirm = await _receive_pairing(ws, ServerPairConfirmMessage)
+        if not cpace.verify(
+            _decode_field(confirm.payload.server_kc, "server_kc", expect_len=_KC_TAG_SIZE)
+        ):
+            await store.record_pin_failure()
+            await abort_pairing(ws, PairAbortReason.PIN_MISMATCH)
+        await store.reset_pin_failures()
+        await ws.send_str(
+            ClientPairConfirmMessage(
+                payload=ClientPairConfirmPayload(
+                    client_kc=b64url_encode(cpace.tag()),
+                    nonce_B=b64url_encode(nonce_b),
+                ),
+            ).to_json(),
+        )
 
-            return await _finalize_client(
-                ws,
-                server_id=server_id,
-                store=store,
-                wrap_key=_wrap_key(sid, cpace),
-            )
-    except TimeoutError:
-        await abort_pairing(ws, PairAbortReason.ATTEMPT_TIMEOUT)
+        return await _finalize_client(
+            ws,
+            server_id=server_id,
+            store=store,
+            wrap_key=_wrap_key(sid, cpace),
+        )
 
 
 async def run_dynamic_pin_server(
@@ -253,24 +255,22 @@ async def run_dynamic_pin_server(
     client_id: str,
     store: ServerPairingStore,
     verify: bool = False,
+    on_pair_pending: Callable[[], None] | None = None,
 ) -> ServerPairingRecord | None:
     """Run the server side of the dynamic-PIN flow.
 
     Returns the persisted record, or ``None`` when ``verify`` is set (re-verified, left pairing).
     """
     sid = _pake_sid(handshake_hash, pairing_index)
-    async with asyncio.timeout(_SERVER_FIRST_MESSAGE_TIMEOUT_S):
-        init = await _receive_pair_init(ws, pairing_index)
+    init = await _receive_pair_init(ws, pairing_index, on_pending=on_pair_pending)
     if init.payload.commit_B is None:
         raise PairingError("client/pair-init missing commit_B for dynamic PIN")
     commit_b = _decode_field(init.payload.commit_B, "commit_B", expect_len=pin_mod.COMMIT_SIZE)
-    async with asyncio.timeout(_SERVER_ATTEMPT_TIMEOUT_S):
+    async with _server_timeout(SERVER_ATTEMPT_TIMEOUT_S, "the rest of the attempt"):
         nonce_a = pin_mod.generate_nonce()
         await ws.send_str(
             ServerPairInitMessage(
-                payload=ServerPairInitPayload(
-                    nonce_A=b64url_encode(nonce_a), pin_length=pin_length
-                ),
+                payload=ServerPairInitPayload(nonce_A=b64url_encode(nonce_a)),
             ).to_json(),
         )
         pin = await pin_provider()
@@ -333,63 +333,58 @@ async def run_static_pin_client(
     server_id: str,
     store: ClientPairingStore,
 ) -> str | None:
-    """Run the client side of the static-PIN flow (the pairing window must already be open).
+    """Run the client side of the static-PIN flow (the caller has opened the pairing window).
 
     Returns ``None`` on finalize, else the raw ``server/activate`` leave frame.
     """
     sid = _pake_sid(handshake_hash, pairing_index)
-    try:
-        async with asyncio.timeout(_CLIENT_ATTEMPT_TIMEOUT_S):
-            await ws.send_str(
-                ClientPairInitMessage(
-                    payload=ClientPairInitPayload(pairing_index=pairing_index),
-                ).to_json(),
+    async with _client_timeout(ws):
+        await ws.send_str(
+            ClientPairInitMessage(
+                payload=ClientPairInitPayload(pairing_index=pairing_index),
+            ).to_json(),
+        )
+        try:
+            cpace = CPace.start(
+                role=CPaceRole.RESPONDER,
+                prs=static_pin.encode("ascii"),
+                sid=sid,
+                ad=_PAKE_AD_CLIENT,
             )
-            try:
-                cpace = CPace.start(
-                    role=CPaceRole.RESPONDER,
-                    prs=static_pin.encode("ascii"),
-                    sid=sid,
-                    ad=_PAKE_AD_CLIENT,
-                )
-            except CPaceError as exc:
-                raise PairingError("CPace initialization failed") from exc
+        except CPaceError as exc:
+            raise PairingError("CPace initialization failed") from exc
 
-            auth = await _receive_pairing(ws, ServerPairAuthMessage)
-            await ws.send_str(
-                ClientPairAuthMessage(
-                    payload=ClientPairAuthPayload(pake_msg_2=b64url_encode(cpace.public_share)),
-                ).to_json(),
-            )
-            peer_share = _decode_field(
-                auth.payload.pake_msg_1, "pake_msg_1", expect_len=_PAKE_SHARE_SIZE
-            )
-            try:
-                cpace.derive(peer_share, _PAKE_AD_SERVER)
-            except CPaceError as exc:
-                raise PairingError("malformed pake_msg_1: invalid CPace share") from exc
+        auth = await _receive_pairing(ws, ServerPairAuthMessage)
+        await ws.send_str(
+            ClientPairAuthMessage(
+                payload=ClientPairAuthPayload(pake_msg_2=b64url_encode(cpace.public_share)),
+            ).to_json(),
+        )
+        peer_share = _decode_field(
+            auth.payload.pake_msg_1, "pake_msg_1", expect_len=_PAKE_SHARE_SIZE
+        )
+        try:
+            cpace.derive(peer_share, _PAKE_AD_SERVER)
+        except CPaceError as exc:
+            raise PairingError("malformed pake_msg_1: invalid CPace share") from exc
 
-            confirm = await _receive_pairing(ws, ServerPairConfirmMessage)
-            if not cpace.verify(
-                _decode_field(confirm.payload.server_kc, "server_kc", expect_len=_KC_TAG_SIZE)
-            ):
-                await store.record_pin_failure(PairMethod.STATIC_PIN)
-                await abort_pairing(ws, PairAbortReason.PIN_MISMATCH)
-            await store.reset_pin_failures(PairMethod.STATIC_PIN)
-            await ws.send_str(
-                ClientPairConfirmMessage(
-                    payload=ClientPairConfirmPayload(client_kc=b64url_encode(cpace.tag())),
-                ).to_json(),
-            )
+        confirm = await _receive_pairing(ws, ServerPairConfirmMessage)
+        if not cpace.verify(
+            _decode_field(confirm.payload.server_kc, "server_kc", expect_len=_KC_TAG_SIZE)
+        ):
+            await abort_pairing(ws, PairAbortReason.PIN_MISMATCH)
+        await ws.send_str(
+            ClientPairConfirmMessage(
+                payload=ClientPairConfirmPayload(client_kc=b64url_encode(cpace.tag())),
+            ).to_json(),
+        )
 
-            return await _finalize_client(
-                ws,
-                server_id=server_id,
-                store=store,
-                wrap_key=_wrap_key(sid, cpace),
-            )
-    except TimeoutError:
-        await abort_pairing(ws, PairAbortReason.ATTEMPT_TIMEOUT)
+        return await _finalize_client(
+            ws,
+            server_id=server_id,
+            store=store,
+            wrap_key=_wrap_key(sid, cpace),
+        )
 
 
 async def run_static_pin_server(
@@ -401,17 +396,17 @@ async def run_static_pin_server(
     client_id: str,
     store: ServerPairingStore,
     verify: bool = False,
+    on_pair_pending: Callable[[], None] | None = None,
 ) -> ServerPairingRecord | None:
     """Run the server side of the static-PIN flow.
 
     Returns the persisted record, or ``None`` when ``verify`` is set (re-verified, left pairing).
     """
     sid = _pake_sid(handshake_hash, pairing_index)
-    async with asyncio.timeout(_SERVER_GESTURE_TIMEOUT_S):
-        init = await _receive_pair_init(ws, pairing_index)
+    init = await _receive_pair_init(ws, pairing_index, on_pending=on_pair_pending)
     if init.payload.commit_B is not None:
         raise PairingError("client/pair-init carries commit_B for static PIN")
-    async with asyncio.timeout(_SERVER_ATTEMPT_TIMEOUT_S):
+    async with _server_timeout(SERVER_ATTEMPT_TIMEOUT_S, "the rest of the attempt"):
         pin = await pin_provider()
         if not pin_mod.is_valid_static_pin(pin):
             raise PairingError("static PIN must be exactly 8 decimal digits")
@@ -546,6 +541,26 @@ def _decode_field(value: str, what: str, *, expect_len: int | None = None) -> by
     return raw
 
 
+@asynccontextmanager
+async def _client_timeout(ws: EncryptedWebSocket) -> AsyncGenerator[None]:
+    """Bound a client attempt, aborting in band with ``attempt_timeout`` on expiry."""
+    try:
+        async with asyncio.timeout(_CLIENT_ATTEMPT_TIMEOUT_S):
+            yield
+    except TimeoutError:
+        await abort_pairing(ws, PairAbortReason.ATTEMPT_TIMEOUT)
+
+
+@asynccontextmanager
+async def _server_timeout(timeout_s: float, what: str) -> AsyncGenerator[None]:
+    """Bound a server-side wait for ``what``, reporting expiry as a pairing timeout."""
+    try:
+        async with asyncio.timeout(timeout_s):
+            yield
+    except TimeoutError as exc:
+        raise PairingTimeoutError(f"{what} did not arrive in time") from exc
+
+
 async def abort_pairing(ws: EncryptedWebSocket, reason: PairAbortReason) -> NoReturn:
     """Send ``pair/abort`` (best-effort) and raise ``LocalPairingAbortError``."""
     with suppress(Exception):
@@ -553,15 +568,29 @@ async def abort_pairing(ws: EncryptedWebSocket, reason: PairAbortReason) -> NoRe
     raise LocalPairingAbortError(reason)
 
 
+@overload
 async def _receive_pairing_frame[T: PairingMessage](
     ws: EncryptedWebSocket, expected: type[T]
-) -> T | str:
-    """Receive a frame: the parsed ``expected`` message, or the raw text if it isn't pairing."""
+) -> T | str: ...
+
+
+@overload
+async def _receive_pairing_frame[T: PairingMessage, U: PairingMessage](
+    ws: EncryptedWebSocket, expected: tuple[type[T], type[U]]
+) -> T | U | str: ...
+
+
+async def _receive_pairing_frame(
+    ws: EncryptedWebSocket, expected: type[PairingMessage] | tuple[type[PairingMessage], ...]
+) -> PairingMessage | str:
+    """Receive a frame: a parsed ``expected`` message, or the raw text if it isn't pairing."""
+    kinds = expected if isinstance(expected, tuple) else (expected,)
+    expected_names = _expected_names(expected)
     msg = await ws.receive()
     if msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSING, WSMsgType.CLOSED):
-        raise PairingError(f"connection closed while awaiting {expected.__name__}")
+        raise PairingError(f"connection closed while awaiting {expected_names}")
     if msg.type is not WSMsgType.TEXT:
-        raise PairingError(f"expected a JSON frame ({expected.__name__}), got {msg.type.name}")
+        raise PairingError(f"expected a JSON frame ({expected_names}), got {msg.type.name}")
     data = cast("str", msg.data)
     try:
         message = PairingMessage.from_json(data)
@@ -569,17 +598,36 @@ async def _receive_pairing_frame[T: PairingMessage](
         return data
     if isinstance(message, PairAbortMessage):
         raise RemotePairingAbortError(message.payload.reason)
-    if not isinstance(message, expected):
-        raise PairingError(f"expected {expected.__name__}, got {type(message).__name__}")
+    if not isinstance(message, kinds):
+        raise PairingError(f"expected {expected_names}, got {type(message).__name__}")
     return message
 
 
-async def _receive_pairing[T: PairingMessage](ws: EncryptedWebSocket, expected: type[T]) -> T:
-    """Receive the next pairing frame, requiring it to be of type ``expected``."""
+@overload
+async def _receive_pairing[T: PairingMessage](ws: EncryptedWebSocket, expected: type[T]) -> T: ...
+
+
+@overload
+async def _receive_pairing[T: PairingMessage, U: PairingMessage](
+    ws: EncryptedWebSocket, expected: tuple[type[T], type[U]]
+) -> T | U: ...
+
+
+async def _receive_pairing(
+    ws: EncryptedWebSocket,
+    expected: type[PairingMessage] | tuple[type[PairingMessage], type[PairingMessage]],
+) -> PairingMessage:
+    """Receive the next pairing frame, requiring it to be of an ``expected`` type."""
     message = await _receive_pairing_frame(ws, expected)
     if isinstance(message, str):
-        raise PairingError(f"malformed message awaiting {expected.__name__}")
+        raise PairingError(f"malformed message awaiting {_expected_names(expected)}")
     return message
+
+
+def _expected_names(expected: type[PairingMessage] | tuple[type[PairingMessage], ...]) -> str:
+    """Human-readable name(s) of the expected message type(s)."""
+    kinds = expected if isinstance(expected, tuple) else (expected,)
+    return " or ".join(kind.__name__ for kind in kinds)
 
 
 async def receive_pairing_abort(ws: EncryptedWebSocket) -> str:
@@ -594,15 +642,38 @@ async def receive_pairing_abort(ws: EncryptedWebSocket) -> str:
     return frame
 
 
-async def _receive_pair_init(ws: EncryptedWebSocket, pairing_index: int) -> ClientPairInitMessage:
-    """Receive this attempt's ``client/pair-init``, discarding stale leftovers."""
-    while True:
+async def _receive_pair_init(
+    ws: EncryptedWebSocket,
+    pairing_index: int,
+    *,
+    on_pending: Callable[[], None] | None = None,
+) -> ClientPairInitMessage:
+    """Receive this attempt's ``client/pair-init``.
+
+    It allows one gesture-extending ``client/pair-pending``.
+    It also discards any leftover pair-init/pair-pending from a superseded attempt.
+    """
+    async with _server_timeout(SERVER_FIRST_MESSAGE_TIMEOUT_S, "client/pair-init"):
+        while True:
+            message = await _receive_pairing(ws, (ClientPairInitMessage, ClientPairPendingMessage))
+            if message.payload.pairing_index > pairing_index:
+                raise PairingError(
+                    f"{type(message).__name__} pairing_index is ahead of the server's count"
+                )
+            if message.payload.pairing_index == pairing_index:
+                break
+            # A leftover from a superseded pairing server/activate: discard silently.
+    if isinstance(message, ClientPairInitMessage):
+        return message
+    if on_pending is not None:
+        on_pending()
+    # In-order delivery leaves no room for leftovers after the matching pair-pending:
+    # the next pairing frame must be this attempt's client/pair-init.
+    async with _server_timeout(SERVER_GESTURE_TIMEOUT_S, "gesture-gated client/pair-init"):
         init = await _receive_pairing(ws, ClientPairInitMessage)
-        if init.payload.pairing_index > pairing_index:
-            raise PairingError("client/pair-init pairing_index is ahead of the server's count")
-        if init.payload.pairing_index == pairing_index:
-            return init
-        # A leftover from a superseded pairing server/activate: discard silently.
+    if init.payload.pairing_index != pairing_index:
+        raise PairingError("client/pair-init pairing_index does not match the attempt")
+    return init
 
 
 def _pake_sid(handshake_hash: bytes, pairing_index: int) -> bytes:

--- a/aiosendspin/noise/pin.py
+++ b/aiosendspin/noise/pin.py
@@ -14,6 +14,7 @@ COMMIT_SIZE: Final[int] = 32
 MIN_PIN_DIGITS: Final[int] = 4
 MAX_PIN_DIGITS: Final[int] = 12
 DEFAULT_MIN_PIN_DIGITS: Final[int] = 6
+SHORT_PIN_DIGITS: Final[int] = 6
 STATIC_PIN_DIGITS: Final[int] = 8
 
 

--- a/aiosendspin/noise/trust_store.py
+++ b/aiosendspin/noise/trust_store.py
@@ -24,12 +24,12 @@ from .keys import (
 )
 from .pin import DEFAULT_MIN_PIN_DIGITS, is_valid_static_pin
 
-# A PIN-pairing method enters terminal lockout when its failure counter reaches
+# Dynamic-PIN pairing escalates to gesture-gating when its failure counter reaches
 # this value.
-PIN_LOCKOUT_THRESHOLD: Final[int] = 10
+PIN_ESCALATION_THRESHOLD: Final[int] = 10
 
 __all__ = [
-    "PIN_LOCKOUT_THRESHOLD",
+    "PIN_ESCALATION_THRESHOLD",
     "ClientPairingConfig",
     "ClientPairingRecord",
     "ClientPairingStore",
@@ -414,20 +414,20 @@ class ClientPairingStore(ABC):
         """Return the configured static PIN, if any."""
 
     @abstractmethod
-    async def pin_failure_count(self, method: PairMethod) -> int:
-        """Return the persisted PIN-pairing failure count for ``method``."""
+    async def pin_failure_count(self) -> int:
+        """Return the persisted dynamic-PIN failure count."""
 
     @abstractmethod
-    async def record_pin_failure(self, method: PairMethod) -> int:
-        """Increment ``method``'s failure counter and return the new count."""
+    async def record_pin_failure(self) -> int:
+        """Increment the dynamic-PIN failure counter and return the new count."""
 
     @abstractmethod
-    async def reset_pin_failures(self, method: PairMethod) -> None:
-        """Reset ``method``'s failure counter to zero (on success or lockout clear)."""
+    async def reset_pin_failures(self) -> None:
+        """Reset the dynamic-PIN failure counter to zero (on ``server_kc`` success)."""
 
     @abstractmethod
-    async def is_pin_locked_out(self, method: PairMethod) -> bool:
-        """Return whether ``method`` is in terminal lockout (count past the threshold)."""
+    async def is_pin_escalated(self) -> bool:
+        """Return whether dynamic PIN is escalated to gesture-gating (count at threshold)."""
 
     @abstractmethod
     async def get_last_playback_server_id(self) -> str | None:
@@ -627,7 +627,7 @@ class _ClientPairingStoreBase(ClientPairingStore):
         self._records: dict[str, ClientPairingRecord] = {}
         self._pairing_psk: PairingPsk | None = None
         self._static_pin: str | None = None
-        self._pin_failures: dict[PairMethod, int] = {}
+        self._pin_failures = 0
         self._pairing_config: ClientPairingConfig | None = None
         self._last_playback_server_id: str | None = None
 
@@ -733,25 +733,25 @@ class _ClientPairingStoreBase(ClientPairingStore):
         """Return the configured static PIN, if any."""
         return self._static_pin
 
-    async def pin_failure_count(self, method: PairMethod) -> int:
-        """Return the PIN-pairing failure count for ``method``."""
-        return self._pin_failures.get(method, 0)
+    async def pin_failure_count(self) -> int:
+        """Return the dynamic-PIN failure count."""
+        return self._pin_failures
 
-    async def record_pin_failure(self, method: PairMethod) -> int:
-        """Increment ``method``'s failure counter and return the new count."""
-        count = self._pin_failures.get(method, 0) + 1
-        self._pin_failures[method] = count
+    async def record_pin_failure(self) -> int:
+        """Increment the dynamic-PIN failure counter and return the new count."""
+        self._pin_failures += 1
         await self._save()
-        return count
+        return self._pin_failures
 
-    async def reset_pin_failures(self, method: PairMethod) -> None:
-        """Reset ``method``'s failure counter to zero (no-op if absent)."""
-        if self._pin_failures.pop(method, None) is not None:
+    async def reset_pin_failures(self) -> None:
+        """Reset the dynamic-PIN failure counter to zero (no-op if already zero)."""
+        if self._pin_failures:
+            self._pin_failures = 0
             await self._save()
 
-    async def is_pin_locked_out(self, method: PairMethod) -> bool:
-        """Return whether ``method`` has reached terminal lockout."""
-        return self._pin_failures.get(method, 0) >= PIN_LOCKOUT_THRESHOLD
+    async def is_pin_escalated(self) -> bool:
+        """Return whether dynamic PIN has escalated to gesture-gating."""
+        return self._pin_failures >= PIN_ESCALATION_THRESHOLD
 
 
 class InMemoryClientPairingStore(_ClientPairingStoreBase):
@@ -796,18 +796,14 @@ class FileClientPairingStore(_ClientPairingStoreBase):
         raw_psk = data.get("pairing_psk")
         self._pairing_psk = PairingPsk.from_dict(raw_psk) if isinstance(raw_psk, Mapping) else None
         self._static_pin = _opt_str(data, "static_pin")
-        failures: dict[PairMethod, int] = {}
-        raw_failures = data.get("pin_failures")
-        if raw_failures is not None:
-            if not isinstance(raw_failures, Mapping):
-                msg = "pairing store 'pin_failures' must be an object"
-                raise TypeError(msg)
-            for method_value, count in raw_failures.items():
-                if isinstance(count, bool) or not isinstance(count, int):
-                    msg = f"pin_failures[{method_value!r}] must be an integer"
-                    raise TypeError(msg)
-                failures[PairMethod(str(method_value))] = count
-        self._pin_failures = failures
+        raw_failures = data.get("pin_failures", 0)
+        if isinstance(raw_failures, Mapping):
+            # Pre-escalation format kept per-method counters; carry over dynamic_pin's.
+            raw_failures = raw_failures.get(PairMethod.DYNAMIC_PIN.value, 0)
+        if isinstance(raw_failures, bool) or not isinstance(raw_failures, int):
+            msg = "pairing store 'pin_failures' must be an integer"
+            raise TypeError(msg)
+        self._pin_failures = raw_failures
         self._last_playback_server_id = _opt_str(data, "last_playback_server_id")
 
     async def _seed(self) -> None:
@@ -827,7 +823,7 @@ class FileClientPairingStore(_ClientPairingStoreBase):
                 "pairing_config": self._pairing_config.to_dict(),
                 "pairing_psk": self._pairing_psk.to_dict() if self._pairing_psk else None,
                 "static_pin": self._static_pin,
-                "pin_failures": {m.value: c for m, c in self._pin_failures.items()},
+                "pin_failures": self._pin_failures,
                 "last_playback_server_id": self._last_playback_server_id,
             }
             await asyncio.to_thread(_atomic_write_json, self._path, payload)

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -46,6 +46,7 @@ from aiohttp import ClientWebSocketResponse, WSMessage, WSMsgType, web
 
 from aiosendspin.models import BINARY_HEADER_SIZE, unpack_binary_header
 from aiosendspin.models.core import (
+    ActivatePairing,
     ClientCommandMessage,
     ClientGoodbyeMessage,
     ClientHelloMessage,
@@ -71,6 +72,7 @@ from aiosendspin.models.management import (
     ManagementAddRecordPayload,
     ManagementGetPairingConfigMessage,
     ManagementListRecordsMessage,
+    ManagementOpenPairingWindowMessage,
     ManagementRemoveRecordMessage,
     ManagementRemoveRecordPayload,
     ManagementResultData,
@@ -113,6 +115,7 @@ from aiosendspin.noise.pairing import (
     PairingAbortError,
     PairingAttempt,
     PairingError,
+    PairingTimeoutError,
     abort_pairing,
     run_dynamic_pin_server,
     run_pairing_psk_server,
@@ -150,6 +153,7 @@ QUIESCE_TIMEOUT_S: float = 30.0
 
 _PAIRING_MESSAGE_TYPES: frozenset[str] = frozenset(
     {
+        "client/pair-pending",
         "client/pair-init",
         "client/pair-finalize",
         "client/pair-auth",
@@ -162,6 +166,7 @@ _PAIR_TRANSITION_TYPES: frozenset[str] = frozenset(
     {
         "noise/handshake",
         "client/hello",
+        "client/pair-pending",
         "client/pair-init",
         "client/pair-finalize",
         "client/pair-auth",
@@ -916,10 +921,14 @@ class SendspinConnection:
                 try:
                     if not await self._pair(transport):
                         return False
+                except PairingTimeoutError as exc:
+                    # Timeout waiting for client; the connection stays open for a retry.
+                    self._logger.debug("Initial-connect pairing timed out: %s", exc)
+                    self._pairing_attempt = None
                 except PairingAbortError as exc:
                     if exc.reason in CLOSING_ABORT_REASONS:
                         raise
-                    # Non-closing abort reason: the connection stays open for a retry.
+                    # Non-closing abort reason; the connection stays open for a retry.
                     self._logger.debug("Initial-connect pairing aborted: %s", exc)
                     self._pairing_attempt = None
             await self._activate()
@@ -1190,6 +1199,7 @@ class SendspinConnection:
         """Run a pairing attempt on a connection.
 
         A pair abort raises and leaves the connection for a retry or ``end_pairing``.
+        A server-side timeout raises after leaving pairing, also keeping the connection.
         Any other failure propagates for the caller to disconnect.
         """
         if self._pairing_attempt is not None:
@@ -1216,6 +1226,12 @@ class SendspinConnection:
             if current_task is not None and current_task.cancelling():
                 # Our own cancellation was forwarded into the child and converted; restore it.
                 raise asyncio.CancelledError from None
+            raise
+        except PairingTimeoutError:
+            # A server has no pair/abort reason for its own timeout: cancel the attempt in
+            # band with the leave activate (best-effort; the client may be gone).
+            with suppress(Exception):
+                await self._leave_pairing()
             raise
         finally:
             self._pairing_attempt = None
@@ -1267,6 +1283,9 @@ class SendspinConnection:
                 if self._pairing_attempt is not None
                 else PairMethod.PAIRING_PSK
             )
+            pin_length = (
+                self._negotiated_dynamic_pin_length() if method is PairMethod.DYNAMIC_PIN else None
+            )
             # No gate on the hello-advertised methods: the advertisement may lag the client's
             # live pairing config (management can change it mid-connection). The client
             # arbitrates, aborting an unsupported method with ``method_not_supported``.
@@ -1275,11 +1294,11 @@ class SendspinConnection:
                     payload=ServerActivatePayload(
                         activities=[Activity.PAIRING],
                         active_roles=[],
-                        selected_pair_method=method,
+                        pairing=ActivatePairing(method=method, pin_length=pin_length),
                     )
                 ).to_json()
             )
-            record = await self._run_pairing_protocol(method, transport)
+            record = await self._run_pairing_protocol(method, transport, pin_length)
         except asyncio.CancelledError:
             # A cancelled attempt ends like any local abort: the task never reports
             # cancelled(), so awaiting callers see the abort rather than the cancel.
@@ -1301,7 +1320,7 @@ class SendspinConnection:
             return await rehandshake
 
     async def _run_pairing_protocol(
-        self, method: PairMethod, transport: EncryptedWebSocket
+        self, method: PairMethod, transport: EncryptedWebSocket, pin_length: int | None
     ) -> ServerPairingRecord | None:
         """Run ``method``'s exchange, returning the record (``None`` when verifying)."""
         assert self._client_id is not None
@@ -1329,16 +1348,19 @@ class SendspinConnection:
                 client_id=self._client_id,
                 store=self._server.pairing_store,
                 verify=verify,
+                on_pair_pending=self._pairing_attempt.on_pair_pending,
             )
+        assert pin_length is not None
         return await run_dynamic_pin_server(
             transport,
             handshake_hash=self._handshake_hash,
             pairing_index=pairing_index,
             pin_provider=self._pairing_attempt.pin_provider,
-            pin_length=self._negotiated_dynamic_pin_length(),
+            pin_length=pin_length,
             client_id=self._client_id,
             store=self._server.pairing_store,
             verify=verify,
+            on_pair_pending=self._pairing_attempt.on_pair_pending,
         )
 
     def _negotiated_dynamic_pin_length(self) -> int:
@@ -1539,6 +1561,13 @@ class SendspinConnection:
         """Apply a pairing-config patch on the client."""
         payload = await self._management_request(
             ManagementSetPairingConfigMessage(payload=patch), ManagementResultPayload
+        )
+        return payload.result
+
+    async def open_pairing_window(self) -> ManagementResult:
+        """Open a pairing window on the client in place of the operator gesture."""
+        payload = await self._management_request(
+            ManagementOpenPairingWindowMessage(), ManagementResultPayload
         )
         return payload.result
 

--- a/aiosendspin/server/server.py
+++ b/aiosendspin/server/server.py
@@ -32,7 +32,7 @@ from aiosendspin.clock import Clock, RawMonotonicClock
 from aiosendspin.models.core import ClientHelloPayload
 from aiosendspin.models.types import ConnectionReason, GoodbyeReason
 from aiosendspin.noise.keys import Identity
-from aiosendspin.noise.pairing import PairingAbortError, PairingAttempt
+from aiosendspin.noise.pairing import PairingAbortError, PairingAttempt, PairingTimeoutError
 from aiosendspin.noise.pin import DEFAULT_MIN_PIN_DIGITS, MAX_PIN_DIGITS, MIN_PIN_DIGITS
 from aiosendspin.noise.trust_store import ServerPairingStore, TrustedUnpairedClient
 from aiosendspin.util import create_task, get_local_ip
@@ -554,12 +554,13 @@ class SendspinServer:
         """Run a pairing attempt on a connected client.
 
         A pair abort raises and leaves the connection open (retry with another
-        ``initiate_pairing`` or drop out with ``end_pairing``); other failures disconnect.
+        ``initiate_pairing`` or drop out with ``end_pairing``); a server-side timeout
+        raises with pairing already left; other failures disconnect.
         """
         connection = self._connection_for(client_id)
         try:
             await connection.initiate_pairing(attempt)
-        except PairingAbortError:
+        except (PairingAbortError, PairingTimeoutError):
             raise
         except BaseException:
             await connection.disconnect(retry_connection=False)

--- a/tests/client/test_management.py
+++ b/tests/client/test_management.py
@@ -9,6 +9,7 @@ from aiosendspin.client.management import (
     handle_add_record,
     handle_get_pairing_config,
     handle_list_records,
+    handle_open_pairing_window,
     handle_remove_record,
     handle_set_pairing_config,
     handle_unpair,
@@ -29,7 +30,7 @@ from aiosendspin.models.management import (
 from aiosendspin.models.types import ManagementResult, PairMethod
 from aiosendspin.noise.keys import b64url_encode, generate_psk, psk_id_for
 from aiosendspin.noise.trust_store import (
-    PIN_LOCKOUT_THRESHOLD,
+    PIN_ESCALATION_THRESHOLD,
     ClientPairingRecord,
     InMemoryClientPairingStore,
 )
@@ -233,7 +234,7 @@ async def test_unpair_unknown_psk_id_is_noop() -> None:
 
 
 async def test_get_pairing_config_projects_state() -> None:
-    """get-config reflects enabled flags + lockout, omits unimplemented methods and secrets."""
+    """get-config reflects enabled flags + escalation, omits unimplemented methods and secrets."""
     store = InMemoryClientPairingStore()
     await store.store_pairing_config(
         replace(
@@ -242,8 +243,8 @@ async def test_get_pairing_config_projects_state() -> None:
             unpaired_access_enabled=True,
         )
     )
-    for _ in range(PIN_LOCKOUT_THRESHOLD):
-        await store.record_pin_failure(PairMethod.DYNAMIC_PIN)
+    for _ in range(PIN_ESCALATION_THRESHOLD):
+        await store.record_pin_failure()
     payload, effect = await handle_get_pairing_config(
         store, implemented_pair_methods=_WITHOUT_STATIC_PIN
     )
@@ -252,9 +253,9 @@ async def test_get_pairing_config_projects_state() -> None:
     assert data is not None
     assert data.pairing_psk is not None
     assert data.pairing_psk.enabled is False
-    assert data.pairing_psk.locked_out is None  # not a PIN method
+    assert data.pairing_psk.escalated is None  # not the dynamic-PIN method
     assert data.dynamic_pin is not None
-    assert data.dynamic_pin.locked_out is True
+    assert data.dynamic_pin.escalated is True
     assert data.dynamic_pin.min_pin_length == 6  # default floor
     assert data.static_pin is None  # not implemented
     assert data.unpaired_access is not None
@@ -266,11 +267,12 @@ async def test_get_pairing_config_projects_state() -> None:
 
 
 async def test_get_pairing_config_shows_static_pin_when_implemented() -> None:
-    """A client that implements static PIN includes it and reports its lockout."""
+    """A client that implements static PIN includes it in the config view."""
     store = InMemoryClientPairingStore()
     payload, _ = await handle_get_pairing_config(store, implemented_pair_methods=_ALL_METHODS)
     assert payload.data is not None
     assert payload.data.static_pin is not None
+    assert payload.data.static_pin.escalated is None  # static PIN has no failure counter
 
 
 # --- set-pairing-config -------------------------------------------------------
@@ -386,30 +388,31 @@ async def test_set_pairing_config_unimplemented_method_is_invalid() -> None:
     assert payload.result is ManagementResult.INVALID
 
 
-async def test_set_pairing_config_clears_lockout() -> None:
-    """locked_out=false clears the PIN failure counter."""
-    store = InMemoryClientPairingStore()
-    for _ in range(PIN_LOCKOUT_THRESHOLD):
-        await store.record_pin_failure(PairMethod.DYNAMIC_PIN)
-    assert await store.is_pin_locked_out(PairMethod.DYNAMIC_PIN)
-    payload, _ = await handle_set_pairing_config(
-        store,
-        ManagementSetPairingConfigPayload(dynamic_pin=SetDynamicPinConfig(locked_out=False)),
-        implemented_pair_methods=_ALL_METHODS,
-    )
-    assert payload.result is ManagementResult.OK
-    assert not await store.is_pin_locked_out(PairMethod.DYNAMIC_PIN)
-
-
-async def test_set_pairing_config_rejects_lockout_true() -> None:
-    """locked_out=true is rejected (only false clears)."""
+async def test_set_pairing_config_enable_static_pin_without_pin_is_invalid() -> None:
+    """Enabling static_pin on a client with no static PIN configured is rejected."""
     store = InMemoryClientPairingStore()
     payload, _ = await handle_set_pairing_config(
         store,
-        ManagementSetPairingConfigPayload(dynamic_pin=SetDynamicPinConfig(locked_out=True)),
+        ManagementSetPairingConfigPayload(static_pin=SetStaticPinConfig(enabled=True)),
         implemented_pair_methods=_ALL_METHODS,
     )
     assert payload.result is ManagementResult.INVALID
+    assert (await store.get_pairing_config()).static_pin_enabled is False
+
+
+async def test_set_pairing_config_enable_static_pin_with_pin_in_patch() -> None:
+    """Enabling static_pin is fine when the same patch provisions the PIN."""
+    store = InMemoryClientPairingStore()
+    payload, _ = await handle_set_pairing_config(
+        store,
+        ManagementSetPairingConfigPayload(
+            static_pin=SetStaticPinConfig(enabled=True, pin="12345678")
+        ),
+        implemented_pair_methods=_ALL_METHODS,
+    )
+    assert payload.result is ManagementResult.OK
+    assert (await store.get_pairing_config()).static_pin_enabled is True
+    assert await store.static_pin() == "12345678"
 
 
 async def test_set_pairing_config_persists_unpaired_access() -> None:
@@ -451,6 +454,56 @@ async def test_set_pairing_config_record_mode_requires_shared_record() -> None:
     )
     assert ok[0].result is ManagementResult.OK
     assert (await store.get_pairing_config()).record_mode_psk_id == shared.psk_id
+
+
+# --- open-pairing-window --------------------------------------------------------
+
+
+async def test_open_pairing_window_opens_when_pin_method_offered() -> None:
+    """A client offering dynamic PIN opens the window and reports ok."""
+    store = InMemoryClientPairingStore()
+    opened: list[None] = []
+    payload, effect = await handle_open_pairing_window(
+        store,
+        implemented_pair_methods=_ALL_METHODS,
+        open_window=lambda: opened.append(None),
+    )
+    assert payload.result is ManagementResult.OK
+    assert effect is ManagementEffect.NONE
+    assert len(opened) == 1
+
+
+async def test_open_pairing_window_with_static_pin_enabled() -> None:
+    """With dynamic PIN unavailable, an enabled static_pin qualifies."""
+    store = InMemoryClientPairingStore()
+    await store.set_static_pin("12345678")
+    await store.store_pairing_config(
+        replace(await store.get_pairing_config(), static_pin_enabled=True)
+    )
+    opened: list[None] = []
+    payload, _ = await handle_open_pairing_window(
+        store,
+        implemented_pair_methods=frozenset({PairMethod.PAIRING_PSK, PairMethod.STATIC_PIN}),
+        open_window=lambda: opened.append(None),
+    )
+    assert payload.result is ManagementResult.OK
+    assert len(opened) == 1
+
+
+async def test_open_pairing_window_invalid_when_no_pin_method_enabled() -> None:
+    """With every PIN method disabled or unimplemented, the request is invalid."""
+    store = InMemoryClientPairingStore()
+    await store.store_pairing_config(
+        replace(await store.get_pairing_config(), dynamic_pin_enabled=False)
+    )
+    opened: list[None] = []
+    payload, _ = await handle_open_pairing_window(
+        store,
+        implemented_pair_methods=_WITHOUT_STATIC_PIN,
+        open_window=lambda: opened.append(None),
+    )
+    assert payload.result is ManagementResult.INVALID
+    assert opened == []
 
 
 # --- storage accounting -------------------------------------------------------

--- a/tests/client/test_source_deactivation.py
+++ b/tests/client/test_source_deactivation.py
@@ -68,7 +68,7 @@ def _connection(
     conn._reported_available = True  # noqa: SLF001
     conn._reported_source_signal = None  # noqa: SLF001
     conn._time_filter = _FakeTimeFilter(synchronized=synchronized)  # type: ignore[assignment]  # noqa: SLF001
-    conn._selected_pair_method = None  # noqa: SLF001
+    conn._selected_pairing = None  # noqa: SLF001
 
     async def _unpaired_access_enabled() -> bool:
         return unpaired_access

--- a/tests/integration/test_management_flow.py
+++ b/tests/integration/test_management_flow.py
@@ -11,6 +11,7 @@ from aiohttp import web
 from aiohttp.test_utils import TestServer
 
 from aiosendspin.client.client import SendspinClient as SdkClient
+from aiosendspin.client.models import PairingSupport
 from aiosendspin.models.management import ManagementSetPairingConfigPayload, SetPairingPskConfig
 from aiosendspin.models.player import ClientHelloPlayerSupport, SupportedAudioFormat
 from aiosendspin.models.types import (
@@ -429,6 +430,57 @@ async def test_set_pairing_config_disables_offered_method() -> None:
             assert PairMethod.PAIRING_PSK not in offered
         finally:
             await reconnect.disconnect()
+
+
+async def test_open_pairing_window_round_trip() -> None:
+    """open-pairing-window opens the client's window; without a PIN method it is invalid."""
+    server_store = InMemoryServerPairingStore()
+    server = _make_server(server_store)
+    identity = Identity.generate()
+    client_store = InMemoryClientPairingStore()
+    await _seed_pairing(server, server_store, client_store, identity.peer_id)
+
+    async def display(pin: str | None) -> None:
+        pass
+
+    async with _serve(server) as url:
+        client = make_sdk_client(
+            identity=identity,
+            pairing_store=client_store,
+            client_name="c",
+            roles=[Roles.CONTROLLER],
+            pairing_support=PairingSupport(pin_display=display),
+        )
+        try:
+            await client.connect(url)
+            await _await_connected_client(server, identity.peer_id)
+            conn = server.enable_management(identity.peer_id)
+            await _await_activity(client, Activity.MANAGEMENT)
+
+            assert not client.pairing_window_open
+            assert await conn.open_pairing_window() is ManagementResult.OK
+            assert client.pairing_window_open
+            # A no-op ok while the window is already open.
+            assert await conn.open_pairing_window() is ManagementResult.OK
+        finally:
+            await client.disconnect()
+
+        # A client with no PIN method enabled rejects the request as invalid.
+        no_pin = make_sdk_client(
+            identity=identity,
+            pairing_store=client_store,
+            client_name="c",
+            roles=[Roles.CONTROLLER],
+        )
+        try:
+            await no_pin.connect(url)
+            await _await_connected_client(server, identity.peer_id)
+            conn = server.enable_management(identity.peer_id)
+            await _await_activity(no_pin, Activity.MANAGEMENT)
+            assert await conn.open_pairing_window() is ManagementResult.INVALID
+            assert not no_pin.pairing_window_open
+        finally:
+            await no_pin.disconnect()
 
 
 async def test_unpair_drops_record_and_closes() -> None:

--- a/tests/integration/test_noise_pairing_flow.py
+++ b/tests/integration/test_noise_pairing_flow.py
@@ -12,6 +12,7 @@ from aiohttp import ClientSession, WSMsgType, web
 from aiohttp.test_utils import TestServer
 
 from aiosendspin.client.client import SendspinClient as SdkClient
+from aiosendspin.client.models import PairingSupport
 from aiosendspin.models.core import (
     ClientHelloMessage,
     ClientHelloPayload,
@@ -33,7 +34,12 @@ from aiosendspin.models.types import (
     TrustLevel,
 )
 from aiosendspin.noise.keys import Identity, generate_psk, psk_id_for
-from aiosendspin.noise.pairing import PairingAbortError, PairingAttempt, PairingError
+from aiosendspin.noise.pairing import (
+    PairingAbortError,
+    PairingAttempt,
+    PairingError,
+    PairingTimeoutError,
+)
 from aiosendspin.noise.trust_store import (
     ClientPairingRecord,
     InMemoryClientPairingStore,
@@ -467,7 +473,7 @@ async def test_live_pairing_dynamic_pin() -> None:
             pairing_store=client_store,
             client_name="c",
             roles=[Roles.CONTROLLER],
-            pin_display=display,
+            pairing_support=PairingSupport(pin_display=display),
         )
         try:
             await client.connect(url)
@@ -513,7 +519,7 @@ async def test_live_pairing_updates_connection_security_trust() -> None:
             pairing_store=client_store,
             client_name="c",
             roles=[Roles.CONTROLLER],
-            pin_display=display,
+            pairing_support=PairingSupport(pin_display=display),
         )
         try:
             await client.connect(url)
@@ -553,7 +559,7 @@ async def test_live_pairing_dynamic_pin_server_floor_raises_length() -> None:
             pairing_store=client_store,
             client_name="c",
             roles=[Roles.CONTROLLER],
-            pin_display=display,
+            pairing_support=PairingSupport(pin_display=display),
         )
         try:
             await client.connect(url)
@@ -591,7 +597,7 @@ async def test_live_pairing_method_enabled_after_hello() -> None:
             pairing_store=client_store,
             client_name="c",
             roles=[Roles.CONTROLLER],
-            pin_display=display,
+            pairing_support=PairingSupport(pin_display=display),
         )
         try:
             await client.connect(url)
@@ -634,7 +640,7 @@ async def test_live_pairing_method_disabled_after_hello_aborts() -> None:
             pairing_store=client_store,
             client_name="c",
             roles=[Roles.CONTROLLER],
-            pin_display=display,
+            pairing_support=PairingSupport(pin_display=display),
         )
         try:
             await client.connect(url)
@@ -694,7 +700,7 @@ async def test_live_pairing_dynamic_pin_wrong_then_retry() -> None:
             pairing_store=client_store,
             client_name="c",
             roles=[Roles.CONTROLLER],
-            pin_display=display,
+            pairing_support=PairingSupport(pin_display=display),
         )
         try:
             await client.connect(url)
@@ -707,7 +713,7 @@ async def test_live_pairing_dynamic_pin_wrong_then_retry() -> None:
             assert excinfo.value.reason is PairAbortReason.PIN_MISMATCH
             assert client.connected
             assert Activity.PAIRING in client.activities
-            assert await client_store.pin_failure_count(PairMethod.DYNAMIC_PIN) == 1
+            assert await client_store.pin_failure_count() == 1
             # One attempt consumed, no re-handshake between attempts, so the index advanced.
             assert conn._pairing_index == 1  # noqa: SLF001
 
@@ -718,7 +724,7 @@ async def test_live_pairing_dynamic_pin_wrong_then_retry() -> None:
             await _await_long_term_record(client_store, server.id)
             assert client.noise_psk is not None
             assert client.noise_psk.category is PskCategory.LONG_TERM
-            assert await client_store.pin_failure_count(PairMethod.DYNAMIC_PIN) == 0
+            assert await client_store.pin_failure_count() == 0
             # The success re-handshake to the long-term PSK reset the per-handshake index.
             assert conn._pairing_index == 0  # noqa: SLF001
         finally:
@@ -775,7 +781,7 @@ async def test_end_pairing_after_failed_attempt_leaves_pairing() -> None:
             pairing_store=client_store,
             client_name="c",
             roles=[Roles.CONTROLLER],
-            pin_display=display,
+            pairing_support=PairingSupport(pin_display=display),
         )
         try:
             await client.connect(url)
@@ -823,7 +829,7 @@ async def test_end_pairing_during_attempt_leaves_pairing() -> None:
             pairing_store=client_store,
             client_name="c",
             roles=[Roles.CONTROLLER],
-            pin_display=display,
+            pairing_support=PairingSupport(pin_display=display),
         )
         attempt: asyncio.Future[None] | None = None
         try:
@@ -864,6 +870,60 @@ async def test_end_pairing_during_attempt_leaves_pairing() -> None:
             await client.disconnect()
 
 
+async def test_gesture_timeout_leaves_pairing_without_dropping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The server's gesture bound cancels the attempt in band: no abort frame, connection alive."""
+    monkeypatch.setattr("aiosendspin.noise.pairing.SERVER_GESTURE_TIMEOUT_S", 0.1)
+    server_store = InMemoryServerPairingStore()
+    server = _make_server(server_store)
+    client_identity = Identity.generate()
+    client_store = InMemoryClientPairingStore()
+    await client_store.store_pairing_config(
+        replace(await client_store.get_pairing_config(), static_pin_enabled=True)
+    )
+    await client_store.set_static_pin("12345678")
+
+    aborts: list[PairAbortReason] = []
+
+    async def gesture_prompt(active: bool) -> None:  # noqa: FBT001
+        pass  # never opens a window: the server's gesture bound expires
+
+    async def provide() -> str:
+        return "12345678"
+
+    async with _serve(server) as url:
+        client = make_sdk_client(
+            identity=client_identity,
+            pairing_store=client_store,
+            client_name="c",
+            roles=[Roles.CONTROLLER],
+            pairing_support=PairingSupport(gesture_prompt=gesture_prompt),
+        )
+        client.add_pairing_abort_listener(aborts.append)
+        try:
+            await client.connect(url)
+            conn = await _find_connection_by_client_id(server, client_identity.peer_id)
+            with pytest.raises(PairingTimeoutError):
+                await conn.initiate_pairing(
+                    PairingAttempt(method=PairMethod.STATIC_PIN, pin_provider=provide)
+                )
+            # The leave activate unparks the client; no pair/abort reason exists for this.
+            await _await_left_pairing(client)
+            assert client.connected
+            assert aborts == []
+            assert await client_store.record_by_server_id(server.id) is None
+
+            # The connection is reusable: an opened window admits a fresh attempt.
+            client.open_pairing_window()
+            await conn.initiate_pairing(
+                PairingAttempt(method=PairMethod.STATIC_PIN, pin_provider=provide)
+            )
+            await _await_long_term_record(client_store, server.id)
+        finally:
+            await client.disconnect()
+
+
 async def test_end_pairing_during_gesture_wait_unparks_client() -> None:
     """end_pairing reaches a client parked in the static-PIN gesture wait; it re-pairs after."""
     server_store = InMemoryServerPairingStore()
@@ -875,13 +935,13 @@ async def test_end_pairing_during_gesture_wait_unparks_client() -> None:
     )
     await client_store.set_static_pin("12345678")
 
-    gesture_awaited = asyncio.Event()
-    never_gesture: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+    prompts: list[bool] = []
+    prompted = asyncio.Event()
 
-    async def open_window() -> None:
-        gesture_awaited.set()
-        if not never_gesture.cancelled():  # cancelled by the SDK when the server ends pairing
-            await never_gesture
+    async def gesture_prompt(active: bool) -> None:  # noqa: FBT001
+        prompts.append(active)
+        if active:
+            prompted.set()
 
     async def provide() -> str:
         return "12345678"
@@ -892,7 +952,7 @@ async def test_end_pairing_during_gesture_wait_unparks_client() -> None:
             pairing_store=client_store,
             client_name="c",
             roles=[Roles.CONTROLLER],
-            pairing_window=open_window,
+            pairing_support=PairingSupport(gesture_prompt=gesture_prompt),
         )
         attempt: asyncio.Future[None] | None = None
         try:
@@ -903,7 +963,7 @@ async def test_end_pairing_during_gesture_wait_unparks_client() -> None:
                     PairingAttempt(method=PairMethod.STATIC_PIN, pin_provider=provide)
                 )
             )
-            await gesture_awaited.wait()  # the client is parked awaiting the operator gesture
+            await prompted.wait()  # the client is parked awaiting the operator gesture
 
             await server.end_pairing(client_identity.peer_id)
             with pytest.raises(PairingAbortError) as excinfo:
@@ -912,10 +972,11 @@ async def test_end_pairing_during_gesture_wait_unparks_client() -> None:
             assert excinfo.value.reason is PairAbortReason.USER_CANCELLED
             assert client.connected
             await _await_left_pairing(client)
-            assert never_gesture.cancelled()  # the SDK cancelled the integrator's gesture wait
+            assert prompts == [True, False]  # the SDK cleared the gesture prompt
             assert await client_store.record_by_server_id(server.id) is None
 
-            # The connection is reusable: a fresh attempt (window opens at once) pairs.
+            # The connection is reusable: a proactively opened window admits a fresh attempt.
+            client.open_pairing_window()
             await conn.initiate_pairing(
                 PairingAttempt(method=PairMethod.STATIC_PIN, pin_provider=provide)
             )
@@ -923,8 +984,6 @@ async def test_end_pairing_during_gesture_wait_unparks_client() -> None:
             assert client.noise_psk is not None
             assert client.noise_psk.category is PskCategory.LONG_TERM
         finally:
-            if not never_gesture.done():
-                never_gesture.cancel()
             if attempt is not None:
                 attempt.cancel()
                 with suppress(asyncio.CancelledError, PairingAbortError):
@@ -955,7 +1014,7 @@ async def test_external_cancel_of_initiate_pairing_stays_cancelled() -> None:
             pairing_store=client_store,
             client_name="c",
             roles=[Roles.CONTROLLER],
-            pin_display=display,
+            pairing_support=PairingSupport(pin_display=display),
         )
         try:
             await client.connect(url)
@@ -1007,7 +1066,7 @@ async def _paired_client_with_stalled_success_tail(
         pairing_store=client_store,
         client_name="c",
         roles=[Roles.CONTROLLER],
-        pin_display=display,
+        pairing_support=PairingSupport(pin_display=display),
     )
     await client.connect(url)
     conn = await _find_connection_by_client_id(server, client_identity.peer_id)
@@ -1201,7 +1260,7 @@ async def test_reverification_leaves_staged_and_trusted_unpaired() -> None:
             pairing_store=client_store,
             client_name="c",
             roles=[Roles.CONTROLLER],
-            pin_display=display,
+            pairing_support=PairingSupport(pin_display=display),
         )
         try:
             await client.connect(url)
@@ -1225,13 +1284,14 @@ async def test_live_pairing_static_pin() -> None:
         replace(await client_store.get_pairing_config(), static_pin_enabled=True)
     )
     await client_store.set_static_pin("12345678")
-    await client_store.record_pin_failure(PairMethod.STATIC_PIN)  # reset on success
+    await client_store.record_pin_failure()  # dynamic-PIN counter; static pairing ignores it
 
     window_opened = asyncio.get_running_loop().create_future()
 
-    async def open_window() -> None:
-        if not window_opened.done():
+    async def gesture_prompt(active: bool) -> None:  # noqa: FBT001
+        if active and not window_opened.done():
             window_opened.set_result(None)
+            client.open_pairing_window()
 
     async def provide() -> str:
         return "12345678"
@@ -1242,7 +1302,7 @@ async def test_live_pairing_static_pin() -> None:
             pairing_store=client_store,
             client_name="c",
             roles=[Roles.CONTROLLER],
-            pairing_window=open_window,
+            pairing_support=PairingSupport(gesture_prompt=gesture_prompt),
         )
         try:
             await client.connect(url)
@@ -1261,30 +1321,42 @@ async def test_live_pairing_static_pin() -> None:
             assert server_record is not None
             assert client_record.psk == server_record.psk
             assert client_record.psk_id == server_record.psk_id
-            assert await client_store.pin_failure_count(PairMethod.STATIC_PIN) == 0
+            # The static flow leaves the dynamic-PIN failure counter alone.
+            assert await client_store.pin_failure_count() == 1
         finally:
             await client.disconnect()
 
 
-async def test_live_pairing_static_pin_locked_out_aborts() -> None:
-    """A static-PIN attempt under terminal lockout aborts and persists no record."""
+async def test_live_pairing_escalated_dynamic_pin_waits_for_window() -> None:
+    """An escalated dynamic-PIN attempt is gesture-gated; the gesture unparks it and it pairs."""
     server_store = InMemoryServerPairingStore()
     server = _make_server(server_store)
     client_identity = Identity.generate()
     client_store = InMemoryClientPairingStore()
-    await client_store.store_pairing_config(
-        replace(await client_store.get_pairing_config(), static_pin_enabled=True)
-    )
-    await client_store.set_static_pin("12345678")
     for _ in range(10):
-        await client_store.record_pin_failure(PairMethod.STATIC_PIN)
-    assert await client_store.is_pin_locked_out(PairMethod.STATIC_PIN)
+        await client_store.record_pin_failure()
+    assert await client_store.is_pin_escalated()
 
-    async def open_window() -> None:
-        return
+    window_opened = asyncio.get_running_loop().create_future()
+    pending_signals = 0
+
+    def on_pending() -> None:
+        nonlocal pending_signals
+        pending_signals += 1
+
+    async def gesture_prompt(active: bool) -> None:  # noqa: FBT001
+        if active and not window_opened.done():
+            window_opened.set_result(None)
+            client.open_pairing_window()
+
+    shown: asyncio.Future[str] = asyncio.get_running_loop().create_future()
+
+    async def display(pin: str | None) -> None:
+        if pin is not None and not shown.done():
+            shown.set_result(pin)
 
     async def provide() -> str:
-        return "12345678"
+        return await shown
 
     async with _serve(server) as url:
         client = make_sdk_client(
@@ -1292,17 +1364,25 @@ async def test_live_pairing_static_pin_locked_out_aborts() -> None:
             pairing_store=client_store,
             client_name="c",
             roles=[Roles.CONTROLLER],
-            pairing_window=open_window,
+            pairing_support=PairingSupport(gesture_prompt=gesture_prompt, pin_display=display),
         )
         try:
             await client.connect(url)
             conn = await _find_connection_by_client_id(server, client_identity.peer_id)
-            with pytest.raises(PairingAbortError) as excinfo:
-                await conn.initiate_pairing(
-                    PairingAttempt(method=PairMethod.STATIC_PIN, pin_provider=provide)
+            await conn.initiate_pairing(
+                PairingAttempt(
+                    method=PairMethod.DYNAMIC_PIN,
+                    pin_provider=provide,
+                    on_pair_pending=on_pending,
                 )
-            assert excinfo.value.reason is PairAbortReason.LOCKED_OUT
-            assert await client_store.record_by_server_id(server.id) is None
+            )
+            await _await_long_term_record(client_store, server.id)
+            assert window_opened.done()  # the attempt waited for the gesture
+            assert pending_signals == 1  # the server surfaced the pending gesture
+            assert client.noise_psk is not None
+            assert client.noise_psk.category is PskCategory.LONG_TERM
+            # Successful inner authentication de-escalates the method.
+            assert not await client_store.is_pin_escalated()
         finally:
             await client.disconnect()
 
@@ -1334,7 +1414,7 @@ async def test_live_pairing_pauses_writer_during_exchange() -> None:
             pairing_store=client_store,
             client_name="c",
             roles=[Roles.CONTROLLER],
-            pin_display=display,
+            pairing_support=PairingSupport(pin_display=display),
         )
         try:
             await client.connect(url)
@@ -1480,7 +1560,7 @@ async def test_resync_resends_current_player_state() -> None:
             client_name="c",
             roles=[Roles.PLAYER],
             player_support=player_support,
-            pin_display=display,
+            pairing_support=PairingSupport(pin_display=display),
         )
         try:
             await client.connect(url)
@@ -1555,7 +1635,7 @@ async def test_reverification_over_long_term_keeps_pairing() -> None:
         ClientPairingRecord(psk_id=long_term_id, psk=long_term, server_id=server.id)
     )
     # A pre-existing dynamic-PIN failure count is reset by a successful re-verification.
-    await client_store.record_pin_failure(PairMethod.DYNAMIC_PIN)
+    await client_store.record_pin_failure()
 
     shown: asyncio.Future[str] = asyncio.get_running_loop().create_future()
 
@@ -1572,7 +1652,7 @@ async def test_reverification_over_long_term_keeps_pairing() -> None:
             pairing_store=client_store,
             client_name="c",
             roles=[Roles.CONTROLLER],
-            pin_display=display,
+            pairing_support=PairingSupport(pin_display=display),
         )
         try:
             await client.connect(url)
@@ -1613,16 +1693,13 @@ async def test_reverification_over_long_term_keeps_pairing() -> None:
             ]
             assert len(stored_pubkey) == 1
             # Inner authentication succeeded, so the failure counter resets to zero.
-            assert await client_store.pin_failure_count(PairMethod.DYNAMIC_PIN) == 0
+            assert await client_store.pin_failure_count() == 0
         finally:
             await client.disconnect()
 
 
-async def test_reverification_rejected_under_dynamic_pin_lockout() -> None:
-    """Re-verification is subject to lockout: under terminal lockout it aborts with locked_out.
-
-    Spec :pin-pairing-lockout — re-verification follows the lockout rules like any other attempt.
-    """
+async def test_reverification_under_escalation_is_gesture_gated() -> None:
+    """Re-verification follows the escalation rules: gated on a window, de-escalated on success."""
     server_store = InMemoryServerPairingStore()
     server = _make_server(server_store)
     client_identity = Identity.generate()
@@ -1638,10 +1715,17 @@ async def test_reverification_rejected_under_dynamic_pin_lockout() -> None:
     await client_store.store_record(
         ClientPairingRecord(psk_id=long_term_id, psk=long_term, server_id=server.id)
     )
-    # Drive dynamic PIN into terminal lockout (counter reaches 10).
+    # Drive dynamic PIN into escalation (counter reaches 10).
     for _ in range(10):
-        await client_store.record_pin_failure(PairMethod.DYNAMIC_PIN)
-    assert await client_store.is_pin_locked_out(PairMethod.DYNAMIC_PIN)
+        await client_store.record_pin_failure()
+    assert await client_store.is_pin_escalated()
+
+    window_opened = asyncio.get_running_loop().create_future()
+
+    async def gesture_prompt(active: bool) -> None:  # noqa: FBT001
+        if active and not window_opened.done():
+            window_opened.set_result(None)
+            client.open_pairing_window()
 
     shown: asyncio.Future[str] = asyncio.get_running_loop().create_future()
 
@@ -1658,16 +1742,19 @@ async def test_reverification_rejected_under_dynamic_pin_lockout() -> None:
             pairing_store=client_store,
             client_name="c",
             roles=[Roles.CONTROLLER],
-            pin_display=display,
+            pairing_support=PairingSupport(gesture_prompt=gesture_prompt, pin_display=display),
         )
         try:
             await client.connect(url)
             conn = await _find_connection_by_client_id(server, client_identity.peer_id)
-            with pytest.raises(PairingAbortError) as excinfo:
-                await conn.initiate_pairing(
-                    PairingAttempt(method=PairMethod.DYNAMIC_PIN, pin_provider=provide, verify=True)
-                )
-            assert excinfo.value.reason is PairAbortReason.LOCKED_OUT
+            await conn.initiate_pairing(
+                PairingAttempt(method=PairMethod.DYNAMIC_PIN, pin_provider=provide, verify=True)
+            )
+            assert window_opened.done()  # the attempt waited for the gesture
+            assert client.connected
+            assert client.noise_psk is not None
+            assert client.noise_psk.psk == long_term  # same long-term PSK, no re-pair
+            assert not await client_store.is_pin_escalated()
         finally:
             await client.disconnect()
 

--- a/tests/models/test_hello_pairing_fields.py
+++ b/tests/models/test_hello_pairing_fields.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import orjson
+
 from aiosendspin.models.core import (
+    ActivatePairing,
     ClientHelloPayload,
     PairMethodDescriptor,
     ServerActivatePayload,
@@ -47,15 +50,23 @@ def test_server_hello_round_trips() -> None:
     assert restored.name == "Server"
 
 
-def test_server_activate_selected_pair_method_round_trips() -> None:
-    """server/activate carries the selected pairing method when present, else omits it."""
+def test_server_activate_pairing_object_round_trips() -> None:
+    """server/activate carries the pairing object when present, else omits it."""
     payload = ServerActivatePayload(
         activities=[Activity.PAIRING],
-        selected_pair_method=PairMethod.PAIRING_PSK,
+        pairing=ActivatePairing(method=PairMethod.DYNAMIC_PIN, pin_length=6),
     )
     restored = ServerActivatePayload.from_json(payload.to_json())
-    assert restored.selected_pair_method is PairMethod.PAIRING_PSK
+    assert restored.pairing == ActivatePairing(method=PairMethod.DYNAMIC_PIN, pin_length=6)
     assert restored.activities == [Activity.PAIRING]
-    assert (
-        ServerActivatePayload.from_json('{"activities":["playback"]}').selected_pair_method is None
+    assert ServerActivatePayload.from_json('{"activities":["playback"]}').pairing is None
+
+
+def test_activate_pairing_omits_pin_length_for_non_dynamic_methods() -> None:
+    """The pairing object omits pin_length when the method carries none."""
+    payload = ServerActivatePayload(
+        activities=[Activity.PAIRING],
+        pairing=ActivatePairing(method=PairMethod.STATIC_PIN),
     )
+    raw = orjson.loads(payload.to_json())
+    assert raw["pairing"] == {"method": "static_pin"}

--- a/tests/models/test_management.py
+++ b/tests/models/test_management.py
@@ -10,6 +10,7 @@ from aiosendspin.models.management import (
     ManagementAddRecordPayload,
     ManagementGetPairingConfigMessage,
     ManagementListRecordsMessage,
+    ManagementOpenPairingWindowMessage,
     ManagementRemoveRecordMessage,
     ManagementRemoveRecordPayload,
     ManagementResultData,
@@ -46,10 +47,11 @@ _PSK_B64 = "a" * 43
         ManagementSetPairingConfigMessage(
             ManagementSetPairingConfigPayload(
                 pairing_psk=SetPairingPskConfig(enabled=False),
-                dynamic_pin=SetDynamicPinConfig(locked_out=False),
+                dynamic_pin=SetDynamicPinConfig(min_pin_length=6),
                 record_mode=RecordModeConfig(psk_id="p1"),
             )
         ),
+        ManagementOpenPairingWindowMessage(),
     ],
 )
 def test_server_request_round_trips(message: ServerMessage) -> None:
@@ -65,6 +67,7 @@ def test_server_request_round_trips(message: ServerMessage) -> None:
         ServerUnpairMessage(),
         ManagementListRecordsMessage(),
         ManagementGetPairingConfigMessage(),
+        ManagementOpenPairingWindowMessage(),
     ],
 )
 def test_empty_payload_messages_send_payload_key(message: ServerMessage) -> None:
@@ -141,10 +144,10 @@ def test_set_config_patch_omits_absent_fields() -> None:
 
 
 def test_get_config_data_round_trips() -> None:
-    """A get-pairing-config result round-trips and omits locked_out for non-PIN methods."""
+    """A get-pairing-config result round-trips and omits escalated for non-dynamic methods."""
     data = ManagementResultData(
         pairing_psk=PairingMethodConfig(enabled=True),
-        dynamic_pin=PairingMethodConfig(enabled=False, locked_out=True),
+        dynamic_pin=PairingMethodConfig(enabled=False, min_pin_length=6, escalated=True),
         record_mode=RecordModeConfig(psk_id="p1"),
         unpaired_access=UnpairedAccess(enabled=False),
     )
@@ -153,5 +156,5 @@ def test_get_config_data_round_trips() -> None:
     )
     assert ClientMessage.from_json(message.to_json()) == message
     raw = orjson.loads(message.to_json())["payload"]["data"]
-    assert "locked_out" not in raw["pairing_psk"]
-    assert raw["dynamic_pin"]["locked_out"] is True
+    assert "escalated" not in raw["pairing_psk"]
+    assert raw["dynamic_pin"]["escalated"] is True

--- a/tests/noise/test_pairing.py
+++ b/tests/noise/test_pairing.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Sequence
-from dataclasses import replace
 from datetime import UTC, datetime
 
 import pytest
@@ -23,6 +22,8 @@ from aiosendspin.noise.models import (
     ClientPairFinalizePayload,
     ClientPairInitMessage,
     ClientPairInitPayload,
+    ClientPairPendingMessage,
+    ClientPairPendingPayload,
     ServerPairAuthMessage,
     ServerPairAuthPayload,
     ServerPairInitMessage,
@@ -31,6 +32,7 @@ from aiosendspin.noise.pairing import (
     PairingAbortError,
     PairingAttempt,
     PairingError,
+    PairingTimeoutError,
     run_dynamic_pin_client,
     run_dynamic_pin_server,
     run_pairing_psk_client,
@@ -67,13 +69,19 @@ def test_pairing_attempt_verify_is_pin_only() -> None:
 
 
 def test_pairing_attempt_pairing_psk_requires_material() -> None:
-    """PAIRING_PSK must carry a 32-byte pairing_psk and no PIN provider."""
+    """PAIRING_PSK must carry a 32-byte pairing_psk and no PIN-flow hooks."""
     with pytest.raises(ValueError, match="requires pairing_psk"):
         PairingAttempt(method=PairMethod.PAIRING_PSK)
     with pytest.raises(ValueError, match="must be 32 bytes"):
         PairingAttempt(method=PairMethod.PAIRING_PSK, pairing_psk=b"\x01" * 16)
     with pytest.raises(ValueError, match="does not use pin_provider"):
         PairingAttempt(method=PairMethod.PAIRING_PSK, pairing_psk=generate_psk(), pin_provider=_pin)
+    with pytest.raises(ValueError, match="does not use on_pair_pending"):
+        PairingAttempt(
+            method=PairMethod.PAIRING_PSK,
+            pairing_psk=generate_psk(),
+            on_pair_pending=lambda: None,
+        )
 
 
 @pytest.mark.parametrize("method", [PairMethod.DYNAMIC_PIN, PairMethod.STATIC_PIN])
@@ -142,25 +150,25 @@ async def test_pairing_psk_server_times_out_without_finalize(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The Pairing PSK server times out locally, sending nothing, if the client never finalizes."""
-    monkeypatch.setattr("aiosendspin.noise.pairing._SERVER_FIRST_MESSAGE_TIMEOUT_S", 0.05)
+    monkeypatch.setattr("aiosendspin.noise.pairing.SERVER_FIRST_MESSAGE_TIMEOUT_S", 0.05)
     _client_ews, server_ews, _client_raw, server_raw = _paired_encrypted_ws()
     server_store = InMemoryServerPairingStore()
 
-    with pytest.raises(TimeoutError):
+    with pytest.raises(PairingTimeoutError):
         await run_pairing_psk_server(server_ews, client_id="client-X", store=server_store)
     assert server_raw.sent == []
     assert await server_store.record_by_client_id("client-X") is None
 
 
-async def test_static_pin_server_gesture_wait_times_out(
+async def test_static_pin_server_first_message_wait_times_out(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The static-PIN server times out locally awaiting the gesture-gated pair-init."""
-    monkeypatch.setattr("aiosendspin.noise.pairing._SERVER_GESTURE_TIMEOUT_S", 0.05)
+    """The static-PIN server times out locally awaiting the client's first pairing message."""
+    monkeypatch.setattr("aiosendspin.noise.pairing.SERVER_FIRST_MESSAGE_TIMEOUT_S", 0.05)
     _client_ews, server_ews, _client_raw, server_raw = _paired_encrypted_ws()
     server_store = InMemoryServerPairingStore()
 
-    with pytest.raises(TimeoutError):
+    with pytest.raises(PairingTimeoutError):
         await run_static_pin_server(
             server_ews,
             handshake_hash=_HANDSHAKE_HASH,
@@ -170,6 +178,174 @@ async def test_static_pin_server_gesture_wait_times_out(
             store=server_store,
         )
     assert server_raw.sent == []
+
+
+async def test_pair_pending_extends_the_first_message_wait() -> None:
+    """A matching pair-pending switches the server to the gesture timeout; pairing completes."""
+    client_ews, server_ews, _client_raw, _server_raw = _paired_encrypted_ws()
+    client_store = InMemoryClientPairingStore()
+    server_store = InMemoryServerPairingStore()
+    pending_signals = 0
+
+    def on_pending() -> None:
+        nonlocal pending_signals
+        pending_signals += 1
+
+    async def gated_client() -> None:
+        await client_ews.send_str(
+            ClientPairPendingMessage(payload=ClientPairPendingPayload(pairing_index=0)).to_json()
+        )
+        await run_static_pin_client(
+            client_ews,
+            handshake_hash=_HANDSHAKE_HASH,
+            pairing_index=0,
+            static_pin=_STATIC_PIN,
+            server_id="server-X",
+            store=client_store,
+        )
+
+    async def provide() -> str:
+        return _STATIC_PIN
+
+    _client_ret, server_record = await asyncio.gather(
+        gated_client(),
+        run_static_pin_server(
+            server_ews,
+            handshake_hash=_HANDSHAKE_HASH,
+            pairing_index=0,
+            pin_provider=provide,
+            client_id="client-A",
+            store=server_store,
+            on_pair_pending=on_pending,
+        ),
+    )
+    assert server_record is not None
+    assert await server_store.record_by_client_id("client-A") == server_record
+    assert pending_signals == 1
+
+
+async def test_gesture_wait_times_out_after_pair_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After pair-pending the gesture bound applies; its expiry raises locally."""
+    monkeypatch.setattr("aiosendspin.noise.pairing.SERVER_GESTURE_TIMEOUT_S", 0.05)
+    client_ews, server_ews, _client_raw, _server_raw = _paired_encrypted_ws()
+    server_store = InMemoryServerPairingStore()
+
+    await client_ews.send_str(
+        ClientPairPendingMessage(payload=ClientPairPendingPayload(pairing_index=0)).to_json()
+    )
+    with pytest.raises(PairingTimeoutError):
+        await run_static_pin_server(
+            server_ews,
+            handshake_hash=_HANDSHAKE_HASH,
+            pairing_index=0,
+            pin_provider=_pin,
+            client_id="client-X",
+            store=server_store,
+        )
+
+
+async def test_stale_pair_pending_is_discarded() -> None:
+    """A pair-pending left over from a superseded activate is ignored; the fresh init pairs."""
+    client_ews, server_ews, _client_raw, _server_raw = _paired_encrypted_ws()
+    client_store = InMemoryClientPairingStore()
+    server_store = InMemoryServerPairingStore()
+    pending_signals = 0
+
+    def on_pending() -> None:
+        nonlocal pending_signals
+        pending_signals += 1
+
+    await client_ews.send_str(
+        ClientPairPendingMessage(payload=ClientPairPendingPayload(pairing_index=0)).to_json()
+    )
+
+    async def provide() -> str:
+        return _STATIC_PIN
+
+    _client_ret, server_record = await asyncio.gather(
+        run_static_pin_client(
+            client_ews,
+            handshake_hash=_HANDSHAKE_HASH,
+            pairing_index=1,
+            static_pin=_STATIC_PIN,
+            server_id="server-X",
+            store=client_store,
+        ),
+        run_static_pin_server(
+            server_ews,
+            handshake_hash=_HANDSHAKE_HASH,
+            pairing_index=1,
+            pin_provider=provide,
+            client_id="client-A",
+            store=server_store,
+            on_pair_pending=on_pending,
+        ),
+    )
+    assert server_record is not None
+    assert pending_signals == 0  # the stale pending is not surfaced
+
+
+async def test_repeated_pair_pending_is_protocol_error() -> None:
+    """A second matching pair-pending within one attempt is a protocol error."""
+    client_ews, server_ews, _client_raw, _server_raw = _paired_encrypted_ws()
+    server_store = InMemoryServerPairingStore()
+
+    for _ in range(2):
+        await client_ews.send_str(
+            ClientPairPendingMessage(payload=ClientPairPendingPayload(pairing_index=0)).to_json()
+        )
+    with pytest.raises(PairingError, match="expected ClientPairInitMessage"):
+        await run_static_pin_server(
+            server_ews,
+            handshake_hash=_HANDSHAKE_HASH,
+            pairing_index=0,
+            pin_provider=_pin,
+            client_id="client-A",
+            store=server_store,
+        )
+
+
+async def test_pair_init_index_mismatch_after_pending_is_protocol_error() -> None:
+    """After the matching pair-pending, an init for a different attempt is a protocol error."""
+    client_ews, server_ews, _client_raw, _server_raw = _paired_encrypted_ws()
+    server_store = InMemoryServerPairingStore()
+
+    await client_ews.send_str(
+        ClientPairPendingMessage(payload=ClientPairPendingPayload(pairing_index=0)).to_json()
+    )
+    await client_ews.send_str(
+        ClientPairInitMessage(payload=ClientPairInitPayload(pairing_index=1)).to_json()
+    )
+    with pytest.raises(PairingError, match="does not match the attempt"):
+        await run_static_pin_server(
+            server_ews,
+            handshake_hash=_HANDSHAKE_HASH,
+            pairing_index=0,
+            pin_provider=_pin,
+            client_id="client-A",
+            store=server_store,
+        )
+
+
+async def test_pair_pending_ahead_of_server_count_is_protocol_error() -> None:
+    """A pair-pending with a pairing_index the server has not reached yet is a protocol error."""
+    client_ews, server_ews, _client_raw, _server_raw = _paired_encrypted_ws()
+    server_store = InMemoryServerPairingStore()
+
+    await client_ews.send_str(
+        ClientPairPendingMessage(payload=ClientPairPendingPayload(pairing_index=1)).to_json()
+    )
+    with pytest.raises(PairingError, match="ahead of the server's count"):
+        await run_static_pin_server(
+            server_ews,
+            handshake_hash=_HANDSHAKE_HASH,
+            pairing_index=0,
+            pin_provider=_pin,
+            client_id="client-A",
+            store=server_store,
+        )
 
 
 async def test_static_pin_server_rejects_non_8_digit_operator_pin() -> None:
@@ -226,7 +402,7 @@ async def test_dynamic_pin_server_times_out_mid_attempt(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The dynamic-PIN server times out locally, with no abort on the wire, if the client stalls."""
-    monkeypatch.setattr("aiosendspin.noise.pairing._SERVER_ATTEMPT_TIMEOUT_S", 0.05)
+    monkeypatch.setattr("aiosendspin.noise.pairing.SERVER_ATTEMPT_TIMEOUT_S", 0.05)
     client_ews, server_ews, client_raw, _server_raw = _paired_encrypted_ws()
     server_store = InMemoryServerPairingStore()
 
@@ -237,7 +413,7 @@ async def test_dynamic_pin_server_times_out_mid_attempt(
             ),
         ).to_json(),
     )
-    with pytest.raises(TimeoutError):
+    with pytest.raises(PairingTimeoutError):
         await run_dynamic_pin_server(
             server_ews,
             handshake_hash=_HANDSHAKE_HASH,
@@ -325,6 +501,7 @@ async def test_dynamic_pin_round_trip() -> None:
             client_ews,
             handshake_hash=_HANDSHAKE_HASH,
             pairing_index=0,
+            pin_length=8,
             pin_emitter=emit,
             server_id="server-X",
             store=client_store,
@@ -375,6 +552,7 @@ async def test_dynamic_pin_server_discards_stale_pair_init() -> None:
             client_ews,
             handshake_hash=_HANDSHAKE_HASH,
             pairing_index=1,
+            pin_length=8,
             pin_emitter=emit,
             server_id="server-X",
             store=client_store,
@@ -433,6 +611,7 @@ async def test_dynamic_pin_wrong_pin_aborts_and_persists_nothing() -> None:
                 client_ews,
                 handshake_hash=_HANDSHAKE_HASH,
                 pairing_index=0,
+                pin_length=8,
                 pin_emitter=emit,
                 server_id="server-X",
                 store=client_store,
@@ -449,88 +628,7 @@ async def test_dynamic_pin_wrong_pin_aborts_and_persists_nothing() -> None:
         )
 
     assert excinfo.value.reason is PairAbortReason.PIN_MISMATCH
-    assert await client_store.pin_failure_count(PairMethod.DYNAMIC_PIN) == 1
-    assert _added_records(await client_store.list_records()) == []
-    assert await server_store.record_by_client_id("client-A") is None
-
-
-async def test_dynamic_pin_length_below_client_floor_aborts() -> None:
-    """A pin_length under the client's min is rejected pre-PAKE; the counter is untouched."""
-    client_ews, server_ews, _client_raw, _server_raw = _paired_encrypted_ws()
-    client_store = InMemoryClientPairingStore()  # default min_pin_length = 6
-    server_store = InMemoryServerPairingStore()
-    emitted: list[str] = []
-
-    async def emit(pin: str) -> None:
-        emitted.append(pin)
-
-    async def provide() -> str:
-        return "0000"
-
-    with pytest.raises(PairingAbortError) as excinfo:
-        await asyncio.gather(
-            run_dynamic_pin_client(
-                client_ews,
-                handshake_hash=_HANDSHAKE_HASH,
-                pairing_index=0,
-                pin_emitter=emit,
-                server_id="server-X",
-                store=client_store,
-            ),
-            run_dynamic_pin_server(
-                server_ews,
-                handshake_hash=_HANDSHAKE_HASH,
-                pairing_index=0,
-                pin_length=4,  # below the client's floor of 6
-                pin_provider=provide,
-                client_id="client-A",
-                store=server_store,
-            ),
-        )
-
-    assert excinfo.value.reason is PairAbortReason.PIN_LENGTH_UNACCEPTABLE
-    assert emitted == []  # no PIN emitted on a length rejection
-    assert await client_store.pin_failure_count(PairMethod.DYNAMIC_PIN) == 0
-    assert _added_records(await client_store.list_records()) == []
-    assert await server_store.record_by_client_id("client-A") is None
-
-
-async def test_dynamic_pin_length_below_spec_minimum_aborts() -> None:
-    """A config min under MIN_PIN_DIGITS still aborts cleanly rather than raising ValueError."""
-    client_ews, server_ews, _client_raw, _server_raw = _paired_encrypted_ws()
-    client_store = InMemoryClientPairingStore()
-    cfg = await client_store.get_pairing_config()
-    await client_store.store_pairing_config(replace(cfg, dynamic_pin_min_length=2))
-    server_store = InMemoryServerPairingStore()
-
-    async def emit(pin: str) -> None:
-        pass
-
-    async def provide() -> str:
-        return "00"
-
-    with pytest.raises(PairingAbortError) as excinfo:
-        await asyncio.gather(
-            run_dynamic_pin_client(
-                client_ews,
-                handshake_hash=_HANDSHAKE_HASH,
-                pairing_index=0,
-                pin_emitter=emit,
-                server_id="server-X",
-                store=client_store,
-            ),
-            run_dynamic_pin_server(
-                server_ews,
-                handshake_hash=_HANDSHAKE_HASH,
-                pairing_index=0,
-                pin_length=2,
-                pin_provider=provide,
-                client_id="client-A",
-                store=server_store,
-            ),
-        )
-
-    assert excinfo.value.reason is PairAbortReason.PIN_LENGTH_UNACCEPTABLE
+    assert await client_store.pin_failure_count() == 1
     assert _added_records(await client_store.list_records()) == []
     assert await server_store.record_by_client_id("client-A") is None
 
@@ -540,7 +638,7 @@ async def test_client_relays_leave_pairing_without_storing() -> None:
     client_ews, server_ews, _client_raw, _server_raw = _paired_encrypted_ws()
     client_store = InMemoryClientPairingStore()
     server_store = InMemoryServerPairingStore()
-    await client_store.record_pin_failure(PairMethod.DYNAMIC_PIN)  # a prior failure to be reset
+    await client_store.record_pin_failure()  # a prior failure to be reset
     shown: asyncio.Future[str] = asyncio.get_running_loop().create_future()
 
     async def emit(pin: str) -> None:
@@ -573,6 +671,7 @@ async def test_client_relays_leave_pairing_without_storing() -> None:
             client_ews,
             handshake_hash=_HANDSHAKE_HASH,
             pairing_index=0,
+            pin_length=8,
             pin_emitter=emit,
             server_id="server-X",
             store=client_store,
@@ -586,18 +685,18 @@ async def test_client_relays_leave_pairing_without_storing() -> None:
     assert _added_records(await client_store.list_records()) == []
     assert await server_store.record_by_client_id("client-A") is None
     # Inner authentication succeeded, so the failure counter resets like any other attempt.
-    assert await client_store.pin_failure_count(PairMethod.DYNAMIC_PIN) == 0
+    assert await client_store.pin_failure_count() == 0
 
 
 _STATIC_PIN = "12345678"
 
 
 async def test_static_pin_round_trip() -> None:
-    """A matching static PIN authenticates the PAKE; both sides persist and the counter resets."""
+    """A matching static PIN authenticates the PAKE and both sides persist the record."""
     client_ews, server_ews, _client_raw, _server_raw = _paired_encrypted_ws()
     client_store = InMemoryClientPairingStore()
     server_store = InMemoryServerPairingStore()
-    await client_store.record_pin_failure(PairMethod.STATIC_PIN)  # a prior failure to be reset
+    await client_store.record_pin_failure()  # a dynamic-PIN failure static pairing ignores
 
     async def provide() -> str:
         return _STATIC_PIN
@@ -627,12 +726,12 @@ async def test_static_pin_round_trip() -> None:
     assert client_record.psk_id == server_record.psk_id
     assert server_record.client_id == "client-A"
     assert await server_store.record_by_client_id("client-A") == server_record
-    # A successful pairing resets the failure counter.
-    assert await client_store.pin_failure_count(PairMethod.STATIC_PIN) == 0
+    # The static flow leaves the dynamic-PIN failure counter alone.
+    assert await client_store.pin_failure_count() == 1
 
 
-async def test_static_pin_wrong_pin_aborts_and_increments_counter() -> None:
-    """A static-PIN mismatch aborts, increments the client counter, and stores nothing."""
+async def test_static_pin_wrong_pin_aborts_and_persists_nothing() -> None:
+    """A static-PIN mismatch aborts and stores nothing; the counter stays untouched."""
     client_ews, server_ews, _client_raw, _server_raw = _paired_encrypted_ws()
     client_store = InMemoryClientPairingStore()
     server_store = InMemoryServerPairingStore()
@@ -661,7 +760,7 @@ async def test_static_pin_wrong_pin_aborts_and_increments_counter() -> None:
         )
 
     assert excinfo.value.reason is PairAbortReason.PIN_MISMATCH
-    assert await client_store.pin_failure_count(PairMethod.STATIC_PIN) == 1
+    assert await client_store.pin_failure_count() == 0
     assert _added_records(await client_store.list_records()) == []
     assert await server_store.record_by_client_id("client-A") is None
 
@@ -701,7 +800,7 @@ async def test_static_pin_invalid_server_share_is_protocol_error(pake_msg_1: str
         )
 
     assert not isinstance(excinfo.value, PairingAbortError)
-    assert await client_store.pin_failure_count(PairMethod.STATIC_PIN) == 0
+    assert await client_store.pin_failure_count() == 0
     assert _added_records(await client_store.list_records()) == []
 
 
@@ -858,7 +957,7 @@ async def _dynamic_pake_client(
     )
     init = ServerPairInitMessage.from_json((await client_ews.receive()).data)
     nonce_a = b64url_decode(init.payload.nonce_A)
-    pin = pin_mod.derive_pin(_HANDSHAKE_HASH, nonce_a, nonce_b, init.payload.pin_length)
+    pin = pin_mod.derive_pin(_HANDSHAKE_HASH, nonce_a, nonce_b, 8)
     if mangle_pin:
         pin = ("2" if pin[0] == "1" else "1") + pin[1:]
     pin_future.set_result(pin)

--- a/tests/noise/test_trust_store.py
+++ b/tests/noise/test_trust_store.py
@@ -12,7 +12,7 @@ import pytest
 from aiosendspin.models.types import PairMethod
 from aiosendspin.noise.keys import generate_psk, psk_id_for
 from aiosendspin.noise.trust_store import (
-    PIN_LOCKOUT_THRESHOLD,
+    PIN_ESCALATION_THRESHOLD,
     ClientPairingRecord,
     ClientPairingStore,
     FileClientPairingStore,
@@ -301,13 +301,13 @@ async def test_file_client_store_persists_state(tmp_path: Path) -> None:
     await store.store_record(record)
     await store.set_pairing_psk(pairing)
     await store.set_static_pin("12345678")
-    await store.record_pin_failure(PairMethod.DYNAMIC_PIN)
+    await store.record_pin_failure()
 
     reloaded = await FileClientPairingStore.open(path)
     assert await reloaded.record_by_server_id("server-X") == record
     assert await reloaded.pairing_psk() == pairing
     assert await reloaded.static_pin() == "12345678"
-    assert await reloaded.pin_failure_count(PairMethod.DYNAMIC_PIN) == 1
+    assert await reloaded.pin_failure_count() == 1
 
 
 async def test_file_client_store_persists_last_playback_server(tmp_path: Path) -> None:
@@ -484,32 +484,25 @@ async def test_client_store_reports_no_storage_accounting_by_default(
 
 
 async def test_pin_failure_counter_increments_and_resets(client_store: ClientPairingStore) -> None:
-    """Failures accumulate per method and reset clears the counter."""
-    assert await client_store.pin_failure_count(PairMethod.DYNAMIC_PIN) == 0
-    assert await client_store.record_pin_failure(PairMethod.DYNAMIC_PIN) == 1
-    assert await client_store.record_pin_failure(PairMethod.DYNAMIC_PIN) == 2
-    await client_store.reset_pin_failures(PairMethod.DYNAMIC_PIN)
-    assert await client_store.pin_failure_count(PairMethod.DYNAMIC_PIN) == 0
+    """Failures accumulate and reset clears the counter."""
+    assert await client_store.pin_failure_count() == 0
+    assert await client_store.record_pin_failure() == 1
+    assert await client_store.record_pin_failure() == 2
+    await client_store.reset_pin_failures()
+    assert await client_store.pin_failure_count() == 0
 
 
-async def test_pin_failure_counter_is_per_method(client_store: ClientPairingStore) -> None:
-    """static_pin and dynamic_pin counters are tracked independently."""
-    await client_store.record_pin_failure(PairMethod.DYNAMIC_PIN)
-    assert await client_store.pin_failure_count(PairMethod.STATIC_PIN) == 0
-    assert await client_store.pin_failure_count(PairMethod.DYNAMIC_PIN) == 1
-
-
-async def test_pin_lockout_at_threshold_and_clears_on_reset(
+async def test_pin_escalation_at_threshold_and_clears_on_reset(
     client_store: ClientPairingStore,
 ) -> None:
-    """Lockout trips at the threshold and clears only on reset."""
-    for _ in range(PIN_LOCKOUT_THRESHOLD - 1):
-        await client_store.record_pin_failure(PairMethod.DYNAMIC_PIN)
-    assert not await client_store.is_pin_locked_out(PairMethod.DYNAMIC_PIN)
-    await client_store.record_pin_failure(PairMethod.DYNAMIC_PIN)
-    assert await client_store.is_pin_locked_out(PairMethod.DYNAMIC_PIN)
-    await client_store.reset_pin_failures(PairMethod.DYNAMIC_PIN)
-    assert not await client_store.is_pin_locked_out(PairMethod.DYNAMIC_PIN)
+    """Escalation trips at the threshold and clears only on reset."""
+    for _ in range(PIN_ESCALATION_THRESHOLD - 1):
+        await client_store.record_pin_failure()
+    assert not await client_store.is_pin_escalated()
+    await client_store.record_pin_failure()
+    assert await client_store.is_pin_escalated()
+    await client_store.reset_pin_failures()
+    assert not await client_store.is_pin_escalated()
 
 
 # --- shared-PSK records --------------------------------------------------

--- a/tests/test_client_pairing.py
+++ b/tests/test_client_pairing.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import asyncio
 import logging
 from contextlib import suppress
+from dataclasses import replace
 
 import pytest
 from aiohttp import WSMessage, WSMsgType
 
 from aiosendspin.client.connection import SendspinConnection
-from aiosendspin.models.core import ServerActivateMessage, ServerActivatePayload
+from aiosendspin.client.models import PairingSupport
+from aiosendspin.models.core import ActivatePairing, ServerActivateMessage, ServerActivatePayload
 from aiosendspin.models.types import (
     Activity,
     GoodbyeReason,
@@ -21,12 +23,13 @@ from aiosendspin.models.types import (
 )
 from aiosendspin.noise.keys import b64url_encode
 from aiosendspin.noise.models import (
+    ClientPairPendingMessage,
     PairAbortMessage,
     ServerPairAuthMessage,
     ServerPairAuthPayload,
 )
 from aiosendspin.noise.pairing import PairingError
-from aiosendspin.noise.trust_store import PskCategory, ResolvedPsk
+from aiosendspin.noise.trust_store import PIN_ESCALATION_THRESHOLD, PskCategory, ResolvedPsk
 
 from .conftest import make_sdk_client
 
@@ -60,9 +63,10 @@ def _client_with(category: PskCategory) -> tuple[SendspinConnection, _FakeWS]:
 
 
 async def test_pairing_psk_method_accepted_on_pairing_psk() -> None:
-    """A Pairing-PSK match with selected_pair_method=pairing_psk passes the cross-check."""
+    """A Pairing-PSK match with pairing.method=pairing_psk passes the cross-check."""
     connection, ws = _client_with(PskCategory.PAIRING)
-    await connection._validate_pair_method(PairMethod.PAIRING_PSK)  # noqa: SLF001
+    pairing = ActivatePairing(method=PairMethod.PAIRING_PSK)
+    assert await connection._validate_pairing(pairing) is pairing  # noqa: SLF001
     assert ws.sent == []
 
 
@@ -71,14 +75,15 @@ async def test_pairing_psk_method_accepted_on_pairing_psk() -> None:
     [
         (PskCategory.PAIRING, PairMethod.DYNAMIC_PIN),  # not offered by this client
         (PskCategory.LONG_TERM, PairMethod.PAIRING_PSK),  # not allowed for long-term PSK
-        (PskCategory.PAIRING, None),  # missing when connection_reason is pairing
+        (PskCategory.PAIRING, None),  # missing when 'pairing' is in activities
     ],
 )
 async def test_invalid_pair_method_aborts(category: PskCategory, method: PairMethod | None) -> None:
     """A disallowed/unoffered/missing method sends pair/abort and raises."""
     connection, ws = _client_with(category)
+    pairing = ActivatePairing(method=method) if method is not None else None
     with pytest.raises(PairingError):
-        await connection._validate_pair_method(method)  # noqa: SLF001
+        await connection._validate_pairing(pairing)  # noqa: SLF001
     abort = PairAbortMessage.from_json(ws.sent[0])
     assert abort.payload.reason is PairAbortReason.METHOD_NOT_SUPPORTED
 
@@ -134,12 +139,8 @@ async def test_pair_abort_and_goodbye_bypass_exchange_suppression() -> None:
 
 
 async def test_pairing_window_tolerates_bare_leave_activate() -> None:
-    """A bare leave server/activate during the gesture wait ends pairing, not the connection."""
-
-    async def never() -> None:
-        await asyncio.Event().wait()
-
-    client = make_sdk_client(client_name="C", roles=[Roles.CONTROLLER], pairing_window=never)
+    """A bare leave server/activate during the window wait ends pairing, not the connection."""
+    client = make_sdk_client(client_name="C", roles=[Roles.CONTROLLER])
     connection = SendspinConnection(client)
     ws = _FakeWS()
     leave = ServerActivateMessage(
@@ -152,13 +153,260 @@ async def test_pairing_window_tolerates_bare_leave_activate() -> None:
     ws.receive = receive  # type: ignore[attr-defined]
     connection._ws = ws  # type: ignore[assignment]  # noqa: SLF001
     connection._server_id = "server-1"  # noqa: SLF001
-    # Static-PIN pairing (the only flow with a gesture wait) runs over the Sentinel PSK.
+    # Gesture-gated pairing runs over the Sentinel PSK.
     connection._noise_psk = ResolvedPsk("psk-id", b"\x00" * 32, PskCategory.SENTINEL)  # noqa: SLF001
 
-    frame = await connection._await_pairing_window()  # noqa: SLF001
+    frame = await connection._gate_on_pairing_window(1)  # noqa: SLF001
 
     # The bare leave activate is surfaced raw for downstream parsing, not raised.
     assert frame == leave
+    assert ClientPairPendingMessage.from_json(ws.sent[0]).payload.pairing_index == 1
+
+
+def _dynamic_pin_connection() -> tuple[SendspinConnection, _FakeWS]:
+    """Build a Sentinel-keyed connection whose client offers dynamic PIN."""
+
+    async def display(pin: str | None) -> None:
+        pass
+
+    client = make_sdk_client(
+        client_name="C",
+        roles=[Roles.CONTROLLER],
+        pairing_support=PairingSupport(pin_display=display),
+    )
+    connection = SendspinConnection(client)
+    ws = _FakeWS()
+    connection._ws = ws  # type: ignore[assignment]  # noqa: SLF001
+    connection._server_id = "server-1"  # noqa: SLF001
+    connection._handshake_hash = b"\x00" * 32  # noqa: SLF001
+    connection._noise_psk = ResolvedPsk("psk-id", b"\x00" * 32, PskCategory.SENTINEL)  # noqa: SLF001
+    return connection, ws
+
+
+async def _set_min_pin_length(connection: SendspinConnection, min_pin_length: int) -> None:
+    store = connection._client.pairing_store  # noqa: SLF001
+    config = await store.get_pairing_config()
+    await store.store_pairing_config(replace(config, dynamic_pin_min_length=min_pin_length))
+
+
+@pytest.mark.parametrize("pin_length", [None, 4, 13])
+async def test_dynamic_activation_with_unacceptable_pin_length_aborts(
+    pin_length: int | None,
+) -> None:
+    """A pairing activation whose pin_length undercuts the floor or the range aborts."""
+    connection, ws = _dynamic_pin_connection()
+    connection._selected_pairing = ActivatePairing(  # noqa: SLF001
+        method=PairMethod.DYNAMIC_PIN, pin_length=pin_length
+    )
+    with pytest.raises(PairingError):
+        await connection._run_pairing_protocol()  # noqa: SLF001
+    abort = PairAbortMessage.from_json(ws.sent[0])
+    assert abort.payload.reason is PairAbortReason.PIN_LENGTH_UNACCEPTABLE
+
+
+async def test_short_pin_attempt_is_gesture_gated() -> None:
+    """A dynamic attempt with pin_length below 6 signals pair-pending and awaits a window."""
+    connection, ws = _dynamic_pin_connection()
+    await _set_min_pin_length(connection, 4)
+    connection._selected_pairing = ActivatePairing(  # noqa: SLF001
+        method=PairMethod.DYNAMIC_PIN, pin_length=4
+    )
+    leave = ServerActivateMessage(
+        payload=ServerActivatePayload(activities=[], active_roles=[])
+    ).to_json()
+
+    async def receive() -> WSMessage:
+        return WSMessage(WSMsgType.TEXT, leave, "")
+
+    ws.receive = receive  # type: ignore[attr-defined]
+
+    frame = await connection._run_pairing_protocol()  # noqa: SLF001
+
+    assert frame == leave
+    pending = ClientPairPendingMessage.from_json(ws.sent[0])
+    assert pending.payload.pairing_index == 1
+
+
+async def test_escalated_dynamic_attempt_is_gesture_gated() -> None:
+    """Once escalated, even a long-PIN dynamic attempt signals pair-pending."""
+    connection, ws = _dynamic_pin_connection()
+    store = connection._client.pairing_store  # noqa: SLF001
+    for _ in range(PIN_ESCALATION_THRESHOLD):
+        await store.record_pin_failure()
+    connection._selected_pairing = ActivatePairing(  # noqa: SLF001
+        method=PairMethod.DYNAMIC_PIN, pin_length=8
+    )
+    leave = ServerActivateMessage(
+        payload=ServerActivatePayload(activities=[], active_roles=[])
+    ).to_json()
+
+    async def receive() -> WSMessage:
+        return WSMessage(WSMsgType.TEXT, leave, "")
+
+    ws.receive = receive  # type: ignore[attr-defined]
+
+    frame = await connection._run_pairing_protocol()  # noqa: SLF001
+
+    assert frame == leave
+    assert ClientPairPendingMessage.from_json(ws.sent[0]).payload.pairing_index == 1
+
+
+async def test_ungated_dynamic_attempt_starts_immediately(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A long-PIN, unescalated dynamic attempt runs without pair-pending or a window."""
+    connection, ws = _dynamic_pin_connection()
+    connection._selected_pairing = ActivatePairing(  # noqa: SLF001
+        method=PairMethod.DYNAMIC_PIN, pin_length=6
+    )
+    captured: dict[str, object] = {}
+
+    async def fake_run(_ws: object, **kwargs: object) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr("aiosendspin.client.connection.run_dynamic_pin_client", fake_run)
+
+    assert await connection._run_pairing_protocol() is None  # noqa: SLF001
+    assert captured["pin_length"] == 6
+    assert ws.sent == []  # no pair-pending
+
+
+async def test_gated_attempt_consumes_open_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With a window already open, a gated attempt skips pair-pending and consumes it."""
+    connection, ws = _dynamic_pin_connection()
+    client = connection._client  # noqa: SLF001
+    store = client.pairing_store
+    for _ in range(PIN_ESCALATION_THRESHOLD):
+        await store.record_pin_failure()
+    client.open_pairing_window()
+    connection._selected_pairing = ActivatePairing(  # noqa: SLF001
+        method=PairMethod.DYNAMIC_PIN, pin_length=8
+    )
+
+    async def fake_run(_ws: object, **kwargs: object) -> None:
+        pass
+
+    monkeypatch.setattr("aiosendspin.client.connection.run_dynamic_pin_client", fake_run)
+
+    assert await connection._run_pairing_protocol() is None  # noqa: SLF001
+    assert ws.sent == []  # no pair-pending
+    assert not client.pairing_window_open  # consumed by the attempt
+
+
+async def test_ungated_attempt_consumes_open_window(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An ungated attempt still spends an open window: its lifetime ends at pair-init."""
+    connection, ws = _dynamic_pin_connection()
+    client = connection._client  # noqa: SLF001
+    client.open_pairing_window()
+    connection._selected_pairing = ActivatePairing(  # noqa: SLF001
+        method=PairMethod.DYNAMIC_PIN, pin_length=8
+    )
+
+    async def fake_run(_ws: object, **kwargs: object) -> None:
+        pass
+
+    monkeypatch.setattr("aiosendspin.client.connection.run_dynamic_pin_client", fake_run)
+
+    assert await connection._run_pairing_protocol() is None  # noqa: SLF001
+    assert ws.sent == []  # no pair-pending
+    assert not client.pairing_window_open  # spent by the attempt
+
+
+async def test_open_pairing_window_is_noop_while_open() -> None:
+    """Re-opening an open window does not extend its deadline."""
+    client = make_sdk_client(client_name="C", roles=[Roles.CONTROLLER])
+    client.open_pairing_window()
+    deadline = client._pairing_window_deadline  # noqa: SLF001
+    client.open_pairing_window()
+    assert client._pairing_window_deadline == deadline  # noqa: SLF001
+
+
+async def test_pairing_window_expires(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An unconsumed window closes silently after its lifetime."""
+    monkeypatch.setattr("aiosendspin.client.client._PAIRING_WINDOW_LIFETIME_S", 0.01)
+    client = make_sdk_client(client_name="C", roles=[Roles.CONTROLLER])
+    client.open_pairing_window()
+    assert client.pairing_window_open
+    await asyncio.sleep(0.02)
+    assert not client.pairing_window_open
+
+
+async def test_await_pairing_window_prompts_for_gesture() -> None:
+    """The wait shows the gesture prompt on entry and clears it once a window opens."""
+    prompts: list[bool] = []
+
+    async def prompt(active: bool) -> None:  # noqa: FBT001
+        prompts.append(active)
+
+    client = make_sdk_client(
+        client_name="C",
+        roles=[Roles.CONTROLLER],
+        pairing_support=PairingSupport(gesture_prompt=prompt),
+    )
+    waiter = asyncio.ensure_future(client.await_pairing_window())
+    await asyncio.sleep(0)
+    assert not waiter.done()
+    assert prompts == [True]
+    client.open_pairing_window()
+    await asyncio.wait_for(waiter, timeout=1)
+    assert client.pairing_window_open
+    assert prompts == [True, False]
+
+
+async def test_await_pairing_window_clears_prompt_on_cancel() -> None:
+    """A cancelled wait (the server ended the attempt) still clears the prompt."""
+    prompts: list[bool] = []
+
+    async def prompt(active: bool) -> None:  # noqa: FBT001
+        prompts.append(active)
+
+    client = make_sdk_client(
+        client_name="C",
+        roles=[Roles.CONTROLLER],
+        pairing_support=PairingSupport(gesture_prompt=prompt),
+    )
+    waiter = asyncio.ensure_future(client.await_pairing_window())
+    await asyncio.sleep(0)
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+    assert prompts == [True, False]
+
+
+async def test_overlapping_window_waits_share_the_prompt() -> None:
+    """Overlapping waits prompt once; the prompt clears only when the last wait ends."""
+    prompts: list[bool] = []
+
+    async def prompt(active: bool) -> None:  # noqa: FBT001
+        prompts.append(active)
+
+    client = make_sdk_client(
+        client_name="C",
+        roles=[Roles.CONTROLLER],
+        pairing_support=PairingSupport(gesture_prompt=prompt),
+    )
+    first = asyncio.ensure_future(client.await_pairing_window())
+    second = asyncio.ensure_future(client.await_pairing_window())
+    await asyncio.sleep(0)
+    assert prompts == [True]
+    first.cancel()  # a displaced connection's wait unwinding
+    with pytest.raises(asyncio.CancelledError):
+        await first
+    assert prompts == [True]
+    client.open_pairing_window()
+    await asyncio.wait_for(second, timeout=1)
+    assert prompts == [True, False]
+
+
+async def test_await_pairing_window_resolves_on_explicit_open() -> None:
+    """open_pairing_window (gesture handler or management) satisfies the wait directly."""
+    client = make_sdk_client(client_name="C", roles=[Roles.CONTROLLER])
+    waiter = asyncio.ensure_future(client.await_pairing_window())
+    await asyncio.sleep(0)
+    assert not waiter.done()
+    client.open_pairing_window()
+    await asyncio.wait_for(waiter, timeout=1)
+    assert client.pairing_window_open
 
 
 async def _cancel_time_task(connection: SendspinConnection) -> None:
@@ -179,7 +427,7 @@ async def test_leave_activate_redeclaring_pairing_runs_next_attempt() -> None:
             ServerActivatePayload(
                 activities=[Activity.PAIRING],
                 active_roles=[],
-                selected_pair_method=PairMethod.DYNAMIC_PIN,
+                pairing=ActivatePairing(method=PairMethod.DYNAMIC_PIN, pin_length=6),
             ),
             ServerActivatePayload(activities=[], active_roles=[]),
         ]


### PR DESCRIPTION
Improve PIN pairing window.

Implements https://github.com/Sendspin/spec/pull/130.

## Breaking changes

This PR implements breaking changes made to protocol. However, those only touch encryption/pairing related parts of the Spec. Legacy clients will still keep working as before.

Client SDK: `pin_display` and `pairing_window` on `SendspinClient` become a single `pairing_support=PairingSupport(...)`, and the SDK now owns the window lifetime, opened via `open_pairing_window()` instead of a caller-supplied awaitable. `ClientPairingStore`'s failure-counter methods drop their `method` argument and `is_pin_locked_out()` becomes `is_pin_escalated()`. The persisted `pin_failures` mapping becomes an integer, migrated on load.

Server SDK: pairing timeouts now raise `PairingTimeoutError` rather than a bare `TimeoutError`.