### PR TITLE
Implement spec PR #168: letterbox art, rename media_width/media_height, drop BMP

### DIFF
--- a/aiosendspin/models/artwork.py
+++ b/aiosendspin/models/artwork.py
@@ -9,9 +9,30 @@ preferred format and resolution.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 from .base import SendspinConfig, SendspinModel
 from .types import ArtworkSource, PictureFormat
+
+# Pre-rename dimension keys, superseded by `width`/`height`.
+_DIMENSION_ALIASES = {"media_width": "width", "media_height": "height"}
+
+
+def _rewrite_legacy_dimensions(d: dict[str, Any]) -> dict[str, Any]:
+    """Rewrite pre-rename dimension keys onto width/height, recording which were used."""
+    normalized = dict(d)
+    legacy_keys: list[str] = []
+    for legacy_key, current_key in _DIMENSION_ALIASES.items():
+        if legacy_key not in normalized:
+            continue
+        legacy_keys.append(legacy_key)
+        value = normalized.pop(legacy_key)
+        # Rewrite only when the client didn't also send the current key.
+        if current_key not in normalized:
+            normalized[current_key] = value
+    # Always overwrite so a client cannot spoof the record via the wire.
+    normalized["legacy_dimension_keys"] = legacy_keys or None
+    return normalized
 
 
 @dataclass
@@ -26,6 +47,14 @@ class ArtworkChannel(SendspinModel):
     """Width in pixels of the delivered image."""
     height: int
     """Height in pixels of the delivered image."""
+    legacy_dimension_keys: list[str] | None = None
+    """Pre-rename dimension keys the parser rewrote, recorded for the server to flag.
+    Not part of the wire schema (omitted when None)."""
+
+    @classmethod
+    def __pre_deserialize__(cls, d: dict[str, Any]) -> dict[str, Any]:
+        """Accept the pre-rename `media_width`/`media_height` spelling."""
+        return _rewrite_legacy_dimensions(d)
 
     def __post_init__(self) -> None:
         """Validate field values."""
@@ -33,6 +62,11 @@ class ArtworkChannel(SendspinModel):
             raise ValueError(f"width must be positive, got {self.width}")
         if self.height <= 0:
             raise ValueError(f"height must be positive, got {self.height}")
+
+    class Config(SendspinConfig):
+        """Config for parsing json messages."""
+
+        omit_none = True
 
 
 # Client -> Server: client/hello artwork support object
@@ -91,6 +125,14 @@ class StreamRequestFormatArtwork(SendspinModel):
     """Requested width in pixels."""
     height: int | None = None
     """Requested height in pixels."""
+    legacy_dimension_keys: list[str] | None = None
+    """Pre-rename dimension keys the parser rewrote, recorded for the role to flag.
+    Not part of the wire schema (omitted when None)."""
+
+    @classmethod
+    def __pre_deserialize__(cls, d: dict[str, Any]) -> dict[str, Any]:
+        """Accept the pre-rename `media_width`/`media_height` spelling."""
+        return _rewrite_legacy_dimensions(d)
 
     def __post_init__(self) -> None:
         """Validate field values."""

--- a/aiosendspin/models/artwork.py
+++ b/aiosendspin/models/artwork.py
@@ -22,17 +22,17 @@ class ArtworkChannel(SendspinModel):
     """Artwork source type."""
     format: PictureFormat
     """Image format identifier."""
-    media_width: int
-    """Max width in pixels."""
-    media_height: int
-    """Max height in pixels."""
+    width: int
+    """Width in pixels of the delivered image."""
+    height: int
+    """Height in pixels of the delivered image."""
 
     def __post_init__(self) -> None:
         """Validate field values."""
-        if self.media_width <= 0:
-            raise ValueError(f"media_width must be positive, got {self.media_width}")
-        if self.media_height <= 0:
-            raise ValueError(f"media_height must be positive, got {self.media_height}")
+        if self.width <= 0:
+            raise ValueError(f"width must be positive, got {self.width}")
+        if self.height <= 0:
+            raise ValueError(f"height must be positive, got {self.height}")
 
 
 # Client -> Server: client/hello artwork support object
@@ -87,10 +87,10 @@ class StreamRequestFormatArtwork(SendspinModel):
     """Artwork source type."""
     format: PictureFormat | None = None
     """Requested image format identifier."""
-    media_width: int | None = None
-    """Requested max width in pixels."""
-    media_height: int | None = None
-    """Requested max height in pixels."""
+    width: int | None = None
+    """Requested width in pixels."""
+    height: int | None = None
+    """Requested height in pixels."""
 
     def __post_init__(self) -> None:
         """Validate field values."""

