### PR TITLE
Keep the event loop responsive while a joining client catches up

### DIFF
--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -45,6 +45,10 @@ _LOGGER = logging.getLogger(__name__)
 DEFAULT_INITIAL_DELAY_US = 250_000  # 250ms
 # Pre-roll amount for catch-up encoding to absorb codec startup delay.
 ENCODER_CATCHUP_WARMUP_US = 120_000
+# Source audio encoded between yields while replaying the PCM cache. The cache holds
+# everything the producer has buffered ahead (tens of seconds), so encoding it in one
+# step would stall the loop and starve the live commit that keeps the timeline moving.
+_PCM_SEQUENCE_YIELD_INTERVAL_US = 500_000
 # Dithering policy when reducing to 16-bit integer PCM.
 _DITHER_METHOD_TRIANGULAR_HP = "triangular_hp"
 # Maximum allowed drift between transformer's internal timeline and the expected output
@@ -2143,7 +2147,7 @@ class PushStream:
         )
         self._channel_timing_residue[channel_id] = 0
 
-    def _encode_pcm_sequence(
+    async def _encode_pcm_sequence(
         self,
         pcm_chunks: list[CachedPCMChunk],
         encoder: AudioTransformer | None,
@@ -2155,6 +2159,9 @@ class PushStream:
     ) -> list[CachedChunk]:
         """Resample PCM chunks to the target format and encode them sequentially.
 
+        Yields periodically so a deep cache does not stall the loop. Output timestamps
+        come from the cached chunks, so they are unaffected by when the work runs.
+
         Pass `resamplers`/`quantizers` to share state across calls (single resampler
         instance per key reused between batches).
         """
@@ -2165,8 +2172,14 @@ class PushStream:
         if quantizers is None:
             quantizers = {}
         prev_resampler_key: _ResamplerKey | None = None
+        since_yield_us = 0
 
         for chunk in pcm_chunks:
+            since_yield_us += chunk.duration_us
+            if since_yield_us >= _PCM_SEQUENCE_YIELD_INTERVAL_US:
+                since_yield_us = 0
+                await asyncio.sleep(0)
+
             source_format = AudioFormat(
                 sample_rate=chunk.sample_rate,
                 bit_depth=chunk.bit_depth,
@@ -2273,7 +2286,7 @@ class PushStream:
         resamplers: dict[_ResamplerKey, _ResamplerState] | None = None,
         quantizers: dict[_ResamplerKey, _ResamplerState] | None = None,
     ) -> list[CachedChunk]:
-        return self._encode_pcm_sequence(
+        return await self._encode_pcm_sequence(
             pcm_chunks,
             encoder,
             req,

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -981,6 +981,13 @@ async def test_pcm_cache_catchup_for_uncached_codec() -> None:
     assert role2.received
 
 
+async def _drain_catchup_tasks(stream: PushStream) -> None:
+    """Run the loop until every catch-up task has finished."""
+    while pending := [t for t in stream._catchup_tasks.values() if not t.done()]:  # noqa: SLF001
+        await asyncio.wait(pending)
+    await asyncio.sleep(0)
+
+
 @pytest.mark.asyncio
 async def test_non_main_pcm_catchup_does_not_anchor_to_far_channel_tail() -> None:
     """Non-main PCM catch-up should start near now, not at a far-ahead channel tail."""
@@ -1060,10 +1067,7 @@ async def test_non_main_pcm_catchup_does_not_anchor_to_far_channel_tail() -> Non
     group.clients.append(_DummyClient([role2]))
 
     stream.on_role_join(role2)
-    for _ in range(50):
-        if role2.received:
-            break
-        await asyncio.sleep(0)
+    await _drain_catchup_tasks(stream)
 
     assert role2.started == 1
     assert role2.received
@@ -1177,10 +1181,7 @@ async def test_catchup_handoff_commit_race_does_not_overlap() -> None:
         AudioFormat(sample_rate=48000, bit_depth=24, channels=2),
     )
     await stream.commit_audio()
-    for _ in range(50):
-        if role2.received:
-            break
-        await asyncio.sleep(0)
+    await _drain_catchup_tasks(stream)
 
     received = sorted(role2.received, key=lambda c: c.timestamp_us)
     assert received
@@ -1192,6 +1193,7 @@ async def test_catchup_handoff_commit_race_does_not_overlap() -> None:
 async def test_catchup_handoff_delivers_contiguous_audio() -> None:
     """Audio across the catch-up hand-off has no gaps through later commits."""
     stream, role2, tail_us = await _setup_deep_buffer_catchup_join()
+    await _drain_catchup_tasks(stream)
 
     for _ in range(3):
         stream.prepare_audio(
@@ -1295,10 +1297,7 @@ async def test_late_joiner_shares_group_timeline() -> None:
     commit_one()
     await stream.commit_audio()
 
-    for _ in range(50):
-        if role2.received:
-            break
-        await asyncio.sleep(0)
+    await _drain_catchup_tasks(stream)
 
     assert role2.started >= 1
     assert role2.received, "joiner was stranded with no audio"
@@ -1410,10 +1409,7 @@ async def test_main_join_with_established_resampler_backfills_near_now() -> None
     group.clients.append(_DummyClient([role2]))
 
     stream.on_role_join(role2)
-    for _ in range(50):
-        if role2.received:
-            break
-        await asyncio.sleep(0)
+    await _drain_catchup_tasks(stream)
 
     assert role2.started == 1
     assert role2.received
@@ -3090,7 +3086,8 @@ def test_24bit_input_expands_to_s32_before_graph(monkeypatch: pytest.MonkeyPatch
     assert captured_input == _expand_packed_s24_to_s32(packed_pcm)
 
 
-def test_encode_pcm_sequence_preserves_packed_s24_for_pcm_passthrough() -> None:
+@pytest.mark.asyncio
+async def test_encode_pcm_sequence_preserves_packed_s24_for_pcm_passthrough() -> None:
     """Raw PCM output should convert internal s32 back to packed s24 on the wire."""
     group = _DummyGroup(clients=[])
     stream = PushStream(loop=MagicMock(), clock=ManualClock(), group=group)
@@ -3113,13 +3110,16 @@ def test_encode_pcm_sequence_preserves_packed_s24_for_pcm_passthrough() -> None:
         channels=2,
     )
 
-    encoded = stream._encode_pcm_sequence([pcm_chunk], encoder, req, MAIN_CHANNEL)  # noqa: SLF001
+    encoded = await stream._encode_pcm_sequence(  # noqa: SLF001
+        [pcm_chunk], encoder, req, MAIN_CHANNEL
+    )
 
     assert len(encoded) == 1
     assert encoded[0].payload == packed_pcm
 
 
-def test_encode_pcm_sequence_expands_s24_before_flac_encoder(
+@pytest.mark.asyncio
+async def test_encode_pcm_sequence_expands_s24_before_flac_encoder(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """FLAC encoding should receive AV-format s32 bytes for 24-bit PCM."""
@@ -3162,11 +3162,63 @@ def test_encode_pcm_sequence_expands_s24_before_flac_encoder(
         channels=2,
     )
 
-    encoded = stream._encode_pcm_sequence([pcm_chunk], encoder, req, MAIN_CHANNEL)  # noqa: SLF001
+    encoded = await stream._encode_pcm_sequence(  # noqa: SLF001
+        [pcm_chunk], encoder, req, MAIN_CHANNEL
+    )
 
     assert len(encoded) == 1
     assert encoded[0].payload == b"flac"
     assert captured_chunk == _expand_packed_s24_to_s32(packed_pcm)
+
+
+def test_encode_pcm_sequence_yields_while_replaying_deep_cache(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deep PCM cache is encoded across several loop steps, without changing output."""
+
+    def _encode() -> tuple[int, list[CachedChunk]]:
+        stream = PushStream(loop=MagicMock(), clock=ManualClock(), group=_DummyGroup(clients=[]))
+        encoder = PcmPassthrough(sample_rate=48_000, bit_depth=16, channels=2)
+        req = AudioRequirements(
+            sample_rate=48_000,
+            bit_depth=16,
+            channels=2,
+            transformer=encoder,
+            channel_id=MAIN_CHANNEL,
+            frame_duration_us=25_000,
+        )
+        # 3 seconds of cached PCM in 100ms chunks, as the producer buffers it.
+        chunks = [
+            CachedPCMChunk(
+                timestamp_us=1_000_000 + index * 100_000,
+                duration_us=100_000,
+                pcm_data=bytes(19_200),
+                sample_rate=48_000,
+                bit_depth=16,
+                channels=2,
+            )
+            for index in range(30)
+        ]
+        # Drive the coroutine by hand so every suspension point is counted.
+        coro = stream._encode_pcm_sequence(chunks, encoder, req, MAIN_CHANNEL)  # noqa: SLF001
+        yields = 0
+        while True:
+            try:
+                coro.send(None)
+            except StopIteration as stop:
+                return yields, stop.value
+            yields += 1
+
+    yields, encoded = _encode()
+    monkeypatch.setattr(push_stream_module, "_PCM_SEQUENCE_YIELD_INTERVAL_US", 10**12)
+    single_step_yields, single_step_encoded = _encode()
+
+    assert single_step_yields == 0
+    assert yields >= 5
+    assert encoded
+    assert [(c.timestamp_us, c.duration_us, c.payload) for c in encoded] == [
+        (c.timestamp_us, c.duration_us, c.payload) for c in single_step_encoded
+    ]
 
 
 def test_soxr_fallback_caches_failure_per_format(

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -982,9 +982,14 @@ async def test_pcm_cache_catchup_for_uncached_codec() -> None:
 
 
 async def _drain_catchup_tasks(stream: PushStream) -> None:
-    """Run the loop until every catch-up task has finished."""
+    """Run the loop until every catch-up task has finished, re-raising any failure."""
     while pending := [t for t in stream._catchup_tasks.values() if not t.done()]:  # noqa: SLF001
-        await asyncio.wait(pending)
+        done, _ = await asyncio.wait(pending)
+        for task in done:
+            if not task.cancelled():
+                # surface a crashed catch-up here instead of leaving the caller to fail
+                # on a missing-audio assertion that says nothing about the real cause
+                task.result()
     await asyncio.sleep(0)
 
 

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -3192,13 +3192,15 @@ def test_encode_pcm_sequence_yields_while_replaying_deep_cache(
             channel_id=MAIN_CHANNEL,
             frame_duration_us=25_000,
         )
-        # 3 seconds of cached PCM in 100ms chunks, as the producer buffers it.
+        # 3 seconds of cached PCM in 100ms chunks, as the producer buffers it. The source
+        # rate differs from the target so a resampler carries FIR state across the yields,
+        # and the audio is a ramp rather than silence so any lost state changes the bytes.
         chunks = [
             CachedPCMChunk(
                 timestamp_us=1_000_000 + index * 100_000,
                 duration_us=100_000,
-                pcm_data=bytes(19_200),
-                sample_rate=48_000,
+                pcm_data=bytes((index * 4410 + frame) % 251 for frame in range(4410 * 2 * 2)),
+                sample_rate=44_100,
                 bit_depth=16,
                 channels=2,
             )


### PR DESCRIPTION
## Problem

When a client joins an already-playing stream, the buffered PCM cache is re-encoded for it. That
replay ran as a single un-yielded step, so nothing else on the event loop could run until it
finished — including the live commit that keeps the play timeline moving.

The cache holds everything the producer has buffered ahead, which is tens of seconds in practice.
Measured on an M4 Pro with a 30s buffer:

| case | loop blocked (before) | after |
|---|---|---|
| 1 Opus joiner | 199 ms | 10 ms |
| 1 FLAC joiner, needs resample | 32 ms | 2 ms |
| 2 Opus joiners flushed together | 377 ms | 19 ms |

It scales linearly with buffer depth and multiplies by the number of clients joining at once, so a
deep buffer with a couple of joiners is enough to stall audio production outright.

## Changes

- `_encode_pcm_sequence` yields once per 500ms of source audio consumed.
- `_encode_catchup_sequence` awaits it; it was already async and already awaited at every call site,
  so no caller changed.

Total encode time is unchanged (198.2 ms → 198.3 ms for the 30s Opus case) — the same work is just
spread across loop iterations. Output is byte-for-byte identical; timestamps come from the cached
chunks, never from the clock, so nothing shifts.

The yield sits inside the encode loop rather than batching from the caller on purpose: the loop
carries `prev_resampler_key`, which flushes the previous resampler's tail on a format change, and
splitting from outside would reset that across batch boundaries.

## Tests

- New `test_encode_pcm_sequence_yields_while_replaying_deep_cache` — counts suspensions over a 3s
  cache and asserts the output matches a single-step run byte for byte.
- Four existing catch-up tests spun `for _ in range(50): await asyncio.sleep(0)` waiting for the
  replay. Those only ever worked because the encode never yielded, so they now await the actual
  catch-up tasks via a `_drain_catchup_tasks` helper instead of a magic number. Their assertions
  are unchanged and still pass.
- Full suite: 1563 passed. Late-join scheduling fuzz run at 400 seeds: 408 passed.
