### PR TITLE
Add timing diagnostics to late audio chunk warnings

### DIFF
--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -479,7 +479,15 @@ class SendspinConnection:
             return
 
         now_us = self._server.clock.now_us()
-        if timestamp_us != 0 and timestamp_us + (duration_us or 0) <= now_us:
+        # buffer_end_time_us already carries the role's static delay, which shifts the
+        # deadline earlier than the raw timestamp. Fall back to the raw span only when
+        # a caller does not supply it.
+        deadline_us = (
+            buffer_end_time_us
+            if buffer_end_time_us is not None
+            else timestamp_us + (duration_us or 0)
+        )
+        if timestamp_us != 0 and deadline_us <= now_us:
             self._warn_late_at_enqueue(role, message_type, timestamp_us, now_us)
 
         # Keep per-role queue ordering monotonic so role-scoped lifecycle JSON
@@ -515,6 +523,7 @@ class SendspinConnection:
             cached = self._client.get_binary_handling_cached(message_type)
         if cached is None or not cached[0].drop_late:
             return
+        behind_by_us = now_us - (timestamp_us - cached[1].get_static_delay_us())
         self._late_at_enqueue_count[role] = self._late_at_enqueue_count.get(role, 0) + 1
         now_s = time.monotonic()
         if now_s - self._last_late_at_enqueue_log_s.get(role, 0.0) < _WARN_INTERVAL_S:
@@ -525,7 +534,7 @@ class SendspinConnection:
             message_type,
             role,
             self._late_at_enqueue_count[role],
-            now_us - timestamp_us,
+            behind_by_us,
             timestamp_us,
             now_us,
             len(self._role_queues.get(role, [])),
