### PR TITLE
Add application-defined owner to server pairing records

### DIFF
--- a/aiosendspin/noise/pairing.py
+++ b/aiosendspin/noise/pairing.py
@@ -111,6 +111,8 @@ class PairingAttempt:
     """Called when the client reports the attempt gesture-gated."""
     languages: tuple[str, ...] = ()
     """Dynamic PIN only: BCP 47 tags in descending operator preference for spoken emission."""
+    owner: str | None = None
+    """Application-defined authorization id the resulting record is bound to."""
 
     def __post_init__(self) -> None:
         """Validate ``method`` / material agree."""
@@ -168,11 +170,12 @@ async def run_pairing_psk_server(
     *,
     client_id: str,
     store: ServerPairingStore,
+    owner: str | None = None,
 ) -> ServerPairingRecord:
     """Run the server side of the Pairing PSK flow."""
     async with _server_timeout(SERVER_FIRST_MESSAGE_TIMEOUT_S, "client/pair-finalize"):
         record = await _finalize_server(
-            ws, client_id=client_id, store=store, method=PairMethod.PAIRING_PSK
+            ws, client_id=client_id, store=store, method=PairMethod.PAIRING_PSK, owner=owner
         )
     assert record is not None
     return record
@@ -264,6 +267,7 @@ async def run_dynamic_pin_server(
     store: ServerPairingStore,
     verify: bool = False,
     on_pair_pending: Callable[[], None] | None = None,
+    owner: str | None = None,
 ) -> ServerPairingRecord | None:
     """Run the server side of the dynamic-PIN flow.
 
@@ -329,6 +333,7 @@ async def run_dynamic_pin_server(
             method=PairMethod.DYNAMIC_PIN,
             verify=verify,
             wrap_key=_wrap_key(sid, cpace),
+            owner=owner,
         )
 
 
@@ -405,6 +410,7 @@ async def run_static_pin_server(
     store: ServerPairingStore,
     verify: bool = False,
     on_pair_pending: Callable[[], None] | None = None,
+    owner: str | None = None,
 ) -> ServerPairingRecord | None:
     """Run the server side of the static-PIN flow.
 
@@ -459,6 +465,7 @@ async def run_static_pin_server(
             method=PairMethod.STATIC_PIN,
             verify=verify,
             wrap_key=_wrap_key(sid, cpace),
+            owner=owner,
         )
 
 
@@ -496,6 +503,7 @@ async def _finalize_server(
     method: PairMethod,
     verify: bool = False,
     wrap_key: bytes | None = None,
+    owner: str | None = None,
 ) -> ServerPairingRecord | None:
     """Consume ``client/pair-finalize``: finalize a record, or re-verify (returns ``None``)."""
     finalize = await _receive_pairing(ws, ClientPairFinalizeMessage)
@@ -505,10 +513,15 @@ async def _finalize_server(
         psk = _unwrap_psk(ws.session.suite, finalize.payload, wrap_key)
         if record is None:
             record = ServerPairingRecord(
-                psk_id=psk_id_for(psk), psk=psk, client_id=client_id, pair_methods=[method]
+                psk_id=psk_id_for(psk),
+                psk=psk,
+                client_id=client_id,
+                pair_methods=[method],
+                owner=owner,
             )
         else:
-            record = replace(record, psk_id=psk_id_for(psk), psk=psk)
+            # Ownership tracks the latest authorization that minted the credential.
+            record = replace(record, psk_id=psk_id_for(psk), psk=psk, owner=owner)
     if record is not None and record is not existing:
         await store.store_record(record)  # persist before acking
     if verify:

--- a/aiosendspin/noise/trust_store.py
+++ b/aiosendspin/noise/trust_store.py
@@ -95,6 +95,13 @@ class ServerPairingRecord:
     client_id: str
     pair_methods: list[PairMethod]
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    owner: str | None = None
+    """Application-defined id of the authorization this record is bound to.
+
+    Owned records are meant to be removed once the owning authorization (e.g. a user
+    account or session) ends; the server attaches no behavior to this field. ``None``
+    marks a self-standing credential.
+    """
 
     def __post_init__(self) -> None:
         """Validate the PSK size."""
@@ -118,6 +125,7 @@ class ServerPairingRecord:
             "client_id": self.client_id,
             "pair_methods": [m.value for m in self.pair_methods],
             "created_at": self.created_at.isoformat(),
+            "owner": self.owner,
         }
 
     @classmethod
@@ -129,6 +137,7 @@ class ServerPairingRecord:
             client_id=_str(data, "client_id"),
             pair_methods=_pair_methods(data, "pair_methods"),
             created_at=datetime.fromisoformat(_str(data, "created_at")),
+            owner=_opt_str(data, "owner"),
         )
 
 
@@ -348,6 +357,10 @@ class ServerPairingStore(ABC):
     @abstractmethod
     async def remove_trusted_unpaired(self, client_id: str) -> None:
         """Revoke client's unpaired-playback approval (no-op if absent)."""
+
+    async def records_by_owner(self, owner: str) -> Sequence[ServerPairingRecord]:
+        """Return all long-term records bound to ``owner``."""
+        return [record for record in await self.list_records() if record.owner == owner]
 
 
 class ClientPairingStore(ABC):

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -1336,10 +1336,13 @@ class SendspinConnection:
         self._pairing_index += 1
         pairing_index = self._pairing_index
         if method is PairMethod.PAIRING_PSK:
