### PR TITLE
Stop advertising FLAC at 32-bit

### DIFF
--- a/aiosendspin/audio/codecs.py
+++ b/aiosendspin/audio/codecs.py
@@ -139,6 +139,10 @@ class PcmPassthrough:
 class FlacEncoder:
     """FLAC audio encoder transformer."""
 
+    # ffmpeg encodes wider than 24 bits only under `-strict experimental`, and decoders
+    # older than libFLAC 1.4 cannot read 32-bit FLAC.
+    VALID_BIT_DEPTHS = frozenset({16, 24})
+
     def __init__(
         self,
         *,
@@ -149,6 +153,11 @@ class FlacEncoder:
         options: Mapping[str, str] | None = None,
     ) -> None:
         """Initialize FLAC encoder with audio format parameters."""
+        if bit_depth not in self.VALID_BIT_DEPTHS:
+            valid = sorted(self.VALID_BIT_DEPTHS)
+            msg = f"FLAC only supports bit depths {valid}, got {bit_depth}"
+            raise ValueError(msg)
+
         self._sample_rate = sample_rate
         self._bit_depth = bit_depth
         self._channels = channels

--- a/aiosendspin/server/roles/player/capabilities.py
+++ b/aiosendspin/server/roles/player/capabilities.py
@@ -8,14 +8,10 @@ from __future__ import annotations
 
 from aiosendspin.models import AudioCodec
 from aiosendspin.models.player import SupportedAudioFormat
-from aiosendspin.server.roles.player.audio_transformers import OpusEncoder
+from aiosendspin.server.roles.player.audio_transformers import FlacEncoder, OpusEncoder
 
 PCM_BIT_DEPTHS: frozenset[int] = frozenset({16, 24, 32})
-
-# ffmpeg's FLAC encoder takes only s16/s32, and `AudioFormat.resolve_av_format`
-# maps both 24- and 32-bit to s32, so STREAMINFO always declares
-# bits_per_sample = 24. Accepting 32 would announce a depth we never send.
-FLAC_BIT_DEPTHS: frozenset[int] = frozenset({16, 24})
+FLAC_BIT_DEPTHS: frozenset[int] = FlacEncoder.VALID_BIT_DEPTHS
 OPUS_BIT_DEPTHS: frozenset[int] = frozenset({16})
 
 # Supported channel counts — matches the layout map in server/audio.py.

--- a/aiosendspin/server/roles/player/capabilities.py
+++ b/aiosendspin/server/roles/player/capabilities.py
@@ -11,7 +11,11 @@ from aiosendspin.models.player import SupportedAudioFormat
 from aiosendspin.server.roles.player.audio_transformers import OpusEncoder
 
 PCM_BIT_DEPTHS: frozenset[int] = frozenset({16, 24, 32})
-FLAC_BIT_DEPTHS: frozenset[int] = frozenset({16, 24, 32})
+
+# ffmpeg's FLAC encoder takes only s16/s32, and `AudioFormat.resolve_av_format`
+# maps both 24- and 32-bit to s32, so STREAMINFO always declares
+# bits_per_sample = 24. Accepting 32 would announce a depth we never send.
+FLAC_BIT_DEPTHS: frozenset[int] = frozenset({16, 24})
 OPUS_BIT_DEPTHS: frozenset[int] = frozenset({16})
 
 # Supported channel counts — matches the layout map in server/audio.py.
@@ -23,7 +27,7 @@ def can_encode_format(fmt: SupportedAudioFormat) -> bool:
 
     Validates against server encoding constraints:
     - PCM bit depth: 16, 24, or 32; channels: 1-8 or 10 (up to 9.1)
-    - FLAC bit depth: 16, 24, or 32; channels: 1-8 or 10 (up to 9.1)
+    - FLAC bit depth: 16 or 24; channels: 1-8 or 10 (up to 9.1)
     - Opus bit depth: 16 only; channels: 1 or 2 only, as multichannel not yet implemented
     - Opus: sample rate must be one of 8k, 12k, 16k, 24k, 48k
     - FLAC/PCM: any sample rate

--- a/tests/server/roles/player/test_capabilities.py
+++ b/tests/server/roles/player/test_capabilities.py
@@ -2,7 +2,10 @@
 
 from aiosendspin.models.player import SupportedAudioFormat
 from aiosendspin.models.types import AudioCodec