@@ -1874,7 +1883,10 @@ class SendspinConnection:
         """
         fields: list[str] = []
         if entry.enqueued_at_us:
-            fields.append(f"enq_lead_ms={(entry.timestamp_us - entry.enqueued_at_us) / 1000:.0f}")
+            # Same effective play time the late-drop decision uses, so this field and
+            # late_by_us in the surrounding line share one basis.
+            effective_ts_us = entry.timestamp_us - role.get_static_delay_us()
+            fields.append(f"enq_lead_ms={(effective_ts_us - entry.enqueued_at_us) / 1000:.0f}")
             fields.append(f"queue_age_ms={(now_us - entry.enqueued_at_us) / 1000:.0f}")
         if (tracker := role.get_buffer_tracker()) is not None:
             fields.append(f"buf_ms={tracker.buffered_horizon_us(now_us) / 1000:.0f}")

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -148,6 +148,11 @@ logger = logging.getLogger(__name__)
 
 MAX_PENDING_MSG = 4096  # Default queue cap (per role queues, and global control queues)
 
+# Quiet period between repeats of a throttled warning. Each warning reports how
+# many occurrences it stands for, so a sustained fault keeps its magnitude visible
+# at default level without emitting one line per event.
+_WARN_INTERVAL_S = 30.0
+
 # Bound the wait for the writer to drain when quiescing.
 QUIESCE_TIMEOUT_S: float = 30.0
 
@@ -202,6 +207,8 @@ class _RoleQueueEntry:
     # Exactly one of these is set
     binary: _BinaryData | None = None
     json_message: ServerMessage | None = None
+    # Server clock at enqueue, for late-drop diagnostics (0 for JSON entries)
+    enqueued_at_us: int = 0
 
 
 class _QueuedTransport(EncryptedWebSocket):
@@ -278,6 +285,11 @@ class SendspinConnection:
         self._max_pending_msg_by_role: defaultdict[str, int] = defaultdict(lambda: MAX_PENDING_MSG)
         # Last timestamp per role for JSON inheritance (JSON gets previous message's timestamp)
         self._last_enqueued_ts_by_role: dict[str, int] = {}
+        # Rate-limit state for already-late-at-enqueue and slow-send warnings
+        self._late_at_enqueue_count: dict[str, int] = {}
+        self._last_late_at_enqueue_log_s: dict[str, float] = {}
+        self._last_slow_send_log_s = 0.0
+        self._slow_send_count = 0
         # Global scheduler heaps for families
         self._ready_roles: list[tuple[int, int, str]] = []
         self._delayed_roles: list[tuple[int, int, str]] = []
@@ -466,6 +478,10 @@ class SendspinConnection:
             )
             return
 
+        now_us = self._server.clock.now_us()
+        if timestamp_us != 0 and timestamp_us + (duration_us or 0) <= now_us:
+            self._warn_late_at_enqueue(role, message_type, timestamp_us, now_us)
+
         # Keep per-role queue ordering monotonic so role-scoped lifecycle JSON
         # (stream/start, stream/end, stream/clear) cannot be overtaken by binary
         # packets that carry an older playback timestamp (e.g. historical backfill).
@@ -480,9 +496,42 @@ class SendspinConnection:
                 buffer_byte_count=buffer_byte_count,
                 duration_us=duration_us,
             ),
+            enqueued_at_us=now_us,
         )
         self._last_enqueued_ts_by_role[role] = sort_ts
         self._enqueue_role_entry(role, sort_ts, entry)
+
+    def _warn_late_at_enqueue(
+        self, role: str, message_type: int, timestamp_us: int, now_us: int
+    ) -> None:
+        """Warn when a binary message is already past its play deadline at enqueue.
+
+        A late drop at send time only says a deadline was missed; this names the
+        moment the unplayable data entered the queue, which points at the producer
+        (stale timestamps, timeline reset) rather than the transport.
+        """
+        cached = None
+        if self._client is not None:
+            cached = self._client.get_binary_handling_cached(message_type)
+        if cached is None or not cached[0].drop_late:
+            return
+        self._late_at_enqueue_count[role] = self._late_at_enqueue_count.get(role, 0) + 1
+        now_s = time.monotonic()
+        if now_s - self._last_late_at_enqueue_log_s.get(role, 0.0) < _WARN_INTERVAL_S:
+            return
+        self._logger.warning(
+            "Enqueued already-late binary type=%s role=%s: %s message(s); "
+            "behind_by_us=%s ts_us=%s now_us=%s queue=%s",
+            message_type,
+            role,
+            self._late_at_enqueue_count[role],
+            now_us - timestamp_us,
+            timestamp_us,
+            now_us,
+            len(self._role_queues.get(role, [])),
+        )
+        self._late_at_enqueue_count[role] = 0
+        self._last_late_at_enqueue_log_s[role] = now_s
 
     def queue_status(self) -> tuple[int, int]:
         """Return (qsize, maxsize) for the outgoing queue."""
@@ -1813,11 +1862,31 @@ class SendspinConnection:
         for role in self._client.active_roles:
             role.on_client_state(payload)
 
+    def _late_binary_diagnostics(
+        self, role: Role, entry: _RoleQueueEntry, now_us: int, elapsed_us: int
+    ) -> str:
+        """Build the field list that tells the late-drop regimes apart.
+
+        enq_lead is the margin the chunk had when it was queued and queue_age how
+        long it then waited, which separates a thin producer lead from a chunk that
+        aged in transit. buf reports the tracked device buffer, and stream_elapsed
+        marks a startup or restart window. Fields with no value are omitted.
+        """
+        fields: list[str] = []
+        if entry.enqueued_at_us:
+            fields.append(f"enq_lead_ms={(entry.timestamp_us - entry.enqueued_at_us) / 1000:.0f}")
+            fields.append(f"queue_age_ms={(now_us - entry.enqueued_at_us) / 1000:.0f}")
+        if (tracker := role.get_buffer_tracker()) is not None:
+            fields.append(f"buf_ms={tracker.buffered_horizon_us(now_us) / 1000:.0f}")
+            fields.append(f"buf_bytes={tracker.buffered_bytes}/{tracker.capacity_bytes}")
+        fields.append(f"stream_elapsed_s={elapsed_us / 1_000_000:.1f}")
+        return " ".join(fields)
+
     def _check_late_binary(
         self,
         handling: BinaryHandling | None,
         role: Role | None,
-        timestamp_us: int,
+        entry: _RoleQueueEntry,
         message_type: int = 0,
     ) -> bool:
         """Check if a binary message's playback time has passed and should be dropped.