--- a/aiosendspin/models/types.py
+++ b/aiosendspin/models/types.py
@@ -187,6 +187,8 @@ class MediaCommand(Enum):
 class PictureFormat(Enum):
     """Supported image formats for artwork/media art."""
 
+    # Removed from the spec, still served to clients that declare it.
+    BMP = "bmp"
     JPEG = "jpeg"
     PNG = "png"
 

--- a/aiosendspin/models/types.py
+++ b/aiosendspin/models/types.py
@@ -187,7 +187,6 @@ class MediaCommand(Enum):
 class PictureFormat(Enum):
     """Supported image formats for artwork/media art."""
 
-    BMP = "bmp"
     JPEG = "jpeg"
     PNG = "png"
 

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -97,6 +97,7 @@ from aiosendspin.models.types import (
     ManagementResult,
     PairAbortReason,
     PairMethod,
+    PictureFormat,
     PlaybackStateType,
     Roles,
     ServerMessage,
@@ -134,6 +135,8 @@ from .roles.negotiation import negotiate_roles
 from .roles.registry import ROLE_FACTORIES, ROLE_SUPPORT_SPECS, role_requires_pairing
 
 if TYPE_CHECKING:
+    from aiosendspin.models.artwork import ClientHelloArtworkSupport
+
     from .audio import BufferTracker
     from .group import SendspinGroup
     from .roles.base import BinaryHandling, Role
@@ -1093,6 +1096,8 @@ class SendspinConnection:
                 "client/hello sent support objects for unlisted roles: "
                 + ", ".join(client_info.unlisted_support_roles)
             )
+        if client_info.artwork_support is not None:
+            self._flag_legacy_artwork_wire(client_info.artwork_support)
         if unimplemented := self._unimplemented_roles(client_info.supported_roles):
             self._logger.info(
                 "Client offered roles/versions this server does not implement: %s", unimplemented
@@ -1127,6 +1132,18 @@ class SendspinConnection:
                 client_info, negotiated_roles=self._negotiated_roles
             )
         return True
+
+    def _flag_legacy_artwork_wire(self, support: ClientHelloArtworkSupport) -> None:
+        """Flag artwork channels declared on the wire the spec superseded."""
+        legacy_keys = sorted(
+            {key for channel in support.channels for key in channel.legacy_dimension_keys or ()}
+        )
+        if legacy_keys:
+            self._flag_noncompliance(
+                "client/hello artwork used pre-rename dimension keys: " + ", ".join(legacy_keys)
+            )
+        if any(channel.format is PictureFormat.BMP for channel in support.channels):
+            self._flag_noncompliance("client/hello artwork declared the removed 'bmp' format")
 
     async def _admit_legacy_client_id(self, client_id: str) -> bool:
         """Whether an unauthenticated (legacy) hello may claim ``client_id``."""

--- a/aiosendspin/server/roles/artwork/group.py
+++ b/aiosendspin/server/roles/artwork/group.py
@@ -81,8 +81,8 @@ class ArtworkGroupRole(GroupRole):
             img_data = await asyncio.to_thread(
                 self._process_and_encode_image,
                 image,
-                channel_config.media_width,
-                channel_config.media_height,
+                channel_config.width,
+                channel_config.height,
                 channel_config.format,
             )
             role.send_artwork(channel, img_data, timestamp_us)
@@ -195,8 +195,6 @@ class ArtworkGroupRole(GroupRole):
                 resized_image.save(img_bytes, format="JPEG", quality=85)
             elif art_format == PictureFormat.PNG:
                 resized_image.save(img_bytes, format="PNG", compress_level=6)
-            elif art_format == PictureFormat.BMP:
-                resized_image.save(img_bytes, format="BMP")
             else:
                 raise NotImplementedError(f"Unsupported artwork format: {art_format}")
             img_bytes.seek(0)

--- a/aiosendspin/server/roles/artwork/group.py
+++ b/aiosendspin/server/roles/artwork/group.py
@@ -195,6 +195,8 @@ class ArtworkGroupRole(GroupRole):
                 resized_image.save(img_bytes, format="JPEG", quality=85)
             elif art_format == PictureFormat.PNG:
                 resized_image.save(img_bytes, format="PNG", compress_level=6)
+            elif art_format == PictureFormat.BMP:
+                resized_image.save(img_bytes, format="BMP")
             else:
                 raise NotImplementedError(f"Unsupported artwork format: {art_format}")
             img_bytes.seek(0)

