### PR TITLE
Fix broken audio at mid-stream player format changes

### DIFF
--- a/aiosendspin/server/audio_transformers.py
+++ b/aiosendspin/server/audio_transformers.py
@@ -166,6 +166,10 @@ class TransformerPool:
             self._transformers[key] = transformer_type(**transformer_kwargs)
         return self._transformers[key]  # type: ignore[return-value]
 
+    def get(self, key: TransformKey) -> AudioTransformer | None:
+        """Return the pooled transformer for key, if one exists."""
+        return self._transformers.get(key)
+
     def reset_all(self) -> None:
         """Reset all transformers (called on stream/clear)."""
         for transformer in self._transformers.values():

--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -804,6 +804,12 @@ class SendspinClient:
             duration_us=duration_us,
         )
 
+    def drop_pending_binary(self, roles: list[str] | None) -> None:
+        """Drop queued binary payloads for the given role families, if connected."""
+        if self._connection is None:
+            return
+        self._connection.drop_pending_binary(roles)
+
     def get_binary_handling_cached(self, message_type: int) -> tuple[BinaryHandling, Role] | None:
         """Return cached binary handling for a message type."""
         return self._binary_handling_cache.get(message_type)

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -414,6 +414,12 @@ class SendspinConnection:
         roles_to_drop = list(self._epoch_by_role.keys()) if roles is None else roles
         for role in roles_to_drop:
             self._epoch_by_role[role] += 1