@@ -1826,6 +1895,7 @@ class SendspinConnection:
         grace period (configurable per-role), late messages are allowed through to give
         clients time to build their initial buffer.
         """
+        timestamp_us = entry.timestamp_us
         # timestamp_us=0 means "no playback semantics" - skip late detection
         if handling is None or role is None or not handling.drop_late or timestamp_us == 0:
             return False
@@ -1847,11 +1917,11 @@ class SendspinConnection:
                 -late_by_us / 1000,
             )
             now_s = time.monotonic()
-            if now_s - role._last_late_log_s >= 1.0:  # noqa: SLF001
+            if now_s - role._last_late_log_s >= _WARN_INTERVAL_S:  # noqa: SLF001
                 qsize, qmax = self.queue_status()
                 self._logger.warning(
                     "Late binary type=%s role=%s: skipping %s chunk(s); "
-                    "late_by_us=%s ts_us=%s now_us=%s queue=%s/%s",
+                    "late_by_us=%s ts_us=%s now_us=%s queue=%s/%s %s",
                     message_type,
                     role.role_family,
                     role._late_skips_since_log,  # noqa: SLF001
@@ -1860,6 +1930,7 @@ class SendspinConnection:
                     now,
                     qsize,
                     qmax,
+                    self._late_binary_diagnostics(role, entry, now, elapsed),
                 )
                 role._late_skips_since_log = 0  # noqa: SLF001
                 role._last_late_log_s = now_s  # noqa: SLF001
@@ -1901,13 +1972,31 @@ class SendspinConnection:
         elapsed_ms = (time.monotonic() - start_s) * 1000
         if elapsed_ms >= 50.0:
             # Slow writes indicate transport/backpressure issues but are not fatal.
-            self._logger.debug(
-                "Slow send_bytes: %.1fms size=%s ts_us=%s role=%s",
-                elapsed_ms,
-                len(binary.data),
-                entry.timestamp_us,
-                role,
-            )
+            # Extreme stalls surface at WARNING (rate-limited) so default-level
+            # logs show transport backpressure alongside any late-binary drops.
+            if elapsed_ms >= 500.0:
+                self._slow_send_count += 1
+            now_s = time.monotonic()
+            if elapsed_ms >= 500.0 and now_s - self._last_slow_send_log_s >= _WARN_INTERVAL_S:
+                self._logger.warning(
+                    "Slow send_bytes: %.1fms size=%s ts_us=%s role=%s; "
+                    "%s stall(s) over 500ms since last report",
+                    elapsed_ms,
+                    len(binary.data),
+                    entry.timestamp_us,
+                    role,
+                    self._slow_send_count,
+                )
+                self._slow_send_count = 0
+                self._last_slow_send_log_s = now_s
+            else:
+                self._logger.debug(
+                    "Slow send_bytes: %.1fms size=%s ts_us=%s role=%s",
+                    elapsed_ms,
+                    len(binary.data),
+                    entry.timestamp_us,
+                    role,
+                )
 
         # Buffer tracking via role's tracker (framework-managed)
         if (
@@ -2112,9 +2201,7 @@ class SendspinConnection:
         if (
             handling is not None
             and handling_role is not None
-            and self._check_late_binary(
-                handling, handling_role, entry.timestamp_us, entry.binary.message_type
-            )
+            and self._check_late_binary(handling, handling_role, entry, entry.binary.message_type)
         ):
             self._discard_role_head(role)
             self._schedule_role_head(role)

--- a/tests/server/test_connection_writer.py
+++ b/tests/server/test_connection_writer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from dataclasses import dataclass
 from typing import Any, Never
 from unittest.mock import AsyncMock, MagicMock
@@ -21,6 +22,7 @@ from aiosendspin.models.core import (
 )
 from aiosendspin.models.player import StreamStartPlayer
 from aiosendspin.models.types import AudioCodec, BinaryMessageType
+from aiosendspin.server.audio import BufferTracker
 from aiosendspin.server.clock import LoopClock, ManualClock
 from aiosendspin.server.connection import (
     MAX_PENDING_MSG,
@@ -300,7 +302,8 @@ def test_check_late_binary_uses_player_effective_timestamp() -> None:
         handling = BinaryHandling(drop_late=True, grace_period_us=2_000_000)
 
         # Raw timestamp is still 4s in the future, but effective play time is 1s in the past.
-        assert conn._check_late_binary(handling, role, 14_000_000) is True  # noqa: SLF001
+        entry = _RoleQueueEntry(epoch=0, timestamp_us=14_000_000)
+        assert conn._check_late_binary(handling, role, entry) is True  # noqa: SLF001
     finally:
         loop.close()
 
@@ -617,5 +620,162 @@ def test_per_role_queue_limit_is_isolated_between_roles() -> None:
         assert len(conn._role_queues["player"]) == 1  # noqa: SLF001
         assert len(conn._role_queues["visualizer"]) == 1  # noqa: SLF001
         assert conn.disconnect.call_count == 0  # type: ignore[attr-defined]
+    finally:
+        loop.close()
+
+
+def _make_connection_with_droppable_client(
+    clock: ManualClock, loop: asyncio.AbstractEventLoop, *, drop_late: bool = True
+) -> SendspinConnection:
+    server = _DummyServer(loop=loop, clock=clock)
+    wsock = MagicMock()
+    wsock.closed = False
+    conn = SendspinConnection(server, wsock_client=wsock)
+    conn._transport = wsock  # noqa: SLF001
+    client = MagicMock()
+    client.active_roles = []
+    client.get_binary_handling_cached.return_value = (
+        BinaryHandling(drop_late=drop_late, grace_period_us=2_000_000),
+        MagicMock(),
+    )
+    conn._client = client  # noqa: SLF001
+    return conn
+
+
+def test_send_binary_warns_when_chunk_already_past_deadline(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Enqueuing a droppable chunk whose play window fully passed warns immediately."""
+    loop = asyncio.new_event_loop()
+    try:
+        clock = ManualClock(now_us_value=10_000_000)
+        conn = _make_connection_with_droppable_client(clock, loop)
+
+        with caplog.at_level(logging.WARNING):
+            conn.send_binary(
+                b"audio",
+                role="player",
+                timestamp_us=8_000_000,
+                message_type=BinaryMessageType.AUDIO_CHUNK.value,
+                duration_us=25_000,
+            )
+
+        assert "Enqueued already-late binary" in caplog.text
+        assert "behind_by_us=2000000" in caplog.text
+    finally:
+        loop.close()
+
+
+def test_send_binary_no_doomed_warning_without_drop_late(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Past timestamps on non-droppable message types are not flagged."""
+    loop = asyncio.new_event_loop()
+    try:
+        clock = ManualClock(now_us_value=10_000_000)
+        conn = _make_connection_with_droppable_client(clock, loop, drop_late=False)
+
+        with caplog.at_level(logging.WARNING):
+            conn.send_binary(
+                b"data",
+                role="visualizer",
+                timestamp_us=8_000_000,
+                message_type=BinaryMessageType.AUDIO_CHUNK.value,
+                duration_us=25_000,
+            )
+
+        assert "Enqueued already-late binary" not in caplog.text
+    finally:
+        loop.close()
+
+
+def test_late_binary_warning_reports_regime_diagnostics(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The late-drop warning includes enqueue lead, queue age and stream elapsed time."""
+    loop = asyncio.new_event_loop()
+    try:
+        clock = ManualClock(now_us_value=10_000_000)
+        server = _DummyServer(loop=loop, clock=clock)
+        wsock = MagicMock()
+        wsock.closed = False
+        conn = SendspinConnection(server, wsock_client=wsock)
+        conn._transport = wsock  # noqa: SLF001
+
+        role = PlayerV1Role(client=_make_player_client_stub())
+        role._stream_start_time_us = 0  # noqa: SLF001
+        handling = BinaryHandling(drop_late=True, grace_period_us=2_000_000)
+
+        entry = _RoleQueueEntry(epoch=0, timestamp_us=9_000_000, enqueued_at_us=8_500_000)
+        with caplog.at_level(logging.WARNING):
+            assert conn._check_late_binary(handling, role, entry) is True  # noqa: SLF001
+
+        assert "enq_lead_ms=500" in caplog.text
+        assert "queue_age_ms=1500" in caplog.text
+        assert "stream_elapsed_s=10.0" in caplog.text
+        # This role has no buffer tracker, so the buffer fields are left out
+        # rather than reported as placeholder values.
+        assert "buf_ms" not in caplog.text
+    finally:
+        loop.close()
+
+
+def test_late_binary_warning_reports_buffer_state_when_tracked(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With a buffer tracker present the warning reports the device buffer state."""
+    loop = asyncio.new_event_loop()
+    try:
+        clock = ManualClock(now_us_value=10_000_000)
+        server = _DummyServer(loop=loop, clock=clock)
+        wsock = MagicMock()
+        wsock.closed = False
+        conn = SendspinConnection(server, wsock_client=wsock)
+        conn._transport = wsock  # noqa: SLF001
+
+        role = PlayerV1Role(client=_make_player_client_stub())
+        role._stream_start_time_us = 0  # noqa: SLF001
+        tracker = BufferTracker(
+            clock=clock, client_id="p", capacity_bytes=200_000, max_duration_us=30_000_000
+        )
+        tracker.register(12_000_000, 4_000, 25_000)
+        role._state().buffer_tracker = tracker  # noqa: SLF001
+
+        entry = _RoleQueueEntry(epoch=0, timestamp_us=9_000_000, enqueued_at_us=8_500_000)
+        handling = BinaryHandling(drop_late=True, grace_period_us=2_000_000)
+        with caplog.at_level(logging.WARNING):
+            assert conn._check_late_binary(handling, role, entry) is True  # noqa: SLF001
+
+        assert "buf_ms=2000" in caplog.text
+        assert "buf_bytes=4000/200000" in caplog.text
+    finally:
+        loop.close()
+
+
+def test_late_binary_warning_is_throttled_across_a_burst(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A burst of late chunks yields one warning that carries the suppressed count."""
+    loop = asyncio.new_event_loop()
+    try:
+        clock = ManualClock(now_us_value=10_000_000)
+        server = _DummyServer(loop=loop, clock=clock)
+        wsock = MagicMock()
+        wsock.closed = False
+        conn = SendspinConnection(server, wsock_client=wsock)
+        conn._transport = wsock  # noqa: SLF001
+
+        role = PlayerV1Role(client=_make_player_client_stub())
+        role._stream_start_time_us = 0  # noqa: SLF001
+        handling = BinaryHandling(drop_late=True, grace_period_us=2_000_000)
+
+        with caplog.at_level(logging.WARNING):
+            for _ in range(5):
+                entry = _RoleQueueEntry(epoch=0, timestamp_us=9_000_000, enqueued_at_us=8_500_000)
+                assert conn._check_late_binary(handling, role, entry) is True  # noqa: SLF001
+
+        assert caplog.text.count("Late binary") == 1
+        # The suppressed drops still accumulate for the next warning to report.
+        assert role._late_skips_since_log == 4  # noqa: SLF001
     finally:
         loop.close()

--- a/tests/server/test_connection_writer.py
+++ b/tests/server/test_connection_writer.py
@@ -634,9 +634,11 @@ def _make_connection_with_droppable_client(
     conn._transport = wsock  # noqa: SLF001
     client = MagicMock()
     client.active_roles = []
+    role = MagicMock()
+    role.get_static_delay_us.return_value = 0
     client.get_binary_handling_cached.return_value = (
         BinaryHandling(drop_late=drop_late, grace_period_us=2_000_000),
-        MagicMock(),
+        role,
     )
     conn._client = client  # noqa: SLF001
     return conn
@@ -777,5 +779,36 @@ def test_late_binary_warning_is_throttled_across_a_burst(
         assert caplog.text.count("Late binary") == 1
         # The suppressed drops still accumulate for the next warning to report.
         assert role._late_skips_since_log == 4  # noqa: SLF001
+    finally:
+        loop.close()
+
+
+def test_late_binary_diagnostics_use_the_effective_play_time(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A static delay shifts the deadline, so enq_lead must agree with late_by_us."""
+    loop = asyncio.new_event_loop()
+    try:
+        clock = ManualClock(now_us_value=10_000_000)
+        server = _DummyServer(loop=loop, clock=clock)
+        wsock = MagicMock()
+        wsock.closed = False
+        conn = SendspinConnection(server, wsock_client=wsock)
+        conn._transport = wsock  # noqa: SLF001
+
+        role = PlayerV1Role(client=_make_player_client_stub())
+        role._stream_start_time_us = 0  # noqa: SLF001
+        role.static_delay_ms = 5_000
+
+        # Raw timestamp is 4s ahead, but the effective play time is 1s in the past.
+        entry = _RoleQueueEntry(epoch=0, timestamp_us=14_000_000, enqueued_at_us=9_500_000)
+        handling = BinaryHandling(drop_late=True, grace_period_us=2_000_000)
+        with caplog.at_level(logging.WARNING):
+            assert conn._check_late_binary(handling, role, entry) is True  # noqa: SLF001
+
+        # Reported against the same deadline as late_by_us, not the raw timestamp
+        # (which would have claimed a healthy +4500ms lead for a late chunk).
+        assert "enq_lead_ms=-500" in caplog.text
+        assert "late_by_us=1000000" in caplog.text
     finally:
         loop.close()


### PR DESCRIPTION
Late binary warnings only say that a chunk missed its deadline but not why, so telling a too small producer lead apart from a chunk that aged in the send queue meant enabling a VERBOSE logging session.

The warning now carries the lead the chunk had when it was queued, how long it then waited, the tracked device buffer, and the time since stream start. A new warning covers chunks that are already unplayable as they enter the queue, which points at the producer rather than the transport, and socket writes over 500ms are raised from debug to a warning reporting how many stalls it stands for. Repeats of all three are throttled to one line per 30 seconds, each carrying the count it represents, so a sustained fault keeps its magnitude without flooding the log.

Nothing changes about which chunks are sent or dropped; this is diagnostics only.