--- a/aiosendspin/server/roles/artwork/v1.py
+++ b/aiosendspin/server/roles/artwork/v1.py
@@ -24,7 +24,7 @@ from aiosendspin.models.core import (
     StreamStartMessage,
     StreamStartPayload,
 )
-from aiosendspin.models.types import ArtworkSource
+from aiosendspin.models.types import ArtworkSource, PictureFormat
 from aiosendspin.server.roles.artwork.group import ArtworkGroupRole
 from aiosendspin.server.roles.base import Role
 
@@ -184,6 +184,8 @@ class ArtworkV1Role(Role):
             )
             return
 
+        self._flag_legacy_artwork_wire(artwork_request)
+
         invalid_dims = [
             name
             for name, value in (
@@ -202,6 +204,18 @@ class ArtworkV1Role(Role):
             return
 
         self._update_channel_config(artwork_request)
+
+    def _flag_legacy_artwork_wire(self, request: StreamRequestFormatArtwork) -> None:
+        """Flag a request phrased on the wire the spec superseded."""
+        if request.legacy_dimension_keys:
+            self._client.flag_noncompliance(
+                "stream/request-format artwork used pre-rename dimension keys: "
+                + ", ".join(request.legacy_dimension_keys)
+            )
+        if request.format is PictureFormat.BMP:
+            self._client.flag_noncompliance(
+                "stream/request-format artwork requested the removed 'bmp' format"
+            )
 
     def _update_channel_config(self, request: StreamRequestFormatArtwork) -> None:
         """Update channel config from a request and send updated stream/start."""

--- a/aiosendspin/server/roles/artwork/v1.py
+++ b/aiosendspin/server/roles/artwork/v1.py
@@ -112,8 +112,8 @@ class ArtworkV1Role(Role):
                 StreamArtworkChannelConfig(
                     source=channel.source,
                     format=channel.format,
-                    width=channel.media_width,
-                    height=channel.media_height,
+                    width=channel.width,
+                    height=channel.height,
                 )
             )
 
@@ -187,8 +187,8 @@ class ArtworkV1Role(Role):
         invalid_dims = [
             name
             for name, value in (
-                ("media_width", artwork_request.media_width),
-                ("media_height", artwork_request.media_height),
+                ("width", artwork_request.width),
+                ("height", artwork_request.height),
             )
             if value is not None and value <= 0
         ]
@@ -210,12 +210,8 @@ class ArtworkV1Role(Role):
         updated = ArtworkChannel(
             source=request.source if request.source is not None else current.source,
             format=request.format if request.format is not None else current.format,
-            media_width=request.media_width
-            if request.media_width is not None
-            else current.media_width,
-            media_height=request.media_height
-            if request.media_height is not None
-            else current.media_height,
+            width=request.width if request.width is not None else current.width,
+            height=request.height if request.height is not None else current.height,
         )
 
         self._channel_configs[request.channel] = updated

--- a/tests/server/roles/artwork/test_group.py
+++ b/tests/server/roles/artwork/test_group.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+from io import BytesIO
 from unittest.mock import MagicMock
 
 import pytest
 from PIL import Image
 
-from aiosendspin.models.types import ArtworkSource
+from aiosendspin.models.types import ArtworkSource, PictureFormat
 from aiosendspin.server.roles.artwork.events import ArtworkClearedEvent, ArtworkUpdatedEvent
 from aiosendspin.server.roles.artwork.group import ArtworkGroupRole
 
@@ -54,3 +55,26 @@ async def test_clear_album_artwork_emits_cleared_event() -> None:
     assert event.source == ArtworkSource.ALBUM
     assert event.timestamp_us == 123_456
     assert agr.get_album_artwork() is None
+
+
+def test_encode_letterboxes_to_the_declared_dimensions() -> None:
+    """An off-aspect source is padded to exactly the declared size, never cropped."""
+    agr = ArtworkGroupRole(_make_group_stub())
+    image = Image.new("RGB", (400, 400), (255, 0, 0))
+
+    encoded = agr._process_and_encode_image(image, 800, 480, PictureFormat.PNG)  # noqa: SLF001
+
+    with Image.open(BytesIO(encoded)) as decoded:
+        assert decoded.size == (800, 480)
+        assert decoded.convert("RGB").getpixel((0, 0)) == (0, 0, 0)
+
+
+def test_encode_still_supports_bmp() -> None:
+    """A client declaring the removed 'bmp' format still gets a BMP image."""
+    agr = ArtworkGroupRole(_make_group_stub())
+    image = Image.new("RGB", (400, 400), (255, 0, 0))
+
+    encoded = agr._process_and_encode_image(image, 320, 320, PictureFormat.BMP)  # noqa: SLF001
+
+    with Image.open(BytesIO(encoded)) as decoded:
+        assert decoded.format == "BMP"

--- a/tests/server/roles/artwork/test_v1.py
+++ b/tests/server/roles/artwork/test_v1.py
@@ -64,6 +64,37 @@ def test_artwork_role_flags_nonpositive_request_dimensions() -> None:
     client.flag_noncompliance.assert_called_once()
 
 
+def test_artwork_role_applies_and_flags_pre_rename_request_dimensions() -> None:
+    """A stream/request-format phrased as media_width/media_height resizes, and is flagged."""
+    client = _make_client_stub_with_channel()
+    role = ArtworkV1Role(client=client)
+    role.on_connect()
+    role.on_stream_request_format(
+        StreamRequestFormatPayload(
+            artwork=StreamRequestFormatArtwork.from_dict(
+                {"channel": 0, "media_width": 800, "media_height": 480}
+            )
+        )
+    )
+    config = role.get_channel_configs()[0]
+    assert (config.width, config.height) == (800, 480)
+    assert "media_width" in client.flag_noncompliance.call_args.args[0]
+
+
+def test_artwork_role_flags_bmp_request_format() -> None:
+    """A stream/request-format asking for the removed 'bmp' format is flagged, not rejected."""
+    client = _make_client_stub_with_channel()
+    role = ArtworkV1Role(client=client)
+    role.on_connect()
+    role.on_stream_request_format(
+        StreamRequestFormatPayload(
+            artwork=StreamRequestFormatArtwork(channel=0, format=PictureFormat.BMP)
+        )
+    )
+    assert "bmp" in client.flag_noncompliance.call_args.args[0]
+    assert role.get_channel_configs()[0].format == PictureFormat.BMP
+
+
 def test_artwork_role_no_flag_for_valid_request_dimensions() -> None:
     """A stream/request-format with positive dimensions is not flagged."""
     client = _make_client_stub_with_channel()

--- a/tests/server/roles/artwork/test_v1.py
+++ b/tests/server/roles/artwork/test_v1.py
@@ -39,8 +39,8 @@ def _make_client_stub_with_channel() -> MagicMock:
         ArtworkChannel(
             source=ArtworkSource.ALBUM,
             format=PictureFormat.JPEG,
-            media_width=300,
-            media_height=300,
+            width=300,
+            height=300,
         )
     ]
     return client
