### PR TITLE
Align the client SDK with the latest pairing spec

### DIFF
--- a/aiosendspin/client/__init__.py
+++ b/aiosendspin/client/__init__.py
@@ -11,11 +11,20 @@ from .client import (
     VisualizerCallback,
 )
 from .listener import ClientListener
-from .models import AudioFormat, PairingSupport, PCMFormat, ServerInfo
+from .models import (
+    SECRET_LOCATIONS,
+    AudioFormat,
+    PairingSupport,
+    PCMFormat,
+    PinDisplay,
+    PinSpeaker,
+    ServerInfo,
+)
 from .source import SourceCapture
 from .time_sync import SendspinTimeFilter
 
 __all__ = [
+    "SECRET_LOCATIONS",
     "AudioChunkCallback",
     "AudioFormat",
     "ClientListener",
@@ -24,6 +33,8 @@ __all__ = [
     "MetadataCallback",
     "PCMFormat",
     "PairingSupport",
+    "PinDisplay",
+    "PinSpeaker",
     "SendspinClient",
     "SendspinTimeFilter",
     "ServerInfo",

--- a/aiosendspin/client/client.py
+++ b/aiosendspin/client/client.py
@@ -368,8 +368,8 @@ class SendspinClient:
         return deadline is not None and self._loop.time() < deadline
 
     async def await_pairing_window(self) -> None:
-        """Resolve once a pairing window is open, prompting for a gesture meanwhile."""
-        if self.pairing_window_open:
+        """Claim a pairing window for the caller's attempt, prompting for a gesture meanwhile."""
+        if self._claim_pairing_window():
             return
         support = self._pairing_support
         prompt = support.gesture_prompt if support is not None else None
@@ -377,13 +377,20 @@ class SendspinClient:
         try:
             if self._pairing_window_waiters == 1 and prompt is not None:
                 await prompt(True)  # noqa: FBT003
-            while not self.pairing_window_open:
+            while not self._claim_pairing_window():
                 self._pairing_window_opened.clear()
                 await self._pairing_window_opened.wait()
         finally:
             self._pairing_window_waiters -= 1
             if self._pairing_window_waiters == 0 and prompt is not None:
                 await prompt(False)  # noqa: FBT003
+
+    def _claim_pairing_window(self) -> bool:
+        """Close an open pairing window for one attempt, reporting whether one was open."""
+        if not self.pairing_window_open:
+            return False
+        self.consume_pairing_window()
+        return True
 
     def consume_pairing_window(self) -> None:
         """Close the pairing window as a pairing attempt starts."""

--- a/aiosendspin/client/client.py
+++ b/aiosendspin/client/client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Callable, Sequence
 from contextlib import suppress
 
 from aiohttp import ClientSession, web
@@ -37,7 +37,7 @@ from aiosendspin.noise.session import NoiseCipherSuite
 from aiosendspin.noise.trust_store import ClientPairingStore, ResolvedPsk
 
 from .connection import DECODABLE_CODECS, UNSYNCED_PLAY_LEAD_US, SendspinConnection
-from .models import AudioFormat, PairingSupport, ServerInfo
+from .models import AudioFormat, PairingSupport, PinDisplay, PinSpeaker, ServerInfo
 from .source import SourceCapture
 
 logger = logging.getLogger(__name__)
@@ -353,13 +353,33 @@ class SendspinClient:
         return self._pairing_store
 
     @property
-    def pin_display(self) -> Callable[[str | None], Awaitable[None]] | None:
+    def pin_display(self) -> PinDisplay | None:
         """Out-channel that surfaces a derived pairing PIN, if configured.
 
         Called with the PIN string when one is derived, and with ``None`` when the
         pairing exchange ends (success or failure) so the channel can clear.
         """
         return self._pairing_support.pin_display if self._pairing_support is not None else None
+
+    @property
+    def pin_speaker(self) -> PinSpeaker | None:
+        """Spoken out-channel for a derived pairing PIN, if configured."""
+        return self._pairing_support.pin_speaker if self._pairing_support is not None else None
+
+    @property
+    def pin_out_channels(self) -> tuple[str, ...]:
+        """Channels the dynamic PIN is conveyed through, in descriptor order."""
+        channels = []
+        if self.pin_display is not None:
+            channels.append("display")
+        if self.pin_speaker is not None:
+            channels.append("speaker")
+        return tuple(channels)
+
+    @property
+    def secret_locations(self) -> tuple[str, ...]:
+        """Where the operator finds a configured static secret, empty when undeclared."""
+        return self._pairing_support.secret_locations if self._pairing_support is not None else ()
 
     @property
     def pairing_window_open(self) -> bool:
@@ -413,8 +433,9 @@ class SendspinClient:
         """Pairing methods this client implements: each PIN method needs its wiring."""
         methods = {PairMethod.PAIRING_PSK}
         if self._pairing_support is not None:
-            methods.add(PairMethod.STATIC_PIN)
-            if self._pairing_support.pin_display is not None:
+            if self._pairing_support.offer_static_pin:
+                methods.add(PairMethod.STATIC_PIN)
+            if self.pin_out_channels:
                 methods.add(PairMethod.DYNAMIC_PIN)
         return frozenset(methods)
 

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -568,7 +568,6 @@ class SendspinConnection:
             # Every static-PIN attempt is gesture-gated.
             if (leave := await self._gate_on_pairing_window(pairing_index)) is not None:
                 return leave
-            self._client.consume_pairing_window()
             with self._attempt_in_progress():
                 return await run_static_pin_client(
                     self._ws,
@@ -618,6 +617,8 @@ class SendspinConnection:
         """
         assert self._ws is not None
         if self._client.pairing_window_open:
+            # Claims the window without signalling pair-pending, since none is awaited.
+            await self._client.await_pairing_window()
             return None
         await self._ws.send_str(
             ClientPairPendingMessage(

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -596,8 +596,7 @@ class SendspinConnection:
                     store=store,
                 )
         finally:
-            if self._client.pin_display is not None:
-                await self._client.pin_display(None)
+            await self._emit_pin(None)
 
     @contextmanager
     def _attempt_in_progress(self) -> Iterator[None]:
@@ -703,23 +702,36 @@ class SendspinConnection:
 
     async def _validate_pin_length(self, pin_length: int | None) -> int:
         """Validate the activation's dynamic ``pin_length``, aborting when unacceptable."""
-        config = await self._client.pairing_store.get_pairing_config()
-        min_length = max(config.dynamic_pin_min_length, MIN_PIN_DIGITS)
+        min_length = await self._min_pin_length()
         if pin_length is None or not min_length <= pin_length <= MAX_PIN_DIGITS:
             await self._abort_pairing(PairAbortReason.PIN_LENGTH_UNACCEPTABLE)
         return pin_length
+
+    async def _min_pin_length(self) -> int:
+        """Shortest dynamic PIN this client accepts, held to the spec's advertisable range."""
+        config = await self._client.pairing_store.get_pairing_config()
+        return min(max(config.dynamic_pin_min_length, MIN_PIN_DIGITS), MAX_PIN_DIGITS)
 
     async def _abort_pairing(self, reason: PairAbortReason) -> NoReturn:
         """Send ``pair/abort``; never returns (the abort raises)."""
         assert self._ws is not None
         await abort_pairing(self._ws, reason)
 
-    async def _emit_pin(self, pin: str) -> None:
-        """Surface the derived pairing PIN through the configured out-channel."""
+    async def _emit_pin(self, pin: str | None) -> None:
+        """Hand ``pin`` to every configured out-channel, or release them when it is ``None``."""
+        emissions = []
         if self._client.pin_display is not None:
-            await self._client.pin_display(pin)
-        else:
-            logger.warning("Pairing PIN (no display configured): %s", pin)
+            emissions.append(self._client.pin_display(pin))
+        if self._client.pin_speaker is not None:
+            emissions.append(self._client.pin_speaker(pin, languages=self._activation_languages()))
+        await asyncio.gather(*emissions)
+
+    def _activation_languages(self) -> tuple[str, ...]:
+        """Operator language preferences carried by the pairing activation."""
+        pairing = self._selected_pairing
+        if pairing is None or pairing.languages is None:
+            return ()
+        return tuple(pairing.languages)
 
     async def _rehandshake(self, hs1_text: str | None = None) -> None:
         """Re-run the Noise handshake as responder and swap the session (None reads msg 1)."""
@@ -982,12 +994,15 @@ class SendspinConnection:
     async def _pair_method_descriptor(self, method: PairMethod) -> PairMethodDescriptor:
         """Build the ``client/hello`` descriptor for ``method``."""
         if method is not PairMethod.DYNAMIC_PIN:
-            return PairMethodDescriptor(method=method)
-        config = await self._client.pairing_store.get_pairing_config()
+            locations = self._client.secret_locations
+            return PairMethodDescriptor(
+                method=method, locations=list(locations) if locations else None
+            )
+        out_channels = self._client.pin_out_channels
         return PairMethodDescriptor(
             method=method,
-            out_channels=["display"],
-            min_pin_length=config.dynamic_pin_min_length,
+            out_channels=list(out_channels) if out_channels else None,
+            min_pin_length=await self._min_pin_length(),
         )
 
     def _compute_trust(self) -> TrustLevel:

--- a/aiosendspin/client/models.py
+++ b/aiosendspin/client/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from aiosendspin.models.types import AudioCodec
 
@@ -11,21 +11,57 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
 
+# Places a static pairing secret may be found, per the spec's pair-method descriptor.
+SECRET_LOCATIONS: frozenset[str] = frozenset({"device", "leaflet", "operator"})
+
+# Visual out-channel for a derived dynamic PIN, cleared by a ``None`` call.
+type PinDisplay = Callable[[str | None], Awaitable[None]]
+
+
+class PinSpeaker(Protocol):
+    """Speaks a derived dynamic PIN through the device's audio out-channel."""
+
+    def __call__(self, pin: str | None, *, languages: tuple[str, ...]) -> Awaitable[None]:
+        """Speak ``pin``, or stop speaking when it is ``None``.
+
+        Return once emission has started rather than awaiting its completion, since the
+        pairing exchange is blocked meanwhile. ``languages`` holds the operator's BCP 47
+        preferences in descending order, and is empty when the server declared none.
+        """
+
+
 @dataclass(frozen=True, slots=True)
 class PairingSupport:
     """Operator wiring for PIN pairing: an operator can perform the pairing gesture here.
 
     The gesture itself is reported by calling ``SendspinClient.open_pairing_window``.
-    Its presence enables offering ``static_pin``; ``pin_display`` additionally
-    enables ``dynamic_pin``.
+    Its presence enables offering ``static_pin``, unless ``offer_static_pin`` declines
+    it. Either PIN out-channel additionally enables ``dynamic_pin``.
     """
 
     gesture_prompt: Callable[[bool], Awaitable[None]] | None = None
     """Optional operator prompt: awaited with ``True`` when a gated attempt starts
     waiting for a pairing window, and with ``False`` when the wait ends."""
-    pin_display: Callable[[str | None], Awaitable[None]] | None = None
-    """Out-channel that surfaces a derived dynamic PIN; called with ``None`` when the
+    pin_display: PinDisplay | None = None
+    """Visual out-channel that surfaces a derived dynamic PIN; called with ``None`` when the
     pairing exchange ends (success or failure) so the channel can clear."""
+    pin_speaker: PinSpeaker | None = None
+    """Spoken out-channel for the derived dynamic PIN, which also receives the operator's
+    language preferences."""
+    offer_static_pin: bool = True
+    """Whether to offer ``static_pin`` at all, for a device with no per-device PIN to hand out."""
+    secret_locations: tuple[str, ...] = ()
+    """Where the operator finds a configured static secret, from ``SECRET_LOCATIONS``.
+
+    Applies to every static-secret method the client offers.
+    """
+
+    def __post_init__(self) -> None:
+        """Reject a secret location the descriptor cannot carry."""
+        unknown = sorted(set(self.secret_locations) - SECRET_LOCATIONS)
+        if unknown:
+            names = ", ".join(unknown)
+            raise ValueError(f"unknown secret_locations: {names}")
 
 
 @dataclass(slots=True)

--- a/tests/noise/test_trust_store.py
+++ b/tests/noise/test_trust_store.py
@@ -310,6 +310,21 @@ async def test_file_client_store_persists_state(tmp_path: Path) -> None:
     assert await reloaded.pin_failure_count() == 1
 
 
+async def test_file_client_store_migrates_per_method_pin_failures(tmp_path: Path) -> None:
+    """A pre-escalation store carries its dynamic-PIN count over, keeping escalation state."""
+    path = tmp_path / "client.json"
+    await FileClientPairingStore.open(path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data["pin_failures"] = {
+        PairMethod.DYNAMIC_PIN.value: PIN_ESCALATION_THRESHOLD,
+        PairMethod.STATIC_PIN.value: 3,
+    }
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+    reloaded = await FileClientPairingStore.open(path)
+    assert await reloaded.pin_failure_count() == PIN_ESCALATION_THRESHOLD
+
+
 async def test_file_client_store_persists_last_playback_server(tmp_path: Path) -> None:
     """The last-playback server id survives a reload."""
     path = tmp_path / "client.json"

--- a/tests/test_client_pairing.py
+++ b/tests/test_client_pairing.py
@@ -293,6 +293,28 @@ async def test_gated_attempt_consumes_open_window(monkeypatch: pytest.MonkeyPatc
     assert not client.pairing_window_open  # consumed by the attempt
 
 
+async def test_static_pin_attempt_consumes_a_pre_open_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A static-PIN attempt that finds a window already open spends it rather than leaving it."""
+    connection, ws = _dynamic_pin_connection()
+    client = connection._client  # noqa: SLF001
+    await client.pairing_store.set_static_pin("12345678")
+    config = await client.pairing_store.get_pairing_config()
+    await client.pairing_store.store_pairing_config(replace(config, static_pin_enabled=True))
+    client.open_pairing_window()
+    connection._selected_pairing = ActivatePairing(method=PairMethod.STATIC_PIN)  # noqa: SLF001
+
+    async def fake_run(_ws: object, **kwargs: object) -> None:
+        pass
+
+    monkeypatch.setattr("aiosendspin.client.connection.run_static_pin_client", fake_run)
+
+    assert await connection._run_pairing_protocol() is None  # noqa: SLF001
+    assert ws.sent == []  # no pair-pending
+    assert not client.pairing_window_open
+
+
 async def test_ungated_attempt_consumes_open_window(monkeypatch: pytest.MonkeyPatch) -> None:
     """An ungated attempt still spends an open window: its lifetime ends at pair-init."""
     connection, ws = _dynamic_pin_connection()
@@ -349,7 +371,6 @@ async def test_await_pairing_window_prompts_for_gesture() -> None:
     assert prompts == [True]
     client.open_pairing_window()
     await asyncio.wait_for(waiter, timeout=1)
-    assert client.pairing_window_open
     assert prompts == [True, False]
 
 
@@ -371,6 +392,21 @@ async def test_await_pairing_window_clears_prompt_on_cancel() -> None:
     with pytest.raises(asyncio.CancelledError):
         await waiter
     assert prompts == [True, False]
+
+
+async def test_one_window_admits_a_single_attempt() -> None:
+    """One window releases one waiter, the rest wait for a fresh gesture."""
+    client = make_sdk_client(client_name="C", roles=[Roles.CONTROLLER])
+    first = asyncio.ensure_future(client.await_pairing_window())
+    second = asyncio.ensure_future(client.await_pairing_window())
+    await asyncio.sleep(0)
+    client.open_pairing_window()
+    await asyncio.wait_for(first, timeout=1)
+    await asyncio.sleep(0)
+    assert not second.done()
+    assert not client.pairing_window_open
+    client.open_pairing_window()
+    await asyncio.wait_for(second, timeout=1)
 
 
 async def test_overlapping_window_waits_share_the_prompt() -> None:
@@ -406,7 +442,7 @@ async def test_await_pairing_window_resolves_on_explicit_open() -> None:
     assert not waiter.done()
     client.open_pairing_window()
     await asyncio.wait_for(waiter, timeout=1)
-    assert client.pairing_window_open
+    assert not client.pairing_window_open
 
 
 async def _cancel_time_task(connection: SendspinConnection) -> None:

--- a/tests/test_client_pairing.py
+++ b/tests/test_client_pairing.py
@@ -394,6 +394,88 @@ async def test_await_pairing_window_clears_prompt_on_cancel() -> None:
     assert prompts == [True, False]
 
 
+async def test_declining_static_pin_drops_it_from_implemented_methods() -> None:
+    """A device with no per-device PIN opts out of static PIN, which is otherwise offered."""
+    wired = make_sdk_client(
+        client_name="C", roles=[Roles.CONTROLLER], pairing_support=PairingSupport()
+    )
+    declined = make_sdk_client(
+        client_name="C",
+        roles=[Roles.CONTROLLER],
+        pairing_support=PairingSupport(offer_static_pin=False),
+    )
+    assert PairMethod.STATIC_PIN in wired.implemented_pair_methods
+    assert PairMethod.STATIC_PIN not in declined.implemented_pair_methods
+
+
+async def test_hello_descriptors_carry_the_wired_channels_and_locations() -> None:
+    """Out-channels follow the wired callbacks, and locations ride the static-secret methods."""
+
+    async def display(pin: str | None) -> None:
+        pass
+
+    async def speak(pin: str | None, *, languages: tuple[str, ...]) -> None:
+        pass
+
+    client = make_sdk_client(
+        client_name="C",
+        roles=[Roles.CONTROLLER],
+        pairing_support=PairingSupport(
+            pin_display=display,
+            pin_speaker=speak,
+            secret_locations=("device", "leaflet"),
+        ),
+    )
+    connection = SendspinConnection(client)
+    connection._noise_psk = ResolvedPsk("psk-id", b"\x00" * 32, PskCategory.SENTINEL)  # noqa: SLF001
+    hello = await connection._build_client_hello()  # noqa: SLF001
+    descriptors = {d.method: d for d in hello.payload.supported_pair_methods or []}
+    assert descriptors[PairMethod.DYNAMIC_PIN].out_channels == ["display", "speaker"]
+    assert descriptors[PairMethod.DYNAMIC_PIN].locations is None
+    assert descriptors[PairMethod.PAIRING_PSK].locations == ["device", "leaflet"]
+    assert descriptors[PairMethod.PAIRING_PSK].out_channels is None
+
+
+async def test_pin_speaker_receives_the_activation_languages() -> None:
+    """The activation's language preferences reach the spoken channel, which the display omits."""
+    spoken: list[tuple[str | None, tuple[str, ...]]] = []
+    displayed: list[str | None] = []
+
+    async def display(pin: str | None) -> None:
+        displayed.append(pin)
+
+    async def speak(pin: str | None, *, languages: tuple[str, ...]) -> None:
+        spoken.append((pin, languages))
+
+    client = make_sdk_client(
+        client_name="C",
+        roles=[Roles.CONTROLLER],
+        pairing_support=PairingSupport(pin_display=display, pin_speaker=speak),
+    )
+    connection = SendspinConnection(client)
+    connection._selected_pairing = ActivatePairing(  # noqa: SLF001
+        method=PairMethod.DYNAMIC_PIN, pin_length=6, languages=["ca", "en"]
+    )
+    await connection._emit_pin("123456")  # noqa: SLF001
+    assert spoken == [("123456", ("ca", "en"))]
+    assert displayed == ["123456"]
+
+
+async def test_pin_speaker_alone_enables_dynamic_pin() -> None:
+    """A speaker-only device offers dynamic PIN, with no display wired."""
+
+    async def speak(pin: str | None, *, languages: tuple[str, ...]) -> None:
+        pass
+
+    client = make_sdk_client(
+        client_name="C",
+        roles=[Roles.CONTROLLER],
+        pairing_support=PairingSupport(pin_speaker=speak),
+    )
+    assert PairMethod.DYNAMIC_PIN in client.implemented_pair_methods
+    assert client.pin_out_channels == ("speaker",)
+
+
 async def test_one_window_admits_a_single_attempt() -> None:
     """One window releases one waiter, the rest wait for a fresh gesture."""
     client = make_sdk_client(client_name="C", roles=[Roles.CONTROLLER])

--- a/tests/test_client_pairing.py
+++ b/tests/test_client_pairing.py
@@ -29,6 +29,7 @@ from aiosendspin.noise.models import (
     ServerPairAuthPayload,
 )
 from aiosendspin.noise.pairing import PairingError
+from aiosendspin.noise.pin import MAX_PIN_DIGITS
 from aiosendspin.noise.trust_store import PIN_ESCALATION_THRESHOLD, PskCategory, ResolvedPsk
 
 from .conftest import make_sdk_client
@@ -202,6 +203,28 @@ async def test_dynamic_activation_with_unacceptable_pin_length_aborts(
         await connection._run_pairing_protocol()  # noqa: SLF001
     abort = PairAbortMessage.from_json(ws.sent[0])
     assert abort.payload.reason is PairAbortReason.PIN_LENGTH_UNACCEPTABLE
+
+
+async def test_configured_minimum_below_the_spec_floor_still_rejects() -> None:
+    """The spec floor holds even for a store written outside the management API."""
+    connection, ws = _dynamic_pin_connection()
+    await _set_min_pin_length(connection, 2)
+    connection._selected_pairing = ActivatePairing(  # noqa: SLF001
+        method=PairMethod.DYNAMIC_PIN, pin_length=2
+    )
+    with pytest.raises(PairingError):
+        await connection._run_pairing_protocol()  # noqa: SLF001
+    abort = PairAbortMessage.from_json(ws.sent[0])
+    assert abort.payload.reason is PairAbortReason.PIN_LENGTH_UNACCEPTABLE
+
+
+async def test_configured_minimum_above_the_spec_ceiling_is_capped() -> None:
+    """A floor past 12 is advertised capped, since a higher one no server could satisfy."""
+    connection, _ws = _dynamic_pin_connection()
+    await _set_min_pin_length(connection, 20)
+    hello = await connection._build_client_hello()  # noqa: SLF001
+    descriptors = {d.method: d for d in hello.payload.supported_pair_methods or []}
+    assert descriptors[PairMethod.DYNAMIC_PIN].min_pin_length == MAX_PIN_DIGITS
 
 
 async def test_short_pin_attempt_is_gesture_gated() -> None:


### PR DESCRIPTION
A single operator gesture could admit more than one pairing attempt, since every attempt waiting on the pairing window woke when it opened and each closed it separately. The first waiter now claims the window, so it admits exactly one attempt.

This completes the client SDK against the merged spec changes: a client can decline `static_pin`, declare where its static secrets are found, and speak the dynamic PIN through a new `pin_speaker` channel that receives the operator's language preferences. The advertised `min_pin_length` is now held to the spec's 4 to 12 range.
