### PR TITLE
Fix `SourceSignalChangedEvent` firing without a change

### DIFF
--- a/aiosendspin/server/roles/source/v1.py
+++ b/aiosendspin/server/roles/source/v1.py
@@ -24,6 +24,7 @@ from .stream import SourceStream
 if TYPE_CHECKING:
     from aiosendspin.models.core import ClientStatePayload
     from aiosendspin.models.source import ClientStreamStartPayload
+    from aiosendspin.models.types import SignalState
     from aiosendspin.server.client import SendspinClient
 
 logger = logging.getLogger(__name__)
@@ -46,6 +47,7 @@ class SourceV1Role(Role):
         self._start_requested = False
         # Stamp decoder output produced during flush.
         self._last_timestamp_us = 0
+        self._signal: SignalState | None = None
 
     @property
     def role_id(self) -> str:
@@ -74,12 +76,14 @@ class SourceV1Role(Role):
         self._end_stream()
         self._initial_state_received = False
         self._start_requested = False
+        self._signal = None
 
     def on_deactivate(self) -> None:
         """End any active stream when the role leaves active_roles."""
         self._end_stream()
         self._initial_state_received = False
         self._start_requested = False
+        self._signal = None
         super().on_deactivate()
 
     def requires_initial_state(self) -> bool:
@@ -216,6 +220,9 @@ class SourceV1Role(Role):
         source = payload.source
         if source is None or source.signal is None or not self._line_sense_supported():
             return
+        if source.signal == self._signal:
+            return
+        self._signal = source.signal
         self._client._signal_event(  # noqa: SLF001
             SourceSignalChangedEvent(signal=source.signal)
         )

--- a/tests/server/roles/source/test_v1.py
+++ b/tests/server/roles/source/test_v1.py
@@ -344,3 +344,33 @@ def test_request_start_and_stop_send_server_command() -> None:
     role.request_stop()
     commands = [m.payload.source.command for m in client.sent]
     assert commands == ["start", "stop"]
+
+
+def test_client_state_signal_event_only_fires_on_change() -> None:
+    """Clients repeat the signal in every state, so only transitions are surfaced."""
+    client = _FakeClient(line_sense=True)
+    role = SourceV1Role(client=client)  # type: ignore[arg-type]
+    role.on_connect()
+
+    for _ in range(3):
+        role.on_client_state(
+            ClientStatePayload(source=SourceStatePayload(signal=SignalState.PRESENT))
+        )
+    role.on_client_state(ClientStatePayload(source=SourceStatePayload(signal=SignalState.ABSENT)))
+    role.on_client_state(ClientStatePayload(source=SourceStatePayload(signal=SignalState.ABSENT)))
+
+    signals = [e.signal for e in client.events if isinstance(e, SourceSignalChangedEvent)]
+    assert signals == [SignalState.PRESENT, SignalState.ABSENT]
+
+
+def test_reconnect_resurfaces_the_current_signal() -> None:
+    """A disconnect forgets the signal, so the client's next report is surfaced again."""
+    client = _FakeClient(line_sense=True)
+    role = SourceV1Role(client=client)  # type: ignore[arg-type]
+    role.on_connect()
+    role.on_client_state(ClientStatePayload(source=SourceStatePayload(signal=SignalState.PRESENT)))
+    role.on_disconnect()
+    role.on_client_state(ClientStatePayload(source=SourceStatePayload(signal=SignalState.PRESENT)))
+
+    signals = [e.signal for e in client.events if isinstance(e, SourceSignalChangedEvent)]
+    assert signals == [SignalState.PRESENT, SignalState.PRESENT]


### PR DESCRIPTION
`SourceSignalChangedEvent` fired on every `client/state` carrying a signal, not only on a change, so consumers had to deduplicate it themselves. The value is cleared on disconnect, so a reconnecting client's first report still fires.