@@ -59,7 +59,7 @@ def test_artwork_role_flags_nonpositive_request_dimensions() -> None:
     role = ArtworkV1Role(client=client)
     role.on_connect()
     role.on_stream_request_format(
-        StreamRequestFormatPayload(artwork=StreamRequestFormatArtwork(channel=0, media_width=-10))
+        StreamRequestFormatPayload(artwork=StreamRequestFormatArtwork(channel=0, width=-10))
     )
     client.flag_noncompliance.assert_called_once()
 
@@ -71,7 +71,7 @@ def test_artwork_role_no_flag_for_valid_request_dimensions() -> None:
     role.on_connect()
     role.on_stream_request_format(
         StreamRequestFormatPayload(
-            artwork=StreamRequestFormatArtwork(channel=0, media_width=100, media_height=100)
+            artwork=StreamRequestFormatArtwork(channel=0, width=100, height=100)
         )
     )
     client.flag_noncompliance.assert_not_called()
@@ -171,14 +171,14 @@ def test_artwork_role_init_channel_configs_from_support() -> None:
         ArtworkChannel(
             source=ArtworkSource.ALBUM,
             format=PictureFormat.JPEG,
-            media_width=300,
-            media_height=300,
+            width=300,
+            height=300,
         ),
         ArtworkChannel(
             source=ArtworkSource.ARTIST,
             format=PictureFormat.PNG,
-            media_width=400,
-            media_height=400,
+            width=400,
+            height=400,
         ),
     ]
     client.info.artwork_support = support
@@ -200,8 +200,8 @@ def test_artwork_role_sends_stream_start_on_connect_with_transport() -> None:
         ArtworkChannel(
             source=ArtworkSource.ALBUM,
             format=PictureFormat.JPEG,
-            media_width=300,
-            media_height=300,
+            width=300,
+            height=300,
         ),
     ]
     client.info.artwork_support = support