-from aiosendspin.server.roles.player.capabilities import can_encode_format
+from aiosendspin.server.roles.player.capabilities import (
+    can_encode_format,
+    filter_encodable_formats,
+)
 
 
 def test_can_encode_format_accepts_pcm_32_bit() -> None:
@@ -11,10 +14,30 @@ def test_can_encode_format_accepts_pcm_32_bit() -> None:
     assert can_encode_format(fmt)
 
 
-def test_can_encode_format_accepts_flac_32_bit() -> None:
-    """FLAC 32-bit should be considered encodable."""
-    fmt = SupportedAudioFormat(codec=AudioCodec.FLAC, sample_rate=48_000, bit_depth=32, channels=2)
+def test_can_encode_format_accepts_flac_24_bit() -> None:
+    """FLAC 24-bit should be considered encodable."""
+    fmt = SupportedAudioFormat(codec=AudioCodec.FLAC, sample_rate=48_000, bit_depth=24, channels=2)
     assert can_encode_format(fmt)
+
+
+def test_can_encode_format_rejects_flac_32_bit() -> None:
+    """FLAC 32-bit should be rejected — the encoder cannot deliver it."""
+    fmt = SupportedAudioFormat(codec=AudioCodec.FLAC, sample_rate=48_000, bit_depth=32, channels=2)
+    assert not can_encode_format(fmt)
+
+
+def test_filter_encodable_formats_drops_flac_32_bit() -> None:
+    """FLAC 32-bit should be filtered out while other formats keep client priority order."""
+    flac_32 = SupportedAudioFormat(
+        codec=AudioCodec.FLAC, sample_rate=48_000, bit_depth=32, channels=2
+    )
+    flac_24 = SupportedAudioFormat(
+        codec=AudioCodec.FLAC, sample_rate=48_000, bit_depth=24, channels=2
+    )
+    pcm_16 = SupportedAudioFormat(
+        codec=AudioCodec.PCM, sample_rate=48_000, bit_depth=16, channels=2
+    )
+    assert filter_encodable_formats([flac_32, flac_24, pcm_16]) == [flac_24, pcm_16]
 
 
 def test_can_encode_format_rejects_opus_32_bit() -> None:

--- a/tests/server/roles/player/test_capabilities.py
+++ b/tests/server/roles/player/test_capabilities.py
@@ -21,7 +21,7 @@ def test_can_encode_format_accepts_flac_24_bit() -> None:
 
 
 def test_can_encode_format_rejects_flac_32_bit() -> None:
-    """FLAC 32-bit should be rejected — the encoder cannot deliver it."""
+    """FLAC 32-bit should be rejected, since the server does not offer that depth."""
     fmt = SupportedAudioFormat(codec=AudioCodec.FLAC, sample_rate=48_000, bit_depth=32, channels=2)
     assert not can_encode_format(fmt)
 

--- a/tests/server/test_audio_transformers.py
+++ b/tests/server/test_audio_transformers.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import struct
 
+import pytest
+
 from aiosendspin.server.audio_transformers import (
     AudioTransformer,
     TransformerPool,
@@ -14,6 +16,7 @@ from aiosendspin.server.roles.player.audio_transformers import (
     OpusEncoder,
     PcmPassthrough,
 )
+from aiosendspin.server.roles.player.capabilities import FLAC_BIT_DEPTHS
 
 
 class TestAudioTransformerProtocol:
@@ -575,17 +578,6 @@ class TestFlacEncoder:
             total_output.extend(result)
         assert len(total_output) > 0
 
-    def test_flac_encoder_supports_32_bit(self) -> None:
-        """FlacEncoder accepts 32-bit PCM input."""
-        encoder = FlacEncoder(sample_rate=48000, bit_depth=32, channels=2)
-        # 25ms at 48kHz stereo 32-bit: 1200 samples * 8 bytes = 9600 bytes.
-        pcm = bytes(9600)
-        total_output: list[tuple[bytes, int]] = []
-        for i in range(4):
-            result = encoder.process(pcm, timestamp_us=i * 25_000, duration_us=25_000)
-            total_output.extend(result)
-        assert len(total_output) > 0
-
     def test_flac_encoder_has_header(self) -> None:
         """FlacEncoder produces fLaC header."""
         encoder = FlacEncoder(sample_rate=48000, bit_depth=16, channels=2)
@@ -696,6 +688,30 @@ class TestFlacEncoder:
                 f"Frame {i}: gap={gap}us, expected {frame_dur}us. "
                 f"Timestamps around gap: {timestamps[max(0, i - 2) : i + 2]}"
             )