+            # The attempt is absent when the client dialed in with a staged Pairing PSK.
+            attempt = self._pairing_attempt
             return await run_pairing_psk_server(
                 transport,
                 client_id=self._client_id,
                 store=self._server.pairing_store,
+                owner=attempt.owner if attempt is not None else None,
             )
         assert self._pairing_attempt is not None
         assert self._pairing_attempt.pin_provider is not None
@@ -1358,6 +1361,7 @@ class SendspinConnection:
                 store=self._server.pairing_store,
                 verify=verify,
                 on_pair_pending=self._pairing_attempt.on_pair_pending,
+                owner=self._pairing_attempt.owner,
             )
         assert pin_length is not None
         return await run_dynamic_pin_server(
@@ -1370,6 +1374,7 @@ class SendspinConnection:
             store=self._server.pairing_store,
             verify=verify,
             on_pair_pending=self._pairing_attempt.on_pair_pending,
+            owner=self._pairing_attempt.owner,
         )
 
     def _negotiated_dynamic_pin_length(self) -> int:

--- a/tests/noise/test_pairing.py
+++ b/tests/noise/test_pairing.py
@@ -470,6 +470,45 @@ async def test_finalize_rotate_preserves_birth_and_appends_method() -> None:
     assert rotated.pair_methods == [PairMethod.DYNAMIC_PIN, PairMethod.PAIRING_PSK]
 
 
+async def test_finalize_stamps_owner_on_a_fresh_record() -> None:
+    """A pairing run with an owner binds the persisted record to that owner."""
+    client_ews, server_ews, _client_raw, _server_raw = _paired_encrypted_ws()
+    client_store = InMemoryClientPairingStore()
+    server_store = InMemoryServerPairingStore()
+
+    _client_ret, record = await asyncio.gather(
+        run_pairing_psk_client(client_ews, server_id="server-X", store=client_store),
+        run_pairing_psk_server(
+            server_ews, client_id="client-A", store=server_store, owner="user-1"
+        ),
+    )
+
+    assert record.owner == "user-1"
+    assert await server_store.record_by_client_id("client-A") == record
+
+
+async def test_finalize_rotate_restamps_owner() -> None:
+    """Re-pairing re-stamps ownership from the new attempt, superseding the old owner."""
+    client_ews, server_ews, _client_raw, _server_raw = _paired_encrypted_ws()
+    client_store = InMemoryClientPairingStore()
+    server_store = InMemoryServerPairingStore()
+    seeded = ServerPairingRecord(
+        psk_id="old",
+        psk=generate_psk(),
+        client_id="client-A",
+        pair_methods=[PairMethod.PAIRING_PSK],
+        owner="user-1",
+    )
+    await server_store.store_record(seeded)
+
+    _client_ret, rotated = await asyncio.gather(
+        run_pairing_psk_client(client_ews, server_id="server-X", store=client_store),
+        run_pairing_psk_server(server_ews, client_id="client-A", store=server_store),
+    )
+
+    assert rotated.owner is None  # an unowned re-pair promotes the record to durable
+
+
 async def test_client_finalize_raises_if_server_closes_before_ack() -> None:
     """If the server closes before sending server/pair-finalize, the client raises."""
     client_ews, _server_ews, _client_raw, server_raw = _paired_encrypted_ws()

--- a/tests/noise/test_trust_store.py
+++ b/tests/noise/test_trust_store.py
@@ -115,6 +115,39 @@ def test_server_record_pair_methods_round_trip_and_back_compat() -> None:
     assert ServerPairingRecord.from_dict(legacy).pair_methods == []
 
 
+def test_server_record_owner_round_trips_and_back_compat() -> None:
+    """Owner round-trips; a legacy dict without the key loads as ``None``."""
+    record = _server_record()
+    assert record.owner is None
+    owned = ServerPairingRecord(
+        psk_id=record.psk_id,
+        psk=record.psk,
+        client_id=record.client_id,
+        pair_methods=[],
+        owner="user-1",
+    )
+    assert ServerPairingRecord.from_dict(owned.to_dict()) == owned
+    legacy = owned.to_dict()
+    del legacy["owner"]
+    assert ServerPairingRecord.from_dict(legacy).owner is None
+
+
+async def test_server_store_records_by_owner(server_store: ServerPairingStore) -> None:
+    """records_by_owner returns only the records bound to the given owner."""
+    unowned = _server_record(client_id="client-A")
+    psk_b, psk_c = generate_psk(), generate_psk()
+    owned_b = ServerPairingRecord(
+        psk_id=psk_id_for(psk_b), psk=psk_b, client_id="client-B", pair_methods=[], owner="user-1"
+    )
+    owned_c = ServerPairingRecord(
+        psk_id=psk_id_for(psk_c), psk=psk_c, client_id="client-C", pair_methods=[], owner="user-2"
+    )
+    for record in (unowned, owned_b, owned_c):
+        await server_store.store_record(record)
+    assert list(await server_store.records_by_owner("user-1")) == [owned_b]
+    assert list(await server_store.records_by_owner("user-3")) == []
+
+
 def test_client_record_round_trips_and_resolves() -> None:
     """ClientPairingRecord to/from dict round-trips; as_resolved names the server."""
     record = _client_record(server_id="server-X")


### PR DESCRIPTION
An application may pair clients on behalf of its own authorizations (e.g. Music Assistant automatically pairing its Web player for a party guest), and such a pairing must not outlive that authorization. This adds an application-defined `owner` to `ServerPairingRecord`, threaded through the pairing flows via `PairingAttempt`, plus `records_by_owner` for revocation.

`aiosendspin` doesn't use `owner` itself. This is just metadata for servers using this library.