### PR TITLE
Drop unused `isort` and `syrupy` dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ asrc = [
 [dependency-groups]
 dev = [
   "codespell==2.4.3",
-  "isort==8.0.1",
   "mypy==2.3.1",
   "pre-commit==4.6.2",
   "pre-commit-hooks==6.0.0",
@@ -57,7 +56,6 @@ dev = [
   "pytest-cov==7.1.0",
   "pytest-timeout==2.4.0",
   "pytest-xdist==3.8.0",
-  "syrupy==5.5.3",
   "tomli==2.4.1",
   "ruff==0.16.6",
 ]


### PR DESCRIPTION
Neither tool is invoked in this repo. `isort` appears only as the dev pin and as `[tool.ruff.lint.isort]` (which configures ruff's own implementation); it is absent from `.pre-commit-config.yaml`, `scripts/`, and CI, where import sorting is ruff's `I001`. `syrupy` has no importer at all: no `import syrupy`, no `__snapshots__` directory, no `.ambr` files.

Both arrived in the initial commit as scaffold carryover (`isort==6.0.1`, `syrupy==4.9.1`) and dependabot has been walking them up ever since, most recently as two open major bumps (#347, #346) for tools nothing runs.

`uv sync --group dev --all-extras` then `pre-commit run -a` and `pytest` are unaffected: 1603 passed, 1 skipped.