### PR TITLE
Raise default `min_buffer_ms` to 1s

### DIFF
--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -71,7 +71,7 @@ class PlayerPersistentState:
     buffer_reset_handle: asyncio.TimerHandle | None = None
     static_delay_ms: int = 0
     required_lead_time_ms: int = 250
-    min_buffer_ms: int = 500
+    min_buffer_ms: int = 1000
     state_supported_commands: list[PlayerCommand] = field(default_factory=list)
     preferred_format_override: AudioFormat | None = None
     preferred_codec_override: AudioCodec | None = None

--- a/tests/integration/test_multi_player_timing_integration.py
+++ b/tests/integration/test_multi_player_timing_integration.py
@@ -585,7 +585,7 @@ async def test_multi_player_group_join_sync_stable_source() -> None:
 
     source_fmt = AudioFormat(sample_rate=48_000, bit_depth=16, channels=2)
 
-    next_play_start_us = clock.now_us() + 500_000
+    next_play_start_us = clock.now_us() + 1_000_000
 
     # Run 3 seconds virtual time; join B at t=1s.
     for i in range(120):  # 120 * 25ms = 3s
@@ -668,7 +668,7 @@ async def test_multi_player_sync_with_jittery_source_is_continuous() -> None:
 
     source_fmt = AudioFormat(sample_rate=48_000, bit_depth=16, channels=2)
 
-    next_play_start_us = clock.now_us() + 500_000
+    next_play_start_us = clock.now_us() + 1_000_000
 
     # Alternate 20ms and 30ms blocks (still "continuous" overall).
     pattern_frames = [960, 1440]  # 20ms, 30ms at 48kHz
@@ -741,7 +741,7 @@ async def test_production_gap_rebases_timeline() -> None:
     stream = group_a.start_stream()
     source_fmt = AudioFormat(sample_rate=48_000, bit_depth=16, channels=2)
 
-    next_play_start_us = clock.now_us() + 500_000
+    next_play_start_us = clock.now_us() + 1_000_000
 
     # Produce 1s of audio.
     for _ in range(40):
@@ -764,7 +764,7 @@ async def test_production_gap_rebases_timeline() -> None:
     )
     stream.prepare_audio(pcm, source_fmt)
     play_start_us = await stream.commit_audio()
-    assert resume_now_us + 500_000 <= play_start_us <= resume_now_us + 600_000
+    assert resume_now_us + 1_000_000 <= play_start_us <= resume_now_us + 1_100_000
 
     # Find the first audio chunk timestamp sent after the gap.
     first_after_gap_ts: int | None = None
@@ -776,7 +776,7 @@ async def test_production_gap_rebases_timeline() -> None:
         break
 
     assert first_after_gap_ts is not None
-    assert resume_now_us + 500_000 <= first_after_gap_ts <= resume_now_us + 600_000
+    assert resume_now_us + 1_000_000 <= first_after_gap_ts <= resume_now_us + 1_100_000
 
 
 @pytest.mark.asyncio
@@ -830,7 +830,7 @@ async def test_four_players_regroup_fast_start_and_sync() -> None:  # noqa: PLR0
     # 100ms per commit to ensure FLAC yields packets promptly.
     duration_us = 100_000
     frame_count = 4800  # 100ms @ 48kHz
-    next_play_start_us = clock.now_us() + 500_000
+    next_play_start_us = clock.now_us() + 1_000_000
 
     # Initial start latency (player A).
     first_idx_a = len(conn_a.events)
@@ -840,7 +840,7 @@ async def test_four_players_regroup_fast_start_and_sync() -> None:  # noqa: PLR0
     assert abs(play_start_us - next_play_start_us) <= 1_000
     ts_a = _first_audio_timestamp_after(conn_a.events, start_index=first_idx_a)
     assert ts_a is not None
-    assert 500_000 <= ts_a - clock.now_us() <= 600_000
+    assert 1_000_000 <= ts_a - clock.now_us() <= 1_100_000
     next_play_start_us = play_start_us + duration_us
 
     joins = _JoinTracker(clock)

--- a/tests/server/roles/test_player_v1.py
+++ b/tests/server/roles/test_player_v1.py
@@ -1010,13 +1010,13 @@ def test_on_client_state_no_event_if_unchanged() -> None:
 
 
 def test_timing_defaults() -> None:
-    """Lead time defaults to 250 ms and min buffer to 500 ms."""
+    """Lead time defaults to 250 ms and min buffer to 1000 ms."""
     client = _make_client_stub()
     role = PlayerV1Role(client=client)
     assert role.required_lead_time_ms == 250
-    assert role.min_buffer_ms == 500
+    assert role.min_buffer_ms == 1000
     assert role.get_required_lead_time_us() == 250_000
-    assert role.get_min_buffer_us() == 500_000
+    assert role.get_min_buffer_us() == 1_000_000
 
 
 def test_on_client_state_updates_required_lead_time() -> None:

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -272,8 +272,8 @@ async def test_late_join_target_includes_player_static_delay() -> None:
 
     stream = PushStream(loop=loop, clock=clock, group=group)
 
-    # now + max(min_buffer=500ms, required_lead=250ms) + static_delay=5s
-    assert stream.get_late_join_target_timestamp_us(role=role) == 6_500_000
+    # now + max(min_buffer=1000ms, required_lead=250ms) + static_delay=5s
+    assert stream.get_late_join_target_timestamp_us(role=role) == 7_000_000
 
 
 @pytest.mark.asyncio
@@ -356,7 +356,7 @@ async def test_non_main_join_rebase_includes_player_static_delay() -> None:
 
     stream._rebase_far_ahead_join_tail(channel_id, role)  # noqa: SLF001
 
-    assert stream._channel_timing[channel_id] == 6_500_000  # noqa: SLF001
+    assert stream._channel_timing[channel_id] == 7_000_000  # noqa: SLF001
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A client that advertises no timing preferences falls back to the server default, so most ESPHome players run on it. At 500ms that is the entire jitter budget for a device on WiFi, where hiccups of one to two seconds are possible.

Measured against the late chunk timings in music-assistant/support#6006, moving from the 250ms those reports ran on to 500ms accounts for about 40% of the drops, and 1s for about 80%. The cost is 500ms of extra scheduling lead before the first chunk plays.

Follows the same reasoning as #285, which raised this default from 250ms to 500ms.

This will of course not be needed anymore once proper measurement is implemented (powered by https://github.com/Sendspin/spec/pull/167)