+            if role in self._blocked_until_us:
+                # The backpressure deadline was computed against audio that is
+                # now invalid; new-epoch work must not wait behind it.
+                self._blocked_until_us.pop(role, None)
+                self._block_generation[role] += 1
+                self._schedule_role_head(role)
         self._wake_writer()
 
     def send_binary(

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -1689,6 +1689,12 @@ class PushStream:
         active_roles = {role for _client, role in self._get_audio_roles()}
 
         for tkey, frame_list in transformed.items():
+            roles = roles_by_transform.get(tkey, [])
+            if not any(r in active_roles for r in roles):
+                # Every recipient was excluded mid-commit (e.g. a format change
+                # deferred the sole role to the join path); caching these frames
+                # would repopulate the transform key the boundary just evicted.
+                continue
             cached_for_key: list[CachedChunk] = []
             for data, ts, dur in frame_list:
                 cached = CachedChunk(
@@ -1700,7 +1706,6 @@ class PushStream:
             cache_results[tkey].extend(cached_for_key)
 
             # Deliver live chunks directly; connection layer enforces late-drop/backpressure.
-            roles = roles_by_transform.get(tkey, [])
             # Share one AudioChunk across roles so its packed frame is built once.
             audio_chunks = [
                 AudioChunk(

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -1874,11 +1874,13 @@ class PushStream:
             self._transform_last_input_end_us.pop(stale_tkey, None)
 
     def on_role_format_changed(self, role: Role) -> None:
-        """Invalidate caches after a role's audio format changed mid-stream.
+        """Re-anchor a role whose audio format changed mid-stream.
 
-        Unlike on_role_leave(), this does NOT touch _started_roles or epoch.
-        The role stays active; only stale caches are cleared so the next
-        commit_audio() picks up the new AudioRequirements.
+        The role stays active (unlike on_role_leave()) but is treated as a
+        late joiner: stale transform-key work is discarded and the join path
+        re-anchors it near the playhead in the new format. In-flight commits
+        need no abort: the synchronous join deferral moves the role into
+        _pending_join_roles, which excludes it from live delivery.
         """
         # Invalidate transform key cache entries for this role
         role_id = id(role)
@@ -1889,6 +1891,13 @@ class PushStream:
                 self._transform_key_cache.pop(cache_key, None)
         for stale_tkey in stale_transform_keys:
             self._transform_last_input_end_us.pop(stale_tkey, None)
+            if not self._other_roles_use_transform_key(stale_tkey, role):
+                # Sole user of the old format: drop its encoded cache and
+                # reset the encoder so a change back starts clean.
+                self._role_chunk_cache.pop(stale_tkey, None)
+                transformer = self._group.transformer_pool.get(stale_tkey)
+                if transformer is not None:
+                    transformer.reset()
 
         # Clean up any catchup state referencing this role
         for tkey in list(self._catchup_roles.keys()):
@@ -1900,6 +1909,13 @@ class PushStream:
                 task = self._catchup_tasks.pop(tkey, None)
                 if task is not None:
                     task.cancel()
+
+        # The changing role's client discards its un-played buffer at the new
+        # stream/start, so re-anchor it near the playhead via the late-join
+        # path: the buffered content is re-encoded in the new format and
+        # handed off to live at the tail, leaving the shared channel timeline
+        # untouched for unchanged roles.
+        self.on_role_join(role)
 
     def has_cached_chunks(self) -> bool:
         """Return True if there are cached chunks for late joiners."""

--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -543,11 +543,11 @@ class PlayerV1Role(Role):
                 state = self._state()
                 state.preferred_format_override = None
                 state.preferred_codec_override = None
+                before = self._effective_format()
                 self._ensure_preferred_format()
                 self._ensure_audio_requirements(force=True)
-                if self._client.group.has_active_stream:
-                    self._pending_stream_start = True
-                    self._client.group.on_role_format_changed(self)
+                if self._client.group.has_active_stream and self._effective_format() != before:
+                    self._begin_format_transition()
                 return True
 
         if codec is None:
@@ -587,14 +587,13 @@ class PlayerV1Role(Role):
         self._preferred_format = audio_format
         self._preferred_codec = codec
 
+        before = self._effective_format()
+
         # Rebuild audio requirements with the new format
         self._ensure_audio_requirements(force=True)
 
-        # Mid-stream server-driven format change: defer stream/start until next chunk
-        # and invalidate push-stream caches for this role.
-        if self._client.group.has_active_stream:
-            self._pending_stream_start = True
-            self._client.group.on_role_format_changed(self)
+        if self._client.group.has_active_stream and self._effective_format() != before:
+            self._begin_format_transition()
 
         return True
 
@@ -792,18 +791,60 @@ class PlayerV1Role(Role):
         self.preferred_format = requested_format
         self.preferred_codec = requested_codec
 
+        current_format = self._effective_format()
+        if current_format is not None and current_format == (requested_codec, requested_format):
+            # Already on the requested format. Running the boundary would evict
+            # valid audio while the announcement's identity guard suppresses
+            # the stream/start that would justify it.
+            return
+
         stream_active = self._client.group.has_active_stream
         if stream_active:
-            # Mid-stream format change: rebuild requirements and defer stream/start
-            # until the next audio chunk (which provides the codec header).
             self._ensure_audio_requirements(force=True)
-            self._pending_stream_start = True
-            self._client.group.on_role_format_changed(self)
+            self._begin_format_transition()
         else:
             # No active stream: also defer stream/start via _pending_stream_start
             # so codec header is included when the first chunk arrives.
             self._ensure_audio_requirements(force=True)
             self._pending_stream_start = True
+
+    def _effective_format(self) -> tuple[AudioCodec, AudioFormat] | None:
+        """Return the current negotiated (codec, format), or None without requirements."""
+        req = self.get_audio_requirements()
+        if req is None:
+            return None
+        transformer = req.transformer
+        if isinstance(transformer, FlacEncoder):
+            codec = AudioCodec.FLAC
+        elif isinstance(transformer, OpusEncoder):
+            codec = AudioCodec.OPUS
+        else:
+            codec = AudioCodec.PCM
+        return (
+            codec,
+            AudioFormat(
+                sample_rate=req.sample_rate,
+                bit_depth=req.bit_depth,
+                channels=req.channels,
+            ),
+        )
+
+    def _begin_format_transition(self) -> None:
+        """Start a mid-stream format change at a clean boundary.
+
+        Frames queued under the old format must never reach the client after
+        the new stream/start; the announcement itself waits for the next
+        chunk so it can carry the new codec header.
+        """
+        self._client.drop_pending_binary([self.role_family])
+        # Everything the buffer tracker and binary timing know about was just
+        # invalidated with the old format; without resetting them the writer
+        # paces the replacement audio against a buffer the client flushed.
+        self.reset_binary_timing()
+        if self._buffer_tracker is not None:
+            self._buffer_tracker.reset()
+        self._pending_stream_start = True
+        self._client.group.on_role_format_changed(self)
 
     # ---- Internal helpers ----
 

--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -844,6 +844,9 @@ class PlayerV1Role(Role):
         if self._buffer_tracker is not None:
             self._buffer_tracker.reset()
         self._pending_stream_start = True
+        # The client flushes its invalidated buffer only on a stream/start, so a
+        # flip-flop back to the announced format must not suppress one.
+        self._last_sent_format = None
         self._client.group.on_role_format_changed(self)
 
     # ---- Internal helpers ----

--- a/tests/server/test_connection_writer.py
+++ b/tests/server/test_connection_writer.py
@@ -282,6 +282,82 @@ async def test_writer_blocks_on_buffer_tracker_capacity() -> None:
     await conn.disconnect(retry_connection=False)
 
 
+@pytest.mark.asyncio
+async def test_drop_pending_binary_unblocks_backpressured_role() -> None:
+    """drop_pending_binary() must immediately release a backpressured role.
+
+    A stream boundary evicts queued audio whose backpressure deadline was
+    computed against now-invalidated state; new-epoch work must be
+    schedulable right away while the stale entry is epoch-discarded.
+    """
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+
+    wsock = MagicMock()
+    wsock.closed = False
+    wsock.send_str = AsyncMock()
+    wsock.send_bytes = AsyncMock()
+
+    conn = SendspinConnection(server, wsock_client=wsock)
+    conn._transport = wsock  # noqa: SLF001
+    await conn._setup_connection()  # noqa: SLF001
+    conn._writer_task = asyncio.create_task(conn._writer())  # noqa: SLF001
+
+    mock_role = MagicMock()
+    mock_buffer_tracker = MagicMock()
+    mock_buffer_tracker.time_until_ready.return_value = 1_000_000
+    mock_role.get_buffer_tracker.return_value = mock_buffer_tracker
+    mock_role._stream_start_time_us = None  # noqa: SLF001
+    mock_role._last_late_log_s = 0.0  # noqa: SLF001
+    mock_role._late_skips_since_log = 0  # noqa: SLF001
+
+    mock_client = MagicMock()
+    binary_handling = BinaryHandling(drop_late=False, buffer_track=True)
+    mock_client.get_binary_handling_cached.return_value = (binary_handling, mock_role)
+    conn._client = mock_client  # noqa: SLF001
+
+    message_type = BinaryMessageType.AUDIO_CHUNK.value
+    conn.send_binary(
+        pack_binary_header_raw(message_type, 0) + b"stale",
+        role="player",
+        timestamp_us=0,
+        message_type=message_type,
+        buffer_end_time_us=1_000_000,
+        buffer_byte_count=100,
+        duration_us=50_000,
+    )
+
+    for _ in range(10):
+        await asyncio.sleep(0)
+    assert wsock.send_bytes.call_count == 0
+    assert "player" in conn._blocked_until_us  # noqa: SLF001
+
+    # Stream boundary: evict the queued binary and open capacity.
+    conn.drop_pending_binary(["player"])
+    mock_buffer_tracker.time_until_ready.return_value = 0
+
+    conn.send_binary(
+        pack_binary_header_raw(message_type, 0) + b"fresh",
+        role="player",
+        timestamp_us=0,
+        message_type=message_type,
+        buffer_end_time_us=2_000_000,
+        buffer_byte_count=100,
+        duration_us=50_000,
+    )
+
+    for _ in range(10):
+        await asyncio.sleep(0)
+
+    # The stale entry was epoch-discarded and the new-epoch frame went out
+    # immediately instead of waiting out the old backpressure deadline.
+    assert wsock.send_bytes.call_count == 1
+    assert wsock.send_bytes.call_args[0][0].endswith(b"fresh")
+    assert "player" not in conn._blocked_until_us  # noqa: SLF001
+
+    await conn.disconnect(retry_connection=False)
+
+
 def test_check_late_binary_uses_player_effective_timestamp() -> None:
     """Static delay should make late-drop compare against effective play time."""
     loop = asyncio.new_event_loop()

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -88,9 +88,13 @@ class _FakeConnection:
         self.sent_json: list[object] = []
         self.sent_binary: list[bytes] = []
         self.buffer_tracker = None
+        self.dropped_pending_binary: list[list[str] | None] = []
 
     async def disconnect(self, *, retry_connection: bool = True) -> None:  # noqa: ARG002
         return
+
+    def drop_pending_binary(self, roles: list[str] | None) -> None:
+        self.dropped_pending_binary.append(roles)
 
     def send_message(self, message: object) -> None:
         self.sent_json.append(message)
@@ -1990,7 +1994,8 @@ async def test_format_change_during_active_stream(mock_loop: Any) -> None:
     4. Commit more audio
     5. Assert: StreamStartMessage (with new format) in sent_json, NO StreamClearMessage
     6. Binary audio continues after format change
-    7. Gap between last pre-change chunk and first post-change chunk ≤ 100ms
+    7. Post-change audio resumes near now via new-format catch-up replay,
+       not at the pre-change tail
     """
     group = _DummyGroup(clients=[])
     client, conn = _make_connected_player_multi_format(mock_loop, group, "p1")
@@ -2000,8 +2005,9 @@ async def test_format_change_during_active_stream(mock_loop: Any) -> None:
     group._push_stream = stream  # noqa: SLF001
     group.has_active_stream = True
 
-    # Commit several chunks at 48kHz PCM
-    for _ in range(3):
+    # Commit enough 48kHz PCM that the channel tail runs well past the
+    # resume floor (25ms per chunk).
+    for _ in range(20):
         stream.prepare_audio(
             bytes(4800),
             AudioFormat(sample_rate=48000, bit_depth=16, channels=2),
@@ -2032,9 +2038,13 @@ async def test_format_change_during_active_stream(mock_loop: Any) -> None:
     assert role is not None
     role.on_stream_request_format(request)
 
-    # No immediate stream/start or stream/clear
-    assert not any(isinstance(msg, StreamStartMessage) for msg in conn.sent_json)
+    # No stream/clear. The stream/start may already have gone out with the
+    # first new-format catch-up chunk re-encoded by the join path.
     assert not any(isinstance(msg, StreamClearMessage) for msg in conn.sent_json)
+
+    # Let the boundary-scheduled catch-up task deliver its replay chunks.
+    for _ in range(5):
+        await asyncio.sleep(0)
 
     # Commit audio at the new format (44.1kHz)
     # 1102 samples * 2 bytes * 2 channels = 4408 bytes (~24.99ms)
@@ -2055,14 +2065,194 @@ async def test_format_change_during_active_stream(mock_loop: Any) -> None:
     # No stream/clear should have been sent
     assert not any(isinstance(msg, StreamClearMessage) for msg in conn.sent_json)
 
+    # The change must evict queued old-format binary, as stream/clear does.
+    assert conn.dropped_pending_binary == [["player"]]
+
     # Binary audio continued after the format change
     assert len(conn.sent_binary) > pre_change_binary_count
 
-    # Check the gap: first post-change chunk start vs last pre-change chunk end
+    # The client flushes its un-played buffer at the announcement, so the
+    # replacement audio must resume near now, not continue at the pre-change tail.
     post_change_binary = conn.sent_binary[pre_change_binary_count:]
     first_post_header = unpack_binary_header(post_change_binary[0])
-    gap_us = first_post_header.timestamp_us - pre_change_end_us
-    assert gap_us <= 100_000, f"Gap between pre/post format change chunks is {gap_us}us (> 100ms)"
+    now_us = clock.now_us()
+    assert now_us <= first_post_header.timestamp_us < pre_change_end_us, (
+        f"Post-change audio starts at {first_post_header.timestamp_us}us "
+        f"(now={now_us}us, pre-change tail={pre_change_end_us}us)"
+    )
+
+    # No old-format frames (9-byte header + 4800-byte 48kHz payload) may
+    # follow the boundary; replayed catch-up chunks are resampled to 44.1kHz
+    # so their exact size can vary slightly.
+    assert all(len(frame) != 9 + 4800 for frame in post_change_binary)
+
+
+@pytest.mark.asyncio
+async def test_format_change_during_inflight_commit_aborts_old_format_delivery(
+    mock_loop: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A format request landing mid-commit must not deliver old-format audio.
+
+    commit_audio() groups roles under the current AudioRequirements before
+    its first await, so a request processed during resampling previously let
+    the commit deliver old-format chunks behind a stream/start built from the
+    NEW requirements. The boundary synchronously defers the role to the join
+    path, which excludes it from that commit's live delivery.
+    """
+    group = _DummyGroup(clients=[])
+    client, conn = _make_connected_player_multi_format(mock_loop, group, "p1")
+    clock = LoopClock(mock_loop)
+
+    stream = PushStream(loop=mock_loop, clock=clock, group=group)
+    group._push_stream = stream  # noqa: SLF001
+    group.has_active_stream = True
+
+    # Establish the stream at 48kHz PCM
+    for _ in range(2):
+        stream.prepare_audio(
+            bytes(4800),
+            AudioFormat(sample_rate=48000, bit_depth=16, channels=2),
+        )
+        await stream.commit_audio()
+    assert conn.sent_binary
+
+    role = client.role("player@v1")
+    assert role is not None
+    conn.sent_json.clear()
+    conn.sent_binary.clear()
+
+    # Land the format request after the commit has grouped roles under the
+    # old requirements, but before encoding and delivery.
+    stream.prepare_audio(
+        bytes(4800),
+        AudioFormat(sample_rate=48000, bit_depth=16, channels=2),
+    )
+    original_resample = stream._resample_for_roles  # noqa: SLF001
+    format_request_fired = False
+
+    async def resample_with_midflight_format_change(*args: Any, **kwargs: Any) -> Any:
+        nonlocal format_request_fired
+        if not format_request_fired:
+            format_request_fired = True
+            role.on_stream_request_format(
+                StreamRequestFormatPayload(
+                    player=StreamRequestFormatPlayer(
+                        codec=AudioCodec.PCM,
+                        sample_rate=44100,
+                        channels=2,
+                        bit_depth=16,
+                    )
+                )
+            )
+        return await original_resample(*args, **kwargs)
+
+    monkeypatch.setattr(stream, "_resample_for_roles", resample_with_midflight_format_change)
+    await stream.commit_audio()
+
+    # The boundary defers the rejoin until the in-flight commit's cleanup, so
+    # let the catch-up task deliver its new-format replay chunks.
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    # The changer gets only new-format replay from the boundary-scheduled
+    # join; the excluded commit must not have delivered old-format frames.
+    assert conn.sent_binary
+    assert all(len(frame) != 9 + 4800 for frame in conn.sent_binary)
+
+    # The next commit delivers the deferred stream/start, then only new-format audio.
+    stream.prepare_audio(
+        bytes(4408),
+        AudioFormat(sample_rate=44100, bit_depth=16, channels=2),
+    )
+    await stream.commit_audio()
+
+    stream_starts = [msg for msg in conn.sent_json if isinstance(msg, StreamStartMessage)]
+    assert len(stream_starts) == 1
+    assert stream_starts[0].payload.player is not None
+    assert stream_starts[0].payload.player.sample_rate == 44100
+    assert conn.sent_binary
+    assert all(len(frame) != 9 + 4800 for frame in conn.sent_binary)
+
+
+@pytest.mark.asyncio
+async def test_format_change_preserves_peer_audio(
+    mock_loop: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One player's mid-commit format change must not cost peers any audio.
+
+    Regression for the stream-global generation bump: aborting the whole
+    in-flight commit dropped its window for every player on the stream.
+    The pending-join exclusion must contain the change to the requesting
+    player.
+    """
+    group = _DummyGroup(clients=[])
+    client_a, conn_a = _make_connected_player_multi_format(mock_loop, group, "p1")
+    _client_b, conn_b = _make_connected_player_multi_format(mock_loop, group, "p2")
+    clock = LoopClock(mock_loop)
+
+    stream = PushStream(loop=mock_loop, clock=clock, group=group)
+    group._push_stream = stream  # noqa: SLF001
+    group.has_active_stream = True
+
+    # Both players receive the same 48kHz PCM windows.
+    for _ in range(3):
+        stream.prepare_audio(
+            bytes(4800),
+            AudioFormat(sample_rate=48000, bit_depth=16, channels=2),
+        )
+        await stream.commit_audio()
+    peer_chunks_before = len(conn_b.sent_binary)
+    assert peer_chunks_before > 0
+    # B's own stream/start from the initial start is expected; ignore it here.
+    conn_b.sent_json.clear()
+
+    # Player A's format request lands after the commit grouped roles, but
+    # before encoding and delivery.
+    role_a = client_a.role("player@v1")
+    assert role_a is not None
+    stream.prepare_audio(
+        bytes(4800),
+        AudioFormat(sample_rate=48000, bit_depth=16, channels=2),
+    )
+    original_resample = stream._resample_for_roles  # noqa: SLF001
+    fired = False
+
+    async def resample_with_midflight_format_change(*args: Any, **kwargs: Any) -> Any:
+        nonlocal fired
+        if not fired:
+            fired = True
+            role_a.on_stream_request_format(
+                StreamRequestFormatPayload(
+                    player=StreamRequestFormatPlayer(
+                        codec=AudioCodec.PCM,
+                        sample_rate=44100,
+                        channels=2,
+                        bit_depth=16,
+                    )
+                )
+            )
+        return await original_resample(*args, **kwargs)
+
+    monkeypatch.setattr(stream, "_resample_for_roles", resample_with_midflight_format_change)
+    await stream.commit_audio()
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    # The unchanged peer received the in-flight commit's window: exactly one
+    # more 48kHz chunk, contiguous with its previous timeline, and no
+    # stream/start disruption of its own.
+    peer_chunks = conn_b.sent_binary[peer_chunks_before:]
+    assert len(peer_chunks) == 1
+    assert len(peer_chunks[0]) == 9 + 4800
+    prev_header = unpack_binary_header(conn_b.sent_binary[peer_chunks_before - 1])
+    this_header = unpack_binary_header(peer_chunks[0])
+    assert this_header.timestamp_us == prev_header.timestamp_us + 25_000
+    assert not any(isinstance(msg, StreamStartMessage) for msg in conn_b.sent_json)
+
+    # The changing player got no old-format frame behind its boundary.
+    assert all(len(frame) != 9 + 4800 for frame in conn_a.sent_binary[peer_chunks_before:])
 
 
 # --- Historical Audio Tests ---

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -2088,6 +2088,76 @@ async def test_format_change_during_active_stream(mock_loop: Any) -> None:
 
 
 @pytest.mark.asyncio
+async def test_format_flipflop_without_a_chunk_announces_the_return(mock_loop: Any) -> None:
+    """Returning to the last announced format must still announce the boundary.
+
+    Two requests with no chunk between them leave the client configured for
+    the format it is already playing, so the sent-format guard suppresses the
+    second stream/start. The boundary has meanwhile dropped the client's
+    queued audio and re-anchored near the playhead, so without the
+    announcement the client never flushes and plays the old buffer over the
+    replacement audio.
+    """
+    group = _DummyGroup(clients=[])
+    client, conn = _make_connected_player_multi_format(mock_loop, group, "p1")
+    clock = LoopClock(mock_loop)
+
+    stream = PushStream(loop=mock_loop, clock=clock, group=group)
+    group._push_stream = stream  # noqa: SLF001
+    group.has_active_stream = True
+
+    role = client.role("player@v1")
+    assert role is not None
+
+    def request_format(sample_rate: int) -> None:
+        role.on_stream_request_format(
+            StreamRequestFormatPayload(
+                player=StreamRequestFormatPlayer(
+                    codec=AudioCodec.PCM,
+                    sample_rate=sample_rate,
+                    channels=2,
+                    bit_depth=16,
+                )
+            )
+        )
+
+    for _ in range(20):
+        stream.prepare_audio(
+            bytes(4800),
+            AudioFormat(sample_rate=48000, bit_depth=16, channels=2),
+        )
+        await stream.commit_audio()
+
+    pre_change_count = len(conn.sent_binary)
+    pre_change_end_us = unpack_binary_header(conn.sent_binary[-1]).timestamp_us + 25_000
+    conn.sent_json.clear()
+
+    request_format(44100)
+    request_format(48000)
+    for _ in range(5):
+        await asyncio.sleep(0)
+
+    stream.prepare_audio(
+        bytes(4800),
+        AudioFormat(sample_rate=48000, bit_depth=16, channels=2),
+    )
+    await stream.commit_audio()
+
+    post_change_binary = conn.sent_binary[pre_change_count:]
+    assert post_change_binary
+    first_post_header = unpack_binary_header(post_change_binary[0])
+    assert first_post_header.timestamp_us < pre_change_end_us
+
+    stream_starts = [msg for msg in conn.sent_json if isinstance(msg, StreamStartMessage)]
+    assert len(stream_starts) == 1, (
+        f"Audio re-anchored to {first_post_header.timestamp_us}us behind the "
+        f"{pre_change_end_us}us tail with {len(stream_starts)} stream/start(s)"
+    )
+    assert stream_starts[0].payload.player is not None
+    assert stream_starts[0].payload.player.sample_rate == 48000
+
+
+@pytest.mark.asyncio
 async def test_format_change_during_inflight_commit_aborts_old_format_delivery(
     mock_loop: Any,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -2119,6 +2119,9 @@ async def test_format_change_during_inflight_commit_aborts_old_format_delivery(
 
     role = client.role("player@v1")
     assert role is not None
+    old_tkey = stream._build_transform_key(  # noqa: SLF001
+        role.get_audio_requirements(), MAIN_CHANNEL, role
+    )
     conn.sent_json.clear()
     conn.sent_binary.clear()
 
@@ -2159,6 +2162,9 @@ async def test_format_change_during_inflight_commit_aborts_old_format_delivery(
     # join; the excluded commit must not have delivered old-format frames.
     assert conn.sent_binary
     assert all(len(frame) != 9 + 4800 for frame in conn.sent_binary)
+
+    # Nor may the excluded commit repopulate the evicted old-format cache.
+    assert not stream._role_chunk_cache.get(old_tkey)  # noqa: SLF001
 
     # The next commit delivers the deferred stream/start, then only new-format audio.
     stream.prepare_audio(

--- a/tests/server/test_sendspin_client_persistence.py
+++ b/tests/server/test_sendspin_client_persistence.py
@@ -62,6 +62,9 @@ class _DummyConnection:
     def send_message(self, message: object) -> None:
         self.sent_json.append(message)
 
+    def drop_pending_binary(self, roles: list[str] | None) -> None:  # noqa: ARG002
+        return
+
     def send_role_message(self, role: str, message: object) -> None:  # noqa: ARG002
         self.sent_json.append(message)
 

--- a/tests/server/test_stream_request_format.py
+++ b/tests/server/test_stream_request_format.py
@@ -26,12 +26,16 @@ from aiosendspin.server.roles.player.v1 import PlayerV1Role
 class _FakeConnection:
     def __init__(self) -> None:
         self.sent: list[object] = []
+        self.dropped_pending_binary: list[list[str] | None] = []
 
     async def disconnect(self, *, retry_connection: bool = True) -> None:  # noqa: ARG002
         return
 
     def send_message(self, message: object) -> None:
         self.sent.append(message)
+
+    def drop_pending_binary(self, roles: list[str] | None) -> None:
+        self.dropped_pending_binary.append(roles)
 
     def send_role_message(self, role: str, message: object) -> None:  # noqa: ARG002
         self.sent.append(message)
@@ -252,3 +256,75 @@ def test_player_partial_format_request_preserves_unchanged_fields(
     assert player_role.preferred_format.sample_rate == 44100
     assert player_role.preferred_format.bit_depth == 16
     assert player_role.preferred_format.channels == 2
+
+
+def test_format_request_resets_buffer_tracker(mock_server: MagicMock) -> None:
+    """A mid-stream format change resets buffer tracking and binary timing.
+
+    The client flushes its buffer at the new stream/start, so the writer must
+    not pace the replacement audio against the old-format audio still
+    registered in the buffer tracker.
+    """
+    client, _conn = _make_player_client(mock_server, "p1")
+    client.group.start_stream()
+
+    player_role = client.role("player@v1")
+    assert isinstance(player_role, PlayerV1Role)
+    tracker = player_role._buffer_tracker  # noqa: SLF001
+    assert tracker is not None
+
+    clock = mock_server.clock
+    now_us = clock.now_us()
+    tracker.register(now_us + 10_000_000, 100_000, 10_000_000)
+    tracker.prune_consumed(now_us)
+    assert tracker.buffered_duration_us > 0
+
+    # Request a genuinely different format (FLAC); an identical-format request
+    # must be ignored entirely.
+    player_role.on_stream_request_format(
+        StreamRequestFormatPayload(
+            player=StreamRequestFormatPlayer(
+                codec=AudioCodec.FLAC,
+                sample_rate=48000,
+                channels=2,
+                bit_depth=16,
+            )
+        )
+    )
+
+    assert tracker.buffered_duration_us == 0
+
+
+def test_noop_format_request_runs_no_boundary(mock_server: MagicMock) -> None:
+    """A request for the format already in use must not run the transition.
+
+    The stream/start identity guard would suppress the announcement, so the
+    boundary would evict queued audio the client still holds with nothing
+    replacing it.
+    """
+    client, conn = _make_player_client(mock_server, "p1")
+    client.group.start_stream()
+
+    player_role = client.role("player@v1")
+    assert isinstance(player_role, PlayerV1Role)
+    tracker = player_role._buffer_tracker  # noqa: SLF001
+    assert tracker is not None
+    clock = mock_server.clock
+    now_us = clock.now_us()
+    tracker.register(now_us + 10_000_000, 100_000, 10_000_000)
+    tracker.prune_consumed(now_us)
+
+    # PCM 48kHz stereo 16-bit is the default negotiated format for this client.
+    player_role.on_stream_request_format(
+        StreamRequestFormatPayload(
+            player=StreamRequestFormatPlayer(
+                codec=AudioCodec.PCM,
+                sample_rate=48000,
+                channels=2,
+                bit_depth=16,
+            )
+        )
+    )
+
+    assert tracker.buffered_duration_us > 0
+    assert conn.dropped_pending_binary == []


### PR DESCRIPTION
I'm testing my `stream/request-format` implementation in SendspinKit when I discovered aiosendspin wasn't handling the new requests cleanly. On this branch, switching from 44.1kHz to 96kHz to 48kHz (etc.) on a live stream has a sub-second audio gap and the new format starts cleanly immediately with no audible glitches. I'm pretty stoked.

A mid-stream stream/request-format (or server-driven set_preferred_format) only invalidated per-role transform caches, which left four holes that delivered a broken transition to a player already switched to the announced format:

- commit_audio() groups roles under a player's AudioRequirements before its first await, so a request processed mid-commit kept delivering old-format chunks behind a stream/start built from the NEW requirements.
- Old-format binary already queued on the connection survived the transition, while the deferred stream/start (enqueued at now_us) could be delivered ahead of it.
- The writer paced the replacement audio against the buffer tracker's record of old-format audio the client had just flushed at the announcement, and a backpressured role stayed blocked until the deadline computed from that record, starving the client for roughly a buffer's worth of wall-clock time.
- A request for the format already in use ran the full boundary while the stream/start identity guard suppressed the announcement, evicting audio the client still held with nothing replacing it.

Enforce an explicit format-transition boundary in PlayerV1Role, skipped when the effective format is unchanged: evict the player's queued binary (the same epoch-based invalidation stream/clear and stream/end use), unblock the role's stale backpressure deadline, reset its buffer tracking and binary timing, and defer the new stream/start to the next chunk so it carries the codec header. The boundary defers the role to the push stream's join path, which excludes it from any in-flight commit's live delivery — containing the change to the requesting player instead of aborting the whole commit for the group.

The join path then re-anchors the player near the playhead: buffered PCM is re-encoded in the new format from the late-join target and handed off to live at the tail, without moving the shared channel timeline and without skipping the buffered content. Formats the player solely used have their encoded chunk cache dropped and encoder reset, so a change back starts clean.

Limitation: the re-anchor replays from the PCM cache, which is enabled by default only on the main channel; players on other channels without a PCM cache resume at the channel tail.

Tests cover the mid-commit race (no old-format binary behind the new stream/start), preservation of an unchanged peer's audio through a mid-commit change, no-op requests running no boundary, resume of post-change audio near now, and the buffer tracker reset.