+
+
+class TestFlacEncoderStreamInfo:
+    """Tests that the FLAC stream delivered matches the bit depth the server announces."""
+
+    @pytest.mark.parametrize("bit_depth", sorted(FLAC_BIT_DEPTHS))
+    def test_streaminfo_bit_depth_matches_announced_depth(self, bit_depth: int) -> None:
+        """Every depth the server accepts is the depth STREAMINFO declares."""
+        encoder = FlacEncoder(sample_rate=48_000, bit_depth=bit_depth, channels=2)
+        encoder._ensure_initialized()  # noqa: SLF001
+
+        header = encoder.get_header()
+        assert header is not None, "FLAC encoder should expose a STREAMINFO header"
+        assert header.startswith(b"fLaC\x80")
+
+        # get_header() prefixes the 34-byte STREAMINFO block with "fLaC", a 1-byte
+        # metadata block header and a 3-byte length. Within the block (RFC 9639 §8.2)
+        # the 64 bits at offset 10 hold: sample rate (20), channels (3),
+        # bits per sample (5, stored as value-1), total samples (36).
+        streaminfo = header[8:]
+        packed = struct.unpack_from(">Q", streaminfo, 10)[0]
+        streaminfo_bit_depth = ((packed >> 36) & 0x1F) + 1
+
+        assert streaminfo_bit_depth == bit_depth
 
 
 class TestOpusEncoderLookaheadCompensation:

--- a/tests/server/test_audio_transformers.py
+++ b/tests/server/test_audio_transformers.py
@@ -578,6 +578,11 @@ class TestFlacEncoder:
             total_output.extend(result)
         assert len(total_output) > 0
 
+    def test_flac_encoder_rejects_32_bit(self) -> None:
+        """FlacEncoder refuses 32-bit input rather than emitting a 24-bit stream."""
+        with pytest.raises(ValueError, match="bit depths"):
+            FlacEncoder(sample_rate=48000, bit_depth=32, channels=2)
+
     def test_flac_encoder_has_header(self) -> None:
         """FlacEncoder produces fLaC header."""
         encoder = FlacEncoder(sample_rate=48000, bit_depth=16, channels=2)
@@ -697,7 +702,6 @@ class TestFlacEncoderStreamInfo:
     def test_streaminfo_bit_depth_matches_announced_depth(self, bit_depth: int) -> None:
         """Every depth the server accepts is the depth STREAMINFO declares."""
         encoder = FlacEncoder(sample_rate=48_000, bit_depth=bit_depth, channels=2)
-        encoder._ensure_initialized()  # noqa: SLF001
 
         header = encoder.get_header()
         assert header is not None, "FLAC encoder should expose a STREAMINFO header"

--- a/tests/server/test_sendspin_client_persistence.py
+++ b/tests/server/test_sendspin_client_persistence.py
@@ -225,7 +225,7 @@ async def test_reconnect_refreshes_audio_requirements_from_new_hello() -> None:
                     codec=AudioCodec.FLAC,
                     channels=2,
                     sample_rate=48_000,
-                    bit_depth=32,
+                    bit_depth=16,
                 )
             ],
         ),
@@ -239,7 +239,7 @@ async def test_reconnect_refreshes_audio_requirements_from_new_hello() -> None:
     first_req = role.get_audio_requirements()
     assert first_req is not None
     assert first_req.sample_rate == 48_000
-    assert first_req.bit_depth == 32
+    assert first_req.bit_depth == 16
     assert first_req.channels == 2
 
     client.detach_connection(None)