@@ -273,14 +273,14 @@ def test_artwork_role_on_connect_schedules_artwork_once_per_channel() -> None:
         ArtworkChannel(
             source=ArtworkSource.ALBUM,
             format=PictureFormat.JPEG,
-            media_width=300,
-            media_height=300,
+            width=300,
+            height=300,
         ),
         ArtworkChannel(
             source=ArtworkSource.ARTIST,
             format=PictureFormat.PNG,
-            media_width=400,
-            media_height=400,
+            width=400,
+            height=400,
         ),
     ]
     client.info.artwork_support = support
@@ -312,8 +312,8 @@ def test_artwork_partial_format_request_preserves_unchanged_fields() -> None:
         ArtworkChannel(
             source=ArtworkSource.ALBUM,
             format=PictureFormat.JPEG,
-            media_width=300,
-            media_height=300,
+            width=300,
+            height=300,
         ),
     ]
     client.info.artwork_support = support
@@ -329,5 +329,5 @@ def test_artwork_partial_format_request_preserves_unchanged_fields() -> None:
     configs = role.get_channel_configs()
     assert configs[0].format == PictureFormat.PNG
     assert configs[0].source == ArtworkSource.ALBUM
-    assert configs[0].media_width == 300
-    assert configs[0].media_height == 300
+    assert configs[0].width == 300
+    assert configs[0].height == 300

--- a/tests/server/test_multi_server.py
+++ b/tests/server/test_multi_server.py
@@ -682,8 +682,8 @@ class TestCustomRoleSupportParsing:
                         {
                             "source": "album",
                             "format": "jpeg",
-                            "media_width": 300,
-                            "media_height": 300,
+                            "width": 300,
+                            "height": 300,
                         }
                     ]
                 },

--- a/tests/server/test_multi_server.py
+++ b/tests/server/test_multi_server.py
@@ -362,6 +362,68 @@ class TestEncryptedActivities:
         assert await conn._exchange_hellos() is False  # noqa: SLF001
         assert "client-1" not in strict_server._clients  # noqa: SLF001
 