--- a/tests/server/test_stream_request_format.py
+++ b/tests/server/test_stream_request_format.py
@@ -184,7 +184,7 @@ def test_player_format_request_uses_client_priority_order_when_codec_missing(
         "p1",
         supported_formats=[
             SupportedAudioFormat(
-                codec=AudioCodec.FLAC, sample_rate=44100, bit_depth=32, channels=2
+                codec=AudioCodec.FLAC, sample_rate=44100, bit_depth=24, channels=2
             ),
             SupportedAudioFormat(
                 codec=AudioCodec.OPUS, sample_rate=48000, bit_depth=16, channels=2
@@ -213,7 +213,7 @@ def test_player_format_request_uses_client_priority_order_when_codec_missing(
     assert player_role.preferred_format is not None
     assert player_role.preferred_format.sample_rate == 44100
     assert player_role.preferred_format.channels == 2
-    assert player_role.preferred_format.bit_depth == 32
+    assert player_role.preferred_format.bit_depth == 24
 
 
 def test_player_partial_format_request_preserves_unchanged_fields(


### PR DESCRIPTION
## The bug

The server accepts a client's FLAC format at 32-bit, announces `bit_depth: 32` in `stream/start`, and then sends a FLAC stream whose own STREAMINFO header declares **24** bits per sample. Announced format and delivered format disagree.

Three pieces combine:

1. `capabilities.py` — `FLAC_BIT_DEPTHS` includes 32, so `can_encode_format()` accepts it.
2. `AudioFormat.resolve_av_format()` maps 16→`s16`, **24→`s32`**, **32→`s32`** — both 24 and 32 become the same PyAV sample format.
3. ffmpeg's FLAC encoder accepts only `s16` and `s32`, and given `s32` it writes `bits_per_sample = 24` into STREAMINFO unless `bits_per_raw_sample=32` and `strict=experimental` are both set.

16 and 24 are honest. Only 32 is a claim the encoder, as configured, does not keep.

Reproduce:

```python
import av
codec = av.codec.Codec("flac", "w")
print([str(f) for f in codec.audio_formats])   # -> s16, s32

for fmt in ("s16", "s32"):
    enc = av.AudioCodecContext.create("flac", "w")
    enc.sample_rate, enc.layout, enc.format = 8000, "mono", fmt
    enc.open()
    b = bytes(enc.extradata)
    # STREAMINFO bits-per-sample: 5 bits starting at bit 36 of the block
    print(fmt, "->", (((b[12] & 0x01) << 4) | ((b[13] & 0xF0) >> 4)) + 1)
# s16 -> 16
# s32 -> 24
```

A client that trusts `stream/start` unpacks at 32-bit and reads the stream wrong. One that trusts STREAMINFO decodes correctly but was told something false.

## The fix

Drop 32 from `FLAC_BIT_DEPTHS`, at the single choke point every format decision already flows through. Such entries are then filtered out the way 8-bit already is.

The alternative — keep accepting 32 but announce 24 — was rejected: `stream/start` requires that *"The format MUST be one the client listed in its `supported_formats`"*, so announcing `flac/24` to a client that offered only `flac/32` violates a MUST in exactly the case that matters. Delivering a real 32-bit stream is also possible (`bits_per_raw_sample=32` plus `strict=experimental` round-trips bit-exact) but is out of scope here: it needs ffmpeg's experimental strictness and yields streams only libFLAC 1.4 and later can decode.

**`PCM_BIT_DEPTHS` is deliberately untouched.** PCM at 32-bit is passthrough with a 4-byte wire sample and no encoder involved; it works correctly and is unaffected.

Resulting capability sets:

```
FLAC [16, 24]   PCM [16, 24, 32]   OPUS [16]
```

## Encoder-level guard

`FlacEncoder.__init__` now rejects any depth outside `VALID_BIT_DEPTHS`, and `FLAC_BIT_DEPTHS` derives from that constant so the advertised list cannot drift from what the encoder accepts. This also covers the source path, which capability filtering never reached: `SourceCapture` builds its encoder through `create_encoder` and then sends `bit_depth` from the requested format next to the encoder's own STREAMINFO, so a 32-bit FLAC capture announced 32 and shipped 24.

## Regression test

Added an invariant test: for every depth in `FLAC_BIT_DEPTHS`, the STREAMINFO the encoder emits must match the depth the server announces. That is the property that was broken, and it will catch both a future re-add of 32 and a change in ffmpeg's encoder behaviour.

Four existing test files needed updating for the narrowed set.

## Verification

```
pytest          1574 passed, 8 skipped
pre-commit      clean
```

The three premises were re-confirmed against current `main` rather than assumed, since `resolve_av_format` has since moved to `aiosendspin/audio/format.py` and the encoders to `aiosendspin/audio/codecs.py`:

- `FLAC_BIT_DEPTHS` did contain 32
- `resolve_av_format` still maps both 24 and 32 to `s32`
- `s32` still yields STREAMINFO `bits_per_sample = 24`

## Note

If `flac/32` is a client's *only* advertised format, dropping it leaves `filter_encodable_formats` empty, and the server currently logs `"Client %s has no server-compatible formats"` and returns without starting a stream — no message to the client, which cannot distinguish that from a slow server. That is a spec-level gap (the spec mandates codec support but not bit depths, and defines no "no compatible format" response); it is being raised separately against `Sendspin/spec` and is not addressed here.

Found during a cross-implementation conformance audit of bit-depth handling.