+    @staticmethod
+    def _pre_rename_artwork_hello() -> str:
+        return orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "client-1",
+                    "name": "client-1",
+                    "version": 1,
+                    "supported_roles": ["artwork@v1"],
+                    "artwork@v1_support": {
+                        "channels": [
+                            {
+                                "source": "album",
+                                "format": "bmp",
+                                "media_width": 300,
+                                "media_height": 200,
+                            }
+                        ]
+                    },
+                },
+            }
+        ).decode()
+
+    @staticmethod
+    def _prime_encrypted_hello(conn: SendspinConnection, raw: str) -> None:
+        psk = generate_psk()
+        conn._client_id = "client-1"  # noqa: SLF001
+        conn._noise_psk = ResolvedPsk(  # noqa: SLF001
+            psk_id=psk_id_for(psk),
+            psk=psk,
+            category=PskCategory.LONG_TERM,
+            counterparty_id="client-1",
+        )
+        conn._transport = _FakeTransport([WSMessage(WSMsgType.TEXT, raw, "")])  # type: ignore[assignment]  # noqa: SLF001
+
+    @pytest.mark.asyncio
+    async def test_pre_rename_artwork_hello_admitted_and_logged(
+        self, mock_server: _MockServer, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A pre-rename artwork hello is admitted, with both deviations logged."""
+        conn = SendspinConnection(mock_server, wsock_client=AsyncMock())
+        self._prime_encrypted_hello(conn, self._pre_rename_artwork_hello())
+
+        with caplog.at_level("INFO"):
+            assert await conn._exchange_hellos() is True  # noqa: SLF001
+        assert "pre-rename dimension keys" in caplog.text
+        assert "'bmp' format" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_strict_server_rejects_pre_rename_artwork_hello(self) -> None:
+        """Strict mode rejects the pre-rename artwork wire instead of tolerating it."""
+        loop = asyncio.get_running_loop()
+        strict_server = _MockServer(
+            loop=loop, clock=LoopClock(loop), allow_noncompliant_clients=False
+        )
+        conn = SendspinConnection(strict_server, wsock_client=AsyncMock())
+        self._prime_encrypted_hello(conn, self._pre_rename_artwork_hello())
+
+        assert await conn._exchange_hellos() is False  # noqa: SLF001
+        assert "client-1" not in strict_server._clients  # noqa: SLF001
+
     @pytest.mark.asyncio
     async def test_message_loop_hard_rejects_on_compliance_error(
         self, mock_server: _MockServer
@@ -747,6 +809,37 @@ class TestCustomRoleSupportParsing:
 
         with pytest.raises(ValueError, match=missing_support_key):
             SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
+
+    def test_deserialize_artwork_hello_accepts_pre_rename_dimensions(self) -> None:
+        """media_width/media_height are rewritten to width/height and recorded."""
+        raw = orjson.dumps(
+            {
+                "type": "client/hello",
+                "payload": {
+                    "client_id": "c1",
+                    "name": "Client",
+                    "version": 1,
+                    "supported_roles": ["artwork@v1"],
+                    "artwork@v1_support": {
+                        "channels": [
+                            {
+                                "source": "album",
+                                "format": "jpeg",
+                                "media_width": 300,
+                                "media_height": 200,
+                            }
+                        ]
+                    },
+                },
+            }
+        ).decode()
+
+        msg = SendspinConnection._deserialize_client_message(raw)  # noqa: SLF001
+        assert isinstance(msg, ClientHelloMessage)
+        assert msg.payload.artwork_support is not None
+        channel = msg.payload.artwork_support.channels[0]
+        assert (channel.width, channel.height) == (300, 200)
+        assert channel.legacy_dimension_keys == ["media_width", "media_height"]
 
     def test_deserialize_client_hello_records_legacy_support_key_use(self) -> None:
         """Unversioned support keys are rewritten to v1 aliases and recorded, not logged."""

--- a/tests/test_client_protocol_callbacks.py
+++ b/tests/test_client_protocol_callbacks.py
@@ -268,8 +268,8 @@ async def test_artwork_listener_receives_binary_frames_after_artwork_stream_star
                 ArtworkChannel(
                     source=ArtworkSource.ALBUM,
                     format=PictureFormat.JPEG,
-                    media_width=256,
-                    media_height=256,
+                    width=256,
+                    height=256,
                 )
             ]
         ),
@@ -309,8 +309,8 @@ def _artwork_support() -> ClientHelloArtworkSupport:
             ArtworkChannel(
                 source=ArtworkSource.ALBUM,
                 format=PictureFormat.JPEG,
-                media_width=256,
-                media_height=256,
+                width=256,
+                height=256,
             )
         ]
     )


### PR DESCRIPTION
## Summary

Implements [spec PR #168](https://github.com/Sendspin/spec/pull/168) ("Letterbox art and remove BMP support"), which aiosendspin hadn't caught up to yet:

- `ArtworkChannel` (the `artwork@v1_support` object in `client/hello`) and `StreamRequestFormatArtwork` (`stream/request-format`): `media_width`/`media_height` → `width`/`height`.
- `PictureFormat`: `'bmp'` is out of the spec's format set (servers must support `'jpeg'` and `'png'`), but stays parseable and encodable for clients that still declare it.
- Letterboxing (scale to fit + pad the remaining area with black, never crop) was **already implemented** in `ArtworkGroupRole._letterbox_image` — no behavior change needed there, it already matches the new "deliver at exactly `width` x `height`" requirement.
- Both superseded spellings stay accepted: `media_width`/`media_height` are rewritten to `width`/`height` on parse, and a `'bmp'` declaration is still served as BMP. Each routes through `flag_noncompliance`, so a lenient server logs once and keeps working while `allow_noncompliant_clients=False` rejects the client.

## Why now

This was surfaced by [Sendspin/sendspin-jvm#33](https://github.com/Sendspin/sendspin-jvm/pull/33) adopting the new field names ahead of aiosendspin. Once that merged, `Sendspin/conformance`'s cross-SDK matrix started failing every `aiosendspin -> sendspin-jvm` scenario (9 of them) — not just the artwork one — because aiosendspin was rejecting `client/hello` outright as malformed (`media_width`/`media_height` are required fields, and sendspin-jvm no longer sends them). See [Sendspin/conformance#107](https://github.com/Sendspin/conformance/pull/107) for the client-side half of this (the conformance harness's own artwork-scenario code also constructed `ArtworkChannel` with the old kwarg names).

## Test plan

- [x] `pytest tests/server/roles/artwork/ tests/test_client_protocol_callbacks.py tests/server/test_multi_server.py` — 114 passed
- [x] Full repo suite otherwise unaffected — 9 pre-existing failures elsewhere in this sandbox are native `av`/PyAV extension loading timeouts (confirmed unrelated: none touch `artwork`/`PictureFormat`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
