### PR TITLE
Implement spec PR #164: rename static_delay_ms to output_delay_ms

### DIFF
--- a/aiosendspin/client/client.py
+++ b/aiosendspin/client/client.py
@@ -144,7 +144,7 @@ class SendspinClient:
     _owns_session: bool
     """Whether this client owns and should close the session."""
 
-    _static_delay_us: int = 0
+    _output_delay_us: int = 0
     """Default static playback delay seeding new connections, in microseconds."""
     _required_lead_time_us: int = 250_000
     """Reported startup lead time in microseconds."""
@@ -217,7 +217,7 @@ class SendspinClient:
         visualizer_support: ClientHelloVisualizerSupport | None = None,
         source_support: ClientHelloSourceSupport | None = None,
         session: ClientSession | None = None,
-        static_delay_ms: float = 0.0,
+        output_delay_ms: float = 0.0,
         required_lead_time_ms: float = 250.0,
         min_buffer_ms: float = 250.0,
         initial_volume: int = 100,
@@ -274,7 +274,7 @@ class SendspinClient:
         self._loop = asyncio.get_running_loop()
         self._initial_volume = initial_volume
         self._initial_muted = initial_muted
-        self.set_static_delay_ms(static_delay_ms)
+        self.set_output_delay_ms(output_delay_ms)
         self.set_required_lead_time_ms(required_lead_time_ms)
         self.set_min_buffer_ms(min_buffer_ms)
         self._state_supported_commands: list[PlayerCommand] = list(state_supported_commands or [])
@@ -485,9 +485,9 @@ class SendspinClient:
         return self._clock
 
     @property
-    def static_delay_us(self) -> int:
+    def output_delay_us(self) -> int:
         """Default static playback delay seeding new connections, in microseconds."""
-        return self._static_delay_us
+        return self._output_delay_us
 
     # --- Connection state ---
 
@@ -518,22 +518,22 @@ class SendspinClient:
         return self._admitted_connection.activities
 
     @property
-    def static_delay_ms(self) -> float:
+    def output_delay_ms(self) -> float:
         """Return the currently configured static playback delay in milliseconds."""
         if self._admitted_connection is not None:
-            return self._admitted_connection.static_delay_ms
-        return self._static_delay_us / 1_000.0
+            return self._admitted_connection.output_delay_ms
+        return self._output_delay_us / 1_000.0
 
-    def set_static_delay_ms(self, delay_ms: float) -> None:
+    def set_output_delay_ms(self, delay_ms: float) -> None:
         """Update the static playback delay applied after clock synchronisation."""
         delay_ms = max(0.0, min(5000.0, delay_ms))
         delay_us = round(delay_ms * 1_000.0)
         if self._admitted_connection is not None:
-            self._admitted_connection.set_static_delay_ms(delay_ms)
-        if delay_us == self._static_delay_us:
+            self._admitted_connection.set_output_delay_ms(delay_ms)
+        if delay_us == self._output_delay_us:
             return
-        self._static_delay_us = delay_us
-        logger.info("Set static playback delay to %.1f ms", self.static_delay_ms)
+        self._output_delay_us = delay_us
+        logger.info("Set static playback delay to %.1f ms", self.output_delay_ms)
 
     @property
     def required_lead_time_ms(self) -> float:
@@ -815,15 +815,15 @@ class SendspinClient:
         return self._admitted_connection.is_time_synchronized()
 
     def compute_play_time(self, server_timestamp_us: int) -> int:
-        """Convert a server timestamp to client play time, with static delay applied."""
+        """Convert a server timestamp to client play time, with output delay applied."""
         if self._admitted_connection is None:
-            return self.now_us() + UNSYNCED_PLAY_LEAD_US - self._static_delay_us
+            return self.now_us() + UNSYNCED_PLAY_LEAD_US - self._output_delay_us
         return self._admitted_connection.compute_play_time(server_timestamp_us)
 
     def compute_server_time(self, client_timestamp_us: int) -> int:
-        """Convert a client timestamp to a server timestamp, with static delay removed."""
+        """Convert a client timestamp to a server timestamp, with output delay removed."""
         if self._admitted_connection is None:
-            return client_timestamp_us + self._static_delay_us
+            return client_timestamp_us + self._output_delay_us
         return self._admitted_connection.compute_server_time(client_timestamp_us)
 
     def now_us(self) -> int:
@@ -931,7 +931,7 @@ class SendspinClient:
 
         To convert server timestamps to client play time (monotonic client clock),
         use the compute_play_time() and compute_server_time() methods provided
-        by this client instance. These handle time synchronization and static delay
+        by this client instance. These handle time synchronization and output delay
         automatically.
 
         Returns:

--- a/aiosendspin/client/client.py
+++ b/aiosendspin/client/client.py
@@ -145,7 +145,7 @@ class SendspinClient:
     """Whether this client owns and should close the session."""
 
     _output_delay_us: int = 0
-    """Default static playback delay seeding new connections, in microseconds."""
+    """Default output delay seeding new connections, in microseconds."""
     _required_lead_time_us: int = 250_000
     """Reported startup lead time in microseconds."""
     _min_buffer_us: int = 250_000
@@ -486,7 +486,7 @@ class SendspinClient:
 
     @property
     def output_delay_us(self) -> int:
-        """Default static playback delay seeding new connections, in microseconds."""
+        """Default output delay seeding new connections, in microseconds."""
         return self._output_delay_us
 
     # --- Connection state ---
@@ -519,13 +519,13 @@ class SendspinClient:
 
     @property
     def output_delay_ms(self) -> float:
-        """Return the currently configured static playback delay in milliseconds."""
+        """Return the currently configured output delay in milliseconds."""
         if self._admitted_connection is not None:
             return self._admitted_connection.output_delay_ms
         return self._output_delay_us / 1_000.0
 
     def set_output_delay_ms(self, delay_ms: float) -> None:
-        """Update the static playback delay applied after clock synchronisation."""
+        """Update the output delay applied after clock synchronisation."""
         delay_ms = max(0.0, min(5000.0, delay_ms))
         delay_us = round(delay_ms * 1_000.0)
         if self._admitted_connection is not None:
@@ -533,7 +533,7 @@ class SendspinClient:
         if delay_us == self._output_delay_us:
             return
         self._output_delay_us = delay_us
-        logger.info("Set static playback delay to %.1f ms", self.output_delay_ms)
+        logger.info("Set output delay to %.1f ms", self.output_delay_ms)
 
     @property
     def required_lead_time_ms(self) -> float:

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -228,7 +228,7 @@ class SendspinConnection:
     _time_task: asyncio.Task[None] | None = None
     """Background task for time synchronization."""
 
-    _static_delay_us: int = 0
+    _output_delay_us: int = 0
     """Static playback delay in microseconds."""
     _send_lock: asyncio.Lock
     """Lock for serializing WebSocket message sends."""
@@ -270,7 +270,7 @@ class SendspinConnection:
         self._exchange_in_progress = False
         self._send_lock = asyncio.Lock()
         self._time_filter = SendspinTimeFilter()
-        self._static_delay_us = client.static_delay_us
+        self._output_delay_us = client.output_delay_us
         self._closed = asyncio.Event()
 
     @property
@@ -303,18 +303,18 @@ class SendspinConnection:
         return list(self._activities)
 
     @property
-    def static_delay_ms(self) -> float:
+    def output_delay_ms(self) -> float:
         """Return the currently configured static playback delay in milliseconds."""
-        return self._static_delay_us / 1_000.0
+        return self._output_delay_us / 1_000.0
 
-    def set_static_delay_ms(self, delay_ms: float) -> None:
+    def set_output_delay_ms(self, delay_ms: float) -> None:
         """Update the static playback delay applied after clock synchronisation."""
         delay_ms = max(0.0, min(5000.0, delay_ms))
         delay_us = round(delay_ms * 1_000.0)
-        if delay_us == self._static_delay_us:
+        if delay_us == self._output_delay_us:
             return
-        self._static_delay_us = delay_us
-        logger.info("Set static playback delay to %.1f ms", self.static_delay_ms)
+        self._output_delay_us = delay_us
+        logger.info("Set static playback delay to %.1f ms", self.output_delay_ms)
 
     async def connect(
         self, raw_ws: ClientWebSocketResponse, *, expected_server_id: str | None
@@ -871,7 +871,7 @@ class SendspinConnection:
                 player=PlayerStatePayload(
                     volume=volume,
                     muted=muted,
-                    static_delay_ms=round(self._static_delay_us / 1_000),
+                    output_delay_ms=round(self._output_delay_us / 1_000),
                     required_lead_time_ms=round(self._client.required_lead_time_ms),
                     min_buffer_ms=round(self._client.min_buffer_ms),
                     supported_commands=self._client.state_supported_commands or None,
@@ -1364,10 +1364,10 @@ class SendspinConnection:
         if payload.player is not None:
             player_cmd = payload.player
             if (
-                player_cmd.command == PlayerCommand.SET_STATIC_DELAY
-                and player_cmd.static_delay_ms is not None
+                player_cmd.command == PlayerCommand.SET_OUTPUT_DELAY
+                and player_cmd.output_delay_ms is not None
             ):
-                self.set_static_delay_ms(float(player_cmd.static_delay_ms))
+                self.set_output_delay_ms(float(player_cmd.output_delay_ms))
         self._client.notify_server_command_callback(payload)
 
     async def _handle_unpair(self) -> None:
@@ -1516,15 +1516,15 @@ class SendspinConnection:
         )
 
     def compute_play_time(self, server_timestamp_us: int) -> int:
-        """Convert a server timestamp to client play time, with static delay applied."""
+        """Convert a server timestamp to client play time, with output delay applied."""
         if self._time_filter.is_synchronized:
             client_time = self._time_filter.compute_client_time(server_timestamp_us)
-            return client_time - self._static_delay_us
-        return self.now_us() + UNSYNCED_PLAY_LEAD_US - self._static_delay_us
+            return client_time - self._output_delay_us
+        return self.now_us() + UNSYNCED_PLAY_LEAD_US - self._output_delay_us
 
     def compute_server_time(self, client_timestamp_us: int) -> int:
-        """Convert a client timestamp to a server timestamp, with static delay removed."""
-        adjusted_client_time = client_timestamp_us + self._static_delay_us
+        """Convert a client timestamp to a server timestamp, with output delay removed."""
+        adjusted_client_time = client_timestamp_us + self._output_delay_us
         return self._time_filter.compute_server_time(adjusted_client_time)
 
     def compute_source_timestamp(self, capture_timestamp_us: int) -> int:

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -1364,7 +1364,8 @@ class SendspinConnection:
         if payload.player is not None:
             player_cmd = payload.player
             if (
-                player_cmd.command == PlayerCommand.SET_OUTPUT_DELAY
+                player_cmd.command
+                in (PlayerCommand.SET_OUTPUT_DELAY, PlayerCommand.SET_STATIC_DELAY)
                 and player_cmd.output_delay_ms is not None
             ):
                 self.set_output_delay_ms(float(player_cmd.output_delay_ms))

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -229,7 +229,7 @@ class SendspinConnection:
     """Background task for time synchronization."""
 
     _output_delay_us: int = 0
-    """Static playback delay in microseconds."""
+    """Output delay in microseconds."""
     _send_lock: asyncio.Lock
     """Lock for serializing WebSocket message sends."""
     _time_filter: SendspinTimeFilter
@@ -304,17 +304,17 @@ class SendspinConnection:
 
     @property
     def output_delay_ms(self) -> float:
-        """Return the currently configured static playback delay in milliseconds."""
+        """Return the currently configured output delay in milliseconds."""
         return self._output_delay_us / 1_000.0
 
     def set_output_delay_ms(self, delay_ms: float) -> None:
-        """Update the static playback delay applied after clock synchronisation."""
+        """Update the output delay applied after clock synchronisation."""
         delay_ms = max(0.0, min(5000.0, delay_ms))
         delay_us = round(delay_ms * 1_000.0)
         if delay_us == self._output_delay_us:
             return
         self._output_delay_us = delay_us
-        logger.info("Set static playback delay to %.1f ms", self.output_delay_ms)
+        logger.info("Set output delay to %.1f ms", self.output_delay_ms)
 
     async def connect(
         self, raw_ws: ClientWebSocketResponse, *, expected_server_id: str | None

--- a/aiosendspin/models/player.py
+++ b/aiosendspin/models/player.py
@@ -84,8 +84,8 @@ class PlayerStatePayload(SendspinModel):
     """Volume range 0-100, only included if 'volume' in supported_commands."""
     muted: bool | None = None
     """Mute state, only included if 'mute' in supported_commands."""
-    static_delay_ms: int | None = None
-    """Static delay in milliseconds (0-5000). Required on the initial state message;
+    output_delay_ms: int | None = None
+    """Output delay in milliseconds (0-5000). Required on the initial state message;
     omitted in incremental updates means unchanged."""
     required_lead_time_ms: int | None = None
     """Minimum startup lead time in milliseconds (0-30000). Required on the initial state
@@ -93,31 +93,31 @@ class PlayerStatePayload(SendspinModel):
 
     Measured from the server transmit time of the start/restart trigger (stream/start
     or stream/clear) to the timestamp of the first subsequent audio chunk. Covers codec
-    init, decode warmup, audio backend buffering, and DAC latency. Excludes static_delay_ms.
+    init, decode warmup, audio backend buffering, and DAC latency. Excludes output_delay_ms.
     """
     min_buffer_ms: int | None = None
     """Requested minimum ongoing buffer duration in milliseconds (0-30000). Required on
     the initial state message; omitted in incremental updates means unchanged.
 
     Maintained during playback (primarily for live streams) to absorb network jitter and
-    decode/playback timing variance. Excludes static_delay_ms.
+    decode/playback timing variance. Excludes output_delay_ms.
     """
     supported_commands: list[PlayerCommand] | None = None
-    """Subset of: 'set_static_delay'. Commands this player supports via client/state."""
+    """Subset of: 'set_output_delay'. Commands this player supports via client/state."""
 
     def __post_init__(self) -> None:
         """Validate field values."""
         if self.volume is not None and not 0 <= self.volume <= 100:
             raise ValueError(f"Volume must be in range 0-100, got {self.volume}")
-        if self.static_delay_ms is not None and not 0 <= self.static_delay_ms <= 5000:
-            raise ValueError(f"static_delay_ms must be in range 0-5000, got {self.static_delay_ms}")
+        if self.output_delay_ms is not None and not 0 <= self.output_delay_ms <= 5000:
+            raise ValueError(f"output_delay_ms must be in range 0-5000, got {self.output_delay_ms}")
         if self.required_lead_time_ms is not None and not 0 <= self.required_lead_time_ms <= 30000:
             raise ValueError(
                 f"required_lead_time_ms must be in range 0-30000, got {self.required_lead_time_ms}"
             )
         if self.min_buffer_ms is not None and not 0 <= self.min_buffer_ms <= 30000:
             raise ValueError(f"min_buffer_ms must be in range 0-30000, got {self.min_buffer_ms}")
-        VALID_STATE_COMMANDS = {PlayerCommand.SET_STATIC_DELAY}  # noqa: N806
+        VALID_STATE_COMMANDS = {PlayerCommand.SET_OUTPUT_DELAY}  # noqa: N806
         if self.supported_commands:
             invalid = [c for c in self.supported_commands if c not in VALID_STATE_COMMANDS]
             if invalid:
@@ -143,8 +143,8 @@ class PlayerCommandPayload(SendspinModel):
     """Volume range 0-100, only set if command is volume."""
     mute: bool | None = None
     """True to mute, false to unmute, only set if command is mute."""
-    static_delay_ms: int | None = None
-    """Delay in milliseconds (0-5000), only set if command is set_static_delay."""
+    output_delay_ms: int | None = None
+    """Delay in milliseconds (0-5000), only set if command is set_output_delay."""
 
     def __post_init__(self) -> None:
         """Validate field values and command consistency."""
@@ -162,18 +162,18 @@ class PlayerCommandPayload(SendspinModel):
         elif self.mute is not None:
             raise ValueError(f"Mute should not be provided for command '{self.command.value}'")
 
-        if self.command == PlayerCommand.SET_STATIC_DELAY:
-            if self.static_delay_ms is None:
+        if self.command == PlayerCommand.SET_OUTPUT_DELAY:
+            if self.output_delay_ms is None:
                 raise ValueError(
-                    "static_delay_ms must be provided when command is 'set_static_delay'"
+                    "output_delay_ms must be provided when command is 'set_output_delay'"
                 )
-            if not 0 <= self.static_delay_ms <= 5000:
+            if not 0 <= self.output_delay_ms <= 5000:
                 raise ValueError(
-                    f"static_delay_ms must be in range 0-5000, got {self.static_delay_ms}"
+                    f"output_delay_ms must be in range 0-5000, got {self.output_delay_ms}"
                 )
-        elif self.static_delay_ms is not None:
+        elif self.output_delay_ms is not None:
             raise ValueError(
-                f"static_delay_ms should not be provided for command '{self.command.value}'"
+                f"output_delay_ms should not be provided for command '{self.command.value}'"
             )
 
     class Config(SendspinConfig):

--- a/aiosendspin/models/player.py
+++ b/aiosendspin/models/player.py
@@ -20,16 +20,14 @@ _LEGACY_DELAY_KEY = "static_delay_ms"
 
 
 def _rewrite_legacy_delay_key(d: dict[str, Any]) -> dict[str, Any]:
-    """Rewrite the pre-rename `static_delay_ms` key onto `output_delay_ms`."""
-    if _LEGACY_DELAY_KEY not in d:
-        return d
+    """Return a copy of `d` with the pre-rename `static_delay_ms` key on `output_delay_ms`."""
     normalized = dict(d)
+    if _LEGACY_DELAY_KEY not in normalized:
+        return normalized
     value = normalized.pop(_LEGACY_DELAY_KEY)
-    # Rewrite only when the client didn't also send the current key.
+    # Rewrite only when the sender didn't also send the current key.
     if "output_delay_ms" not in normalized:
         normalized["output_delay_ms"] = value
-    # Always overwrite so a client cannot spoof the record via the wire.
-    normalized["legacy_delay_key"] = _LEGACY_DELAY_KEY
     return normalized
 
 
@@ -128,8 +126,11 @@ class PlayerStatePayload(SendspinModel):
 
     @classmethod
     def __pre_deserialize__(cls, d: dict[str, Any]) -> dict[str, Any]:
-        """Accept the pre-rename `static_delay_ms` spelling."""
-        return _rewrite_legacy_delay_key(d)
+        """Accept the pre-rename `static_delay_ms` spelling, recording that it was used."""
+        normalized = _rewrite_legacy_delay_key(d)
+        # Always overwrite so a client cannot spoof the record via the wire.
+        normalized["legacy_delay_key"] = _LEGACY_DELAY_KEY if _LEGACY_DELAY_KEY in d else None
+        return normalized
 
     def __post_init__(self) -> None:
         """Validate field values."""
@@ -174,6 +175,11 @@ class PlayerCommandPayload(SendspinModel):
     """True to mute, false to unmute, only set if command is mute."""
     output_delay_ms: int | None = None
     """Delay in milliseconds (0-5000), only set if command is set_output_delay."""
+
+    @classmethod
+    def __pre_deserialize__(cls, d: dict[str, Any]) -> dict[str, Any]:
+        """Accept the pre-rename `static_delay_ms` spelling from a pre-rename server."""
+        return _rewrite_legacy_delay_key(d)
 
     def __post_init__(self) -> None:
         """Validate field values and command consistency."""

--- a/aiosendspin/models/player.py
+++ b/aiosendspin/models/player.py
@@ -10,9 +10,27 @@ audio formats based on their capabilities and current conditions.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 from .base import SendspinConfig, SendspinModel
 from .types import AudioCodec, PlayerCommand
+
+# Pre-rename delay key, superseded by `output_delay_ms`.
+_LEGACY_DELAY_KEY = "static_delay_ms"
+
+
+def _rewrite_legacy_delay_key(d: dict[str, Any]) -> dict[str, Any]:
+    """Rewrite the pre-rename `static_delay_ms` key onto `output_delay_ms`."""
+    if _LEGACY_DELAY_KEY not in d:
+        return d
+    normalized = dict(d)
+    value = normalized.pop(_LEGACY_DELAY_KEY)
+    # Rewrite only when the client didn't also send the current key.
+    if "output_delay_ms" not in normalized:
+        normalized["output_delay_ms"] = value
+    # Always overwrite so a client cannot spoof the record via the wire.
+    normalized["legacy_delay_key"] = _LEGACY_DELAY_KEY
+    return normalized
 
 
 # Client -> Server client/hello player support object
@@ -104,6 +122,14 @@ class PlayerStatePayload(SendspinModel):
     """
     supported_commands: list[PlayerCommand] | None = None
     """Subset of: 'set_output_delay'. Commands this player supports via client/state."""
+    legacy_delay_key: str | None = None
+    """Pre-rename delay key the parser rewrote, recorded for the role to flag.
+    Not part of the wire schema (omitted when None)."""
+
+    @classmethod
+    def __pre_deserialize__(cls, d: dict[str, Any]) -> dict[str, Any]:
+        """Accept the pre-rename `static_delay_ms` spelling."""
+        return _rewrite_legacy_delay_key(d)
 
     def __post_init__(self) -> None:
         """Validate field values."""
@@ -117,7 +143,10 @@ class PlayerStatePayload(SendspinModel):
             )
         if self.min_buffer_ms is not None and not 0 <= self.min_buffer_ms <= 30000:
             raise ValueError(f"min_buffer_ms must be in range 0-30000, got {self.min_buffer_ms}")
-        VALID_STATE_COMMANDS = {PlayerCommand.SET_OUTPUT_DELAY}  # noqa: N806
+        VALID_STATE_COMMANDS = {  # noqa: N806
+            PlayerCommand.SET_OUTPUT_DELAY,
+            PlayerCommand.SET_STATIC_DELAY,
+        }
         if self.supported_commands:
             invalid = [c for c in self.supported_commands if c not in VALID_STATE_COMMANDS]
             if invalid:
@@ -162,10 +191,10 @@ class PlayerCommandPayload(SendspinModel):
         elif self.mute is not None:
             raise ValueError(f"Mute should not be provided for command '{self.command.value}'")
 
-        if self.command == PlayerCommand.SET_OUTPUT_DELAY:
+        if self.command in (PlayerCommand.SET_OUTPUT_DELAY, PlayerCommand.SET_STATIC_DELAY):
             if self.output_delay_ms is None:
                 raise ValueError(
-                    "output_delay_ms must be provided when command is 'set_output_delay'"
+                    f"output_delay_ms must be provided when command is '{self.command.value}'"
                 )
             if not 0 <= self.output_delay_ms <= 5000:
                 raise ValueError(
@@ -175,6 +204,18 @@ class PlayerCommandPayload(SendspinModel):
             raise ValueError(
                 f"output_delay_ms should not be provided for command '{self.command.value}'"
             )
+
+    def __post_serialize__(self, d: dict[str, Any]) -> dict[str, Any]:
+        """Serialize `output_delay_ms` under the wire key matching `command`.
+
+        Lets a caller address a client that only declared the pre-rename
+        `set_static_delay` command by constructing this payload with
+        `command=PlayerCommand.SET_STATIC_DELAY` — the Python-side field stays
+        `output_delay_ms` either way.
+        """
+        if self.command == PlayerCommand.SET_STATIC_DELAY and "output_delay_ms" in d:
+            d["static_delay_ms"] = d.pop("output_delay_ms")
+        return d
 
     class Config(SendspinConfig):
         """Config for parsing json messages."""

--- a/aiosendspin/models/types.py
+++ b/aiosendspin/models/types.py
@@ -161,7 +161,7 @@ class PlayerCommand(Enum):
 
     VOLUME = "volume"
     MUTE = "mute"
-    SET_STATIC_DELAY = "set_static_delay"
+    SET_OUTPUT_DELAY = "set_output_delay"
 
 
 class MediaCommand(Enum):

--- a/aiosendspin/models/types.py
+++ b/aiosendspin/models/types.py
@@ -162,6 +162,8 @@ class PlayerCommand(Enum):
     VOLUME = "volume"
     MUTE = "mute"
     SET_OUTPUT_DELAY = "set_output_delay"
+    # Removed from the spec, still served to clients that declare it.
+    SET_STATIC_DELAY = "set_static_delay"
 
 
 class MediaCommand(Enum):

--- a/aiosendspin/server/__init__.py
+++ b/aiosendspin/server/__init__.py
@@ -28,6 +28,7 @@ __all__ = [
     "GroupRoleEvent",
     "GroupStateChangedEvent",
     "MinBufferChangedEvent",
+    "OutputDelayChangedEvent",
     "RequiredLeadTimeChangedEvent",
     "SendspinClient",
     "SendspinEvent",
@@ -38,7 +39,6 @@ __all__ = [
     "SourceStream",
     "SourceStreamEndedEvent",
     "SourceStreamStartedEvent",
-    "StaticDelayChangedEvent",
     "VolumeChangedEvent",
 ]
 
@@ -62,8 +62,8 @@ from .group import (
 )
 from .roles.player.events import (
     MinBufferChangedEvent,
+    OutputDelayChangedEvent,
     RequiredLeadTimeChangedEvent,
-    StaticDelayChangedEvent,
     VolumeChangedEvent,
 )
 from .roles.source import (

--- a/aiosendspin/server/audio.py
+++ b/aiosendspin/server/audio.py
@@ -171,7 +171,7 @@ class BufferTracker:
 
         This preserves effective playback headroom based on the furthest buffered end time,
         which is more accurate than summing durations when chunks are intentionally shifted
-        on the timeline (for example, player static delay).
+        on the timeline (for example, player output delay).
         """
         if self.max_duration_us == 0:
             return 0

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -488,7 +488,7 @@ class SendspinConnection:
             return
 
         now_us = self._server.clock.now_us()
-        # buffer_end_time_us already carries the role's static delay, which shifts the
+        # buffer_end_time_us already carries the role's output delay, which shifts the
         # deadline earlier than the raw timestamp. Fall back to the raw span only when
         # a caller does not supply it.
         deadline_us = (
@@ -532,7 +532,7 @@ class SendspinConnection:
             cached = self._client.get_binary_handling_cached(message_type)
         if cached is None or not cached[0].drop_late:
             return
-        behind_by_us = now_us - (timestamp_us - cached[1].get_static_delay_us())
+        behind_by_us = now_us - (timestamp_us - cached[1].get_output_delay_us())
         self._late_at_enqueue_count[role] = self._late_at_enqueue_count.get(role, 0) + 1
         now_s = time.monotonic()
         if now_s - self._last_late_at_enqueue_log_s.get(role, 0.0) < _WARN_INTERVAL_S:
@@ -1913,7 +1913,7 @@ class SendspinConnection:
         if entry.enqueued_at_us:
             # Same effective play time the late-drop decision uses, so this field and
             # late_by_us in the surrounding line share one basis.
-            effective_ts_us = entry.timestamp_us - role.get_static_delay_us()
+            effective_ts_us = entry.timestamp_us - role.get_output_delay_us()
             fields.append(f"enq_lead_ms={(effective_ts_us - entry.enqueued_at_us) / 1000:.0f}")
             fields.append(f"queue_age_ms={(now_us - entry.enqueued_at_us) / 1000:.0f}")
         if (tracker := role.get_buffer_tracker()) is not None:
@@ -1945,7 +1945,7 @@ class SendspinConnection:
             role._stream_start_time_us = now  # noqa: SLF001
         elapsed = now - role._stream_start_time_us  # noqa: SLF001
         in_grace_period = elapsed < handling.grace_period_us
-        late_by_us = now - (timestamp_us - role.get_static_delay_us())
+        late_by_us = now - (timestamp_us - role.get_output_delay_us())
 
         if late_by_us > 0 and not in_grace_period:
             role._late_skips_since_log += 1  # noqa: SLF001

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -817,12 +817,12 @@ class PushStream:
                 result.append((client, role))
         return result
 
-    def _max_active_static_delay_us(self) -> int:
-        """Return the largest static delay among active audio roles."""
+    def _max_active_output_delay_us(self) -> int:
+        """Return the largest output delay among active audio roles."""
         roles = self._get_audio_roles()
         if not roles:
             return 0
-        return max(role.get_static_delay_us() for _, role in roles)
+        return max(role.get_output_delay_us() for _, role in roles)
 
     def _role_send_ahead_us(self, role: Role) -> int:
         """Per-role send-ahead floor.
@@ -833,7 +833,7 @@ class PushStream:
         playback begins and extra lead would only add latency.
         """
         min_buffer_us = role.get_min_buffer_us()
-        static_us = role.get_static_delay_us()
+        static_us = role.get_output_delay_us()
         if self._is_live:
             return min_buffer_us + static_us
         return max(min_buffer_us, role.get_required_lead_time_us()) + static_us
@@ -921,7 +921,7 @@ class PushStream:
         max_timing_us = max(active_timings)
         now_us = self._clock.now_us()
         ahead_us = max_timing_us - now_us
-        effective_limit_us = max_buffer_us + self._max_active_static_delay_us()
+        effective_limit_us = max_buffer_us + self._max_active_output_delay_us()
         if ahead_us > effective_limit_us:
             await asyncio.sleep(min((ahead_us - effective_limit_us) / 1_000_000, 1.0))
 

--- a/aiosendspin/server/push_stream.py
+++ b/aiosendspin/server/push_stream.py
@@ -827,16 +827,16 @@ class PushStream:
     def _role_send_ahead_us(self, role: Role) -> int:
         """Per-role send-ahead floor.
 
-        Both cases floor at min_buffer + static. Buffered streams extend the lead
-        toward required_lead (it adds no latency once the queue grows past
+        Both cases floor at min_buffer + output_delay. Buffered streams extend the
+        lead toward required_lead (it adds no latency once the queue grows past
         min_buffer); live streams do not, since a realtime queue cannot grow after
         playback begins and extra lead would only add latency.
         """
         min_buffer_us = role.get_min_buffer_us()
-        static_us = role.get_output_delay_us()
+        output_delay_us = role.get_output_delay_us()
         if self._is_live:
-            return min_buffer_us + static_us
-        return max(min_buffer_us, role.get_required_lead_time_us()) + static_us
+            return min_buffer_us + output_delay_us
+        return max(min_buffer_us, role.get_required_lead_time_us()) + output_delay_us
 
     def _min_send_ahead_us(self) -> int:
         """Return the common send-ahead floor across active audio roles."""

--- a/aiosendspin/server/roles/base.py
+++ b/aiosendspin/server/roles/base.py
@@ -297,7 +297,7 @@ class Role(ABC):
         """Return the role-owned buffer tracker, if any."""
         return self._buffer_tracker
 
-    def get_static_delay_us(self) -> int:
+    def get_output_delay_us(self) -> int:
         """Return transport delay in microseconds applied by this role (default: 0)."""
         return 0
 

--- a/aiosendspin/server/roles/player/__init__.py
+++ b/aiosendspin/server/roles/player/__init__.py
@@ -4,11 +4,11 @@ from aiosendspin.models.player import ClientHelloPlayerSupport
 from aiosendspin.server.roles.player.audio_transformers import FlacEncoder, PcmPassthrough
 from aiosendspin.server.roles.player.events import (
     MinBufferChangedEvent,
+    OutputDelayChangedEvent,
     PlayerGroupEvent,
     PlayerGroupMuteChangedEvent,
     PlayerGroupVolumeChangedEvent,
     RequiredLeadTimeChangedEvent,
-    StaticDelayChangedEvent,
     VolumeChangedEvent,
 )
 from aiosendspin.server.roles.player.group import PlayerGroupRole
@@ -33,6 +33,7 @@ register_role_support_spec(
 __all__ = [
     "FlacEncoder",
     "MinBufferChangedEvent",
+    "OutputDelayChangedEvent",
     "PcmPassthrough",
     "PlayerGroupEvent",
     "PlayerGroupMuteChangedEvent",
@@ -41,6 +42,5 @@ __all__ = [
     "PlayerRoleProtocol",
     "PlayerV1Role",
     "RequiredLeadTimeChangedEvent",
-    "StaticDelayChangedEvent",
     "VolumeChangedEvent",
 ]

--- a/aiosendspin/server/roles/player/events.py
+++ b/aiosendspin/server/roles/player/events.py
@@ -17,9 +17,9 @@ class VolumeChangedEvent(ClientRoleEvent):
 
 @dataclass
 class StaticDelayChangedEvent(ClientRoleEvent):
-    """The static delay of the player was changed."""
+    """The output delay of the player was changed."""
 
-    static_delay_ms: int
+    output_delay_ms: int
 
 
 @dataclass

--- a/aiosendspin/server/roles/player/events.py
+++ b/aiosendspin/server/roles/player/events.py
@@ -16,7 +16,7 @@ class VolumeChangedEvent(ClientRoleEvent):
 
 
 @dataclass
-class StaticDelayChangedEvent(ClientRoleEvent):
+class OutputDelayChangedEvent(ClientRoleEvent):
     """The output delay of the player was changed."""
 
     output_delay_ms: int

--- a/aiosendspin/server/roles/player/types.py
+++ b/aiosendspin/server/roles/player/types.py
@@ -39,12 +39,12 @@ class PlayerRoleProtocol(Protocol):
         """Set the player mute state if supported."""
         ...
 
-    def get_static_delay_ms(self) -> int:
-        """Return the player's static delay in milliseconds."""
+    def get_output_delay_ms(self) -> int:
+        """Return the player's output delay in milliseconds."""
         ...
 
-    def set_static_delay(self, delay_ms: int) -> None:
-        """Set the player's static delay via server command."""
+    def set_output_delay(self, delay_ms: int) -> None:
+        """Set the player's output delay via server command."""
         ...
 
     @property

--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -69,7 +69,7 @@ class PlayerPersistentState:
     max_duration_us: int = 30_000_000
     disconnect_time_us: int | None = None
     buffer_reset_handle: asyncio.TimerHandle | None = None
-    static_delay_ms: int = 0
+    output_delay_ms: int = 0
     required_lead_time_ms: int = 250
     min_buffer_ms: int = 1000
     state_supported_commands: list[PlayerCommand] = field(default_factory=list)
@@ -351,9 +351,9 @@ class PlayerV1Role(Role):
         # Reuse the frame packed once and shared across subscribers.
         message_type = BinaryMessageType.AUDIO_CHUNK.value
         # Compute the wall-clock buffer horizon (effective play time) by shifting
-        # the chunk's end time earlier by the configured static delay.
-        static_delay_us = self.static_delay_ms * 1_000
-        chunk_end_us = chunk.timestamp_us + chunk.duration_us - static_delay_us
+        # the chunk's end time earlier by the configured output delay.
+        output_delay_us = self.output_delay_ms * 1_000
+        chunk_end_us = chunk.timestamp_us + chunk.duration_us - output_delay_us
 
         self._client.send_binary(
             chunk.packed,
@@ -419,13 +419,13 @@ class PlayerV1Role(Role):
         self._state().muted = value
 
     @property
-    def static_delay_ms(self) -> int:
-        """Current static delay of this player in milliseconds (0-5000)."""
-        return self._state().static_delay_ms
+    def output_delay_ms(self) -> int:
+        """Current output delay of this player in milliseconds (0-5000)."""
+        return self._state().output_delay_ms
 
-    @static_delay_ms.setter
-    def static_delay_ms(self, value: int) -> None:
-        self._state().static_delay_ms = value
+    @output_delay_ms.setter
+    def output_delay_ms(self, value: int) -> None:
+        self._state().output_delay_ms = value
 
     @property
     def required_lead_time_ms(self) -> int:
@@ -447,7 +447,7 @@ class PlayerV1Role(Role):
 
     @property
     def state_supported_commands(self) -> list[PlayerCommand]:
-        """Commands supported via client/state (e.g., set_static_delay)."""
+        """Commands supported via client/state (e.g., set_output_delay)."""
         return self._state().state_supported_commands
 
     @state_supported_commands.setter
@@ -470,9 +470,9 @@ class PlayerV1Role(Role):
         """Set player mute via role API."""
         self.set_mute(muted)
 
-    def get_static_delay_us(self) -> int:
+    def get_output_delay_us(self) -> int:
         """Return transport delay in microseconds for timestamp offsetting."""
-        return max(self.static_delay_ms, 0) * 1_000
+        return max(self.output_delay_ms, 0) * 1_000
 
     def get_required_lead_time_us(self) -> int:
         """Return reported startup lead time in microseconds."""
@@ -482,21 +482,21 @@ class PlayerV1Role(Role):
         """Return reported minimum ongoing buffer duration in microseconds."""
         return max(self.min_buffer_ms, 0) * 1_000
 
-    def get_static_delay_ms(self) -> int:
-        """Return static delay for protocol API."""
-        return self.static_delay_ms
+    def get_output_delay_ms(self) -> int:
+        """Return output delay for protocol API."""
+        return self.output_delay_ms
 
-    def set_static_delay(self, delay_ms: int) -> None:
-        """Send set_static_delay command to client."""
-        if PlayerCommand.SET_STATIC_DELAY not in self.state_supported_commands:
+    def set_output_delay(self, delay_ms: int) -> None:
+        """Send set_output_delay command to client."""
+        if PlayerCommand.SET_OUTPUT_DELAY not in self.state_supported_commands:
             return
 
         self._client.send_message(
             ServerCommandMessage(
                 payload=ServerCommandPayload(
                     player=PlayerCommandPayload(
-                        command=PlayerCommand.SET_STATIC_DELAY,
-                        static_delay_ms=delay_ms,
+                        command=PlayerCommand.SET_OUTPUT_DELAY,
+                        output_delay_ms=delay_ms,
                     )
                 )
             )
@@ -640,7 +640,7 @@ class PlayerV1Role(Role):
             return ["has an active player role but no player state"]
         reasons: list[str] = []
         if (
-            player.static_delay_ms is None
+            player.output_delay_ms is None
             or player.required_lead_time_ms is None
             or player.min_buffer_ms is None
         ):
@@ -704,9 +704,9 @@ class PlayerV1Role(Role):
         if state.supported_commands is not None:
             self.state_supported_commands = state.supported_commands
 
-        if state.static_delay_ms is not None and self.static_delay_ms != state.static_delay_ms:
-            self.static_delay_ms = state.static_delay_ms
-            self.emit_client_event(StaticDelayChangedEvent(static_delay_ms=state.static_delay_ms))
+        if state.output_delay_ms is not None and self.output_delay_ms != state.output_delay_ms:
+            self.output_delay_ms = state.output_delay_ms
+            self.emit_client_event(StaticDelayChangedEvent(output_delay_ms=state.output_delay_ms))
 
         if (
             state.required_lead_time_ms is not None

--- a/aiosendspin/server/roles/player/v1.py
+++ b/aiosendspin/server/roles/player/v1.py
@@ -45,8 +45,8 @@ from aiosendspin.server.roles.player.audio_transformers import (
 from aiosendspin.server.roles.player.capabilities import can_encode_format, filter_encodable_formats
 from aiosendspin.server.roles.player.events import (
     MinBufferChangedEvent,
+    OutputDelayChangedEvent,
     RequiredLeadTimeChangedEvent,
-    StaticDelayChangedEvent,
     VolumeChangedEvent,
 )
 from aiosendspin.util import create_task
@@ -487,15 +487,24 @@ class PlayerV1Role(Role):
         return self.output_delay_ms
 
     def set_output_delay(self, delay_ms: int) -> None:
-        """Send set_output_delay command to client."""
-        if PlayerCommand.SET_OUTPUT_DELAY not in self.state_supported_commands:
+        """Send set_output_delay command to client.
+
+        Addresses the client using whichever spelling it declared support for
+        — a client that only declared the pre-rename 'set_static_delay' still
+        receives a delay command it can act on.
+        """
+        if PlayerCommand.SET_OUTPUT_DELAY in self.state_supported_commands:
+            command = PlayerCommand.SET_OUTPUT_DELAY
+        elif PlayerCommand.SET_STATIC_DELAY in self.state_supported_commands:
+            command = PlayerCommand.SET_STATIC_DELAY
+        else:
             return
 
         self._client.send_message(
             ServerCommandMessage(
                 payload=ServerCommandPayload(
                     player=PlayerCommandPayload(
-                        command=PlayerCommand.SET_OUTPUT_DELAY,
+                        command=command,
                         output_delay_ms=delay_ms,
                     )
                 )
@@ -667,6 +676,10 @@ class PlayerV1Role(Role):
             reasons.append("sent volume without declaring the volume command")
         if state.muted is not None and PlayerCommand.MUTE not in commands:
             reasons.append("sent muted without declaring the mute command")
+        if state.legacy_delay_key:
+            reasons.append(f"used the pre-rename '{state.legacy_delay_key}' key")
+        if state.supported_commands and PlayerCommand.SET_STATIC_DELAY in state.supported_commands:
+            reasons.append("declared the pre-rename 'set_static_delay' command")
         return reasons
 
     def on_client_state(self, payload: ClientStatePayload) -> None:
@@ -706,7 +719,7 @@ class PlayerV1Role(Role):
 
         if state.output_delay_ms is not None and self.output_delay_ms != state.output_delay_ms:
             self.output_delay_ms = state.output_delay_ms
-            self.emit_client_event(StaticDelayChangedEvent(output_delay_ms=state.output_delay_ms))
+            self.emit_client_event(OutputDelayChangedEvent(output_delay_ms=state.output_delay_ms))
 
         if (
             state.required_lead_time_ms is not None

--- a/tests/client/test_source_capture.py
+++ b/tests/client/test_source_capture.py
@@ -166,10 +166,10 @@ async def test_stop_discards_buffer_after_connection_ends_stream() -> None:
     assert [timestamp for timestamp, _ in conn.chunks] == [2_000_000]
 
 
-def test_compute_source_timestamp_excludes_static_delay() -> None:
-    """Capture timestamps skip the static delay that playback conversion applies."""
+def test_compute_source_timestamp_excludes_output_delay() -> None:
+    """Capture timestamps skip the output delay that playback conversion applies."""
     conn = SendspinConnection.__new__(SendspinConnection)
-    conn._static_delay_us = 250_000  # noqa: SLF001
+    conn._output_delay_us = 250_000  # noqa: SLF001
 
     class _IdentityFilter:
         def compute_server_time(self, client_time: int) -> int:

--- a/tests/models/test_player.py
+++ b/tests/models/test_player.py
@@ -8,51 +8,51 @@ from aiosendspin.models.player import PlayerCommandPayload, PlayerStatePayload
 from aiosendspin.models.types import PlayerCommand
 
 
-def test_player_state_static_delay_serializes_when_set() -> None:
-    """static_delay_ms is serialized when explicitly set."""
-    payload = PlayerStatePayload(static_delay_ms=0)
+def test_player_state_output_delay_serializes_when_set() -> None:
+    """output_delay_ms is serialized when explicitly set."""
+    payload = PlayerStatePayload(output_delay_ms=0)
     data = payload.to_dict()
-    assert "static_delay_ms" in data
-    assert data["static_delay_ms"] == 0
+    assert "output_delay_ms" in data
+    assert data["output_delay_ms"] == 0
 
 
-def test_player_state_static_delay_omitted_when_unset() -> None:
-    """static_delay_ms is omitted when not provided so partial deltas don't reset it."""
+def test_player_state_output_delay_omitted_when_unset() -> None:
+    """output_delay_ms is omitted when not provided so partial deltas don't reset it."""
     payload = PlayerStatePayload()
     data = payload.to_dict()
-    assert "static_delay_ms" not in data
+    assert "output_delay_ms" not in data
 
 
-def test_player_state_static_delay_range_valid() -> None:
+def test_player_state_output_delay_range_valid() -> None:
     """Maximum value 5000 is accepted."""
-    payload = PlayerStatePayload(static_delay_ms=5000)
-    assert payload.static_delay_ms == 5000
+    payload = PlayerStatePayload(output_delay_ms=5000)
+    assert payload.output_delay_ms == 5000
 
 
-def test_player_state_static_delay_range_invalid() -> None:
+def test_player_state_output_delay_range_invalid() -> None:
     """Values above 5000 are rejected."""
-    with pytest.raises(ValueError, match="static_delay_ms"):
-        PlayerStatePayload(static_delay_ms=5001)
+    with pytest.raises(ValueError, match="output_delay_ms"):
+        PlayerStatePayload(output_delay_ms=5001)
 
 
-def test_player_state_static_delay_negative_invalid() -> None:
+def test_player_state_output_delay_negative_invalid() -> None:
     """Negative values are rejected."""
-    with pytest.raises(ValueError, match="static_delay_ms"):
-        PlayerStatePayload(static_delay_ms=-1)
+    with pytest.raises(ValueError, match="output_delay_ms"):
+        PlayerStatePayload(output_delay_ms=-1)
 
 
 def test_player_state_supported_commands_serializes() -> None:
     """supported_commands serializes enum values as strings."""
-    payload = PlayerStatePayload(supported_commands=[PlayerCommand.SET_STATIC_DELAY])
+    payload = PlayerStatePayload(supported_commands=[PlayerCommand.SET_OUTPUT_DELAY])
     data = payload.to_dict()
-    assert data["supported_commands"] == ["set_static_delay"]
+    assert data["supported_commands"] == ["set_output_delay"]
 
 
 def test_player_state_backward_compat_no_delay() -> None:
-    """Omitted static_delay_ms parses as None so server treats it as 'unchanged'."""
+    """Omitted output_delay_ms parses as None so server treats it as 'unchanged'."""
     data = '{"volume": 50}'
     payload = PlayerStatePayload.from_json(data)
-    assert payload.static_delay_ms is None
+    assert payload.output_delay_ms is None
 
 
 def test_player_state_timing_defaults_to_none() -> None:
@@ -81,31 +81,31 @@ def test_player_state_min_buffer_negative_invalid() -> None:
         PlayerStatePayload(min_buffer_ms=-1)
 
 
-def test_player_command_set_static_delay_valid() -> None:
-    """SET_STATIC_DELAY command accepts valid delay value."""
-    cmd = PlayerCommandPayload(command=PlayerCommand.SET_STATIC_DELAY, static_delay_ms=300)
-    assert cmd.static_delay_ms == 300
+def test_player_command_set_output_delay_valid() -> None:
+    """SET_OUTPUT_DELAY command accepts valid delay value."""
+    cmd = PlayerCommandPayload(command=PlayerCommand.SET_OUTPUT_DELAY, output_delay_ms=300)
+    assert cmd.output_delay_ms == 300
 
 
-def test_player_command_set_static_delay_missing() -> None:
-    """SET_STATIC_DELAY command requires static_delay_ms."""
-    with pytest.raises(ValueError, match="static_delay_ms must be provided"):
-        PlayerCommandPayload(command=PlayerCommand.SET_STATIC_DELAY)
+def test_player_command_set_output_delay_missing() -> None:
+    """SET_OUTPUT_DELAY command requires output_delay_ms."""
+    with pytest.raises(ValueError, match="output_delay_ms must be provided"):
+        PlayerCommandPayload(command=PlayerCommand.SET_OUTPUT_DELAY)
 
 
-def test_player_command_set_static_delay_out_of_range() -> None:
-    """SET_STATIC_DELAY command rejects out-of-range values."""
-    with pytest.raises(ValueError, match="static_delay_ms"):
-        PlayerCommandPayload(command=PlayerCommand.SET_STATIC_DELAY, static_delay_ms=6000)
+def test_player_command_set_output_delay_out_of_range() -> None:
+    """SET_OUTPUT_DELAY command rejects out-of-range values."""
+    with pytest.raises(ValueError, match="output_delay_ms"):
+        PlayerCommandPayload(command=PlayerCommand.SET_OUTPUT_DELAY, output_delay_ms=6000)
 
 
-def test_player_command_volume_rejects_static_delay() -> None:
-    """VOLUME command rejects static_delay_ms parameter."""
-    with pytest.raises(ValueError, match="static_delay_ms should not"):
-        PlayerCommandPayload(command=PlayerCommand.VOLUME, volume=50, static_delay_ms=100)
+def test_player_command_volume_rejects_output_delay() -> None:
+    """VOLUME command rejects output_delay_ms parameter."""
+    with pytest.raises(ValueError, match="output_delay_ms should not"):
+        PlayerCommandPayload(command=PlayerCommand.VOLUME, volume=50, output_delay_ms=100)
 
 
 def test_player_state_rejects_invalid_supported_commands() -> None:
-    """State-level supported_commands only allows set_static_delay."""
+    """State-level supported_commands only allows set_output_delay."""
     with pytest.raises(ValueError, match="Invalid state-level"):
         PlayerStatePayload(supported_commands=[PlayerCommand.VOLUME])

--- a/tests/models/test_player.py
+++ b/tests/models/test_player.py
@@ -148,3 +148,48 @@ def test_player_command_set_static_delay_requires_output_delay_ms() -> None:
     """SET_STATIC_DELAY command requires output_delay_ms same as SET_OUTPUT_DELAY."""
     with pytest.raises(ValueError, match="output_delay_ms must be provided"):
         PlayerCommandPayload(command=PlayerCommand.SET_STATIC_DELAY)
+
+
+def test_player_command_accepts_pre_rename_delay_key() -> None:
+    """A pre-rename server's set_static_delay command parses into output_delay_ms."""
+    cmd = PlayerCommandPayload.from_dict({"command": "set_static_delay", "static_delay_ms": 300})
+    assert cmd.command == PlayerCommand.SET_STATIC_DELAY
+    assert cmd.output_delay_ms == 300
+
+
+def test_player_command_pre_rename_round_trips() -> None:
+    """SET_STATIC_DELAY survives the pre-rename wire shape in both directions."""
+    cmd = PlayerCommandPayload(command=PlayerCommand.SET_STATIC_DELAY, output_delay_ms=300)
+    restored = PlayerCommandPayload.from_dict(cmd.to_dict())
+    assert restored == cmd
+
+
+def test_player_command_accepts_current_delay_key() -> None:
+    """The current set_output_delay spelling still parses."""
+    cmd = PlayerCommandPayload.from_dict({"command": "set_output_delay", "output_delay_ms": 300})
+    assert cmd.command == PlayerCommand.SET_OUTPUT_DELAY
+    assert cmd.output_delay_ms == 300
+
+
+def test_player_command_current_delay_key_wins_over_legacy() -> None:
+    """When both delay keys are present, the current output_delay_ms value is kept."""
+    cmd = PlayerCommandPayload.from_dict(
+        {"command": "set_static_delay", "static_delay_ms": 250, "output_delay_ms": 400}
+    )
+    assert cmd.output_delay_ms == 400
+
+
+def test_player_state_legacy_delay_key_cannot_be_spoofed() -> None:
+    """A client sending legacy_delay_key on the wire is not flagged for it."""
+    payload = PlayerStatePayload.from_dict(
+        {"output_delay_ms": 250, "legacy_delay_key": "static_delay_ms"}
+    )
+    assert payload.output_delay_ms == 250
+    assert payload.legacy_delay_key is None
+
+
+def test_player_state_from_dict_does_not_mutate_input() -> None:
+    """Parsing a pre-rename payload leaves the caller's dict untouched."""
+    raw = {"static_delay_ms": 250}
+    PlayerStatePayload.from_dict(raw)
+    assert raw == {"static_delay_ms": 250}

--- a/tests/models/test_player.py
+++ b/tests/models/test_player.py
@@ -109,3 +109,42 @@ def test_player_state_rejects_invalid_supported_commands() -> None:
     """State-level supported_commands only allows set_output_delay."""
     with pytest.raises(ValueError, match="Invalid state-level"):
         PlayerStatePayload(supported_commands=[PlayerCommand.VOLUME])
+
+
+def test_player_state_accepts_pre_rename_delay_key() -> None:
+    """static_delay_ms is rewritten to output_delay_ms and recorded for the role to flag."""
+    payload = PlayerStatePayload.from_dict({"static_delay_ms": 250})
+    assert payload.output_delay_ms == 250
+    assert payload.legacy_delay_key == "static_delay_ms"
+
+
+def test_player_state_current_key_wins_over_legacy() -> None:
+    """When both keys are present, the current output_delay_ms value is kept."""
+    payload = PlayerStatePayload.from_dict({"static_delay_ms": 250, "output_delay_ms": 400})
+    assert payload.output_delay_ms == 400
+    assert payload.legacy_delay_key == "static_delay_ms"
+
+
+def test_player_state_current_delay_key_not_flagged_as_legacy() -> None:
+    """output_delay_ms alone leaves legacy_delay_key unset."""
+    payload = PlayerStatePayload.from_dict({"output_delay_ms": 250})
+    assert payload.legacy_delay_key is None
+
+
+def test_player_state_accepts_pre_rename_command_name() -> None:
+    """set_static_delay is still a valid state-level supported_commands entry."""
+    payload = PlayerStatePayload(supported_commands=[PlayerCommand.SET_STATIC_DELAY])
+    assert payload.supported_commands == [PlayerCommand.SET_STATIC_DELAY]
+
+
+def test_player_command_set_static_delay_serializes_pre_rename_wire_shape() -> None:
+    """Constructing with SET_STATIC_DELAY addresses a client that only declared that name."""
+    cmd = PlayerCommandPayload(command=PlayerCommand.SET_STATIC_DELAY, output_delay_ms=300)
+    data = cmd.to_dict()
+    assert data == {"command": "set_static_delay", "static_delay_ms": 300}
+
+
+def test_player_command_set_static_delay_requires_output_delay_ms() -> None:
+    """SET_STATIC_DELAY command requires output_delay_ms same as SET_OUTPUT_DELAY."""
+    with pytest.raises(ValueError, match="output_delay_ms must be provided"):
+        PlayerCommandPayload(command=PlayerCommand.SET_STATIC_DELAY)

--- a/tests/server/roles/test_player_v1.py
+++ b/tests/server/roles/test_player_v1.py
@@ -128,7 +128,7 @@ def test_player_role_initial_state_deviations_accepts_complete_timing() -> None:
     role = PlayerV1Role(client=_make_client_stub())
     payload = ClientStatePayload(
         available=True,
-        player=PlayerStatePayload(static_delay_ms=0, required_lead_time_ms=100, min_buffer_ms=200),
+        player=PlayerStatePayload(output_delay_ms=0, required_lead_time_ms=100, min_buffer_ms=200),
     )
     assert role.initial_state_deviations(payload) == []
 
@@ -146,7 +146,7 @@ def _stub_with_player_support(*commands: PlayerCommand) -> MagicMock:
 
 
 def _complete_timing_state(**overrides: object) -> ClientStatePayload:
-    fields = {"static_delay_ms": 0, "required_lead_time_ms": 100, "min_buffer_ms": 200}
+    fields = {"output_delay_ms": 0, "required_lead_time_ms": 100, "min_buffer_ms": 200}
     fields.update(overrides)
     return ClientStatePayload(available=True, player=PlayerStatePayload(**fields))  # type: ignore[arg-type]
 
@@ -560,15 +560,15 @@ def test_player_role_on_audio_chunk_passes_buffer_metadata() -> None:
     assert call_kwargs["duration_us"] == 25000
 
 
-def test_player_role_on_audio_chunk_applies_static_delay_to_buffer_end() -> None:
-    """Buffer tracking end time should account for the player's static delay."""
+def test_player_role_on_audio_chunk_applies_output_delay_to_buffer_end() -> None:
+    """Buffer tracking end time should account for the player's output delay."""
     client = _make_client_stub()
     client.send_binary.return_value = True
 
     role = PlayerV1Role(client=client)
     role._client.connection = MagicMock()  # noqa: SLF001
     role._stream_started = True  # noqa: SLF001
-    role.static_delay_ms = 500
+    role.output_delay_ms = 500
 
     chunk = AudioChunk(
         data=b"audio",
@@ -980,23 +980,23 @@ def test_preferred_format_override_superseded_after_client_hello() -> None:
     assert role.preferred_format == AudioFormat(sample_rate=48000, bit_depth=16, channels=2)
 
 
-# --- Static delay ---
+# --- Output delay ---
 
 
-def test_static_delay_default_zero() -> None:
-    """Static delay defaults to 0."""
+def test_output_delay_default_zero() -> None:
+    """Output delay defaults to 0."""
     client = _make_client_stub()
     role = PlayerV1Role(client=client)
-    assert role.static_delay_ms == 0
+    assert role.output_delay_ms == 0
 
 
-def test_on_client_state_updates_static_delay() -> None:
-    """on_client_state() updates static_delay_ms and fires event."""
+def test_on_client_state_updates_output_delay() -> None:
+    """on_client_state() updates output_delay_ms and fires event."""
     client = _make_client_stub()
     role = PlayerV1Role(client=client)
-    payload = ClientStatePayload(player=PlayerStatePayload(static_delay_ms=300))
+    payload = ClientStatePayload(player=PlayerStatePayload(output_delay_ms=300))
     role.on_client_state(payload)
-    assert role.static_delay_ms == 300
+    assert role.output_delay_ms == 300
     client._signal_event.assert_called_once()  # noqa: SLF001
 
 
@@ -1004,7 +1004,7 @@ def test_on_client_state_no_event_if_unchanged() -> None:
     """on_client_state() does not fire event when delay is unchanged."""
     client = _make_client_stub()
     role = PlayerV1Role(client=client)
-    payload = ClientStatePayload(player=PlayerStatePayload(static_delay_ms=0))
+    payload = ClientStatePayload(player=PlayerStatePayload(output_delay_ms=0))
     role.on_client_state(payload)
     client._signal_event.assert_not_called()  # noqa: SLF001
 
@@ -1057,13 +1057,13 @@ def test_partial_client_state_does_not_reset_timing_fields() -> None:
         ClientStatePayload(
             player=PlayerStatePayload(
                 volume=80,
-                static_delay_ms=400,
+                output_delay_ms=400,
                 required_lead_time_ms=120,
                 min_buffer_ms=600,
             )
         )
     )
-    assert role.static_delay_ms == 400
+    assert role.output_delay_ms == 400
     assert role.required_lead_time_ms == 120
     assert role.min_buffer_ms == 600
 
@@ -1071,7 +1071,7 @@ def test_partial_client_state_does_not_reset_timing_fields() -> None:
 
     role.on_client_state(ClientStatePayload(player=PlayerStatePayload(volume=70)))
 
-    assert role.static_delay_ms == 400
+    assert role.output_delay_ms == 400
     assert role.required_lead_time_ms == 120
     assert role.min_buffer_ms == 600
     emitted_types = [
@@ -1084,22 +1084,22 @@ def test_partial_client_state_does_not_reset_timing_fields() -> None:
     assert VolumeChangedEvent in emitted_types
 
 
-def test_explicit_zero_static_delay_in_delta_updates_field() -> None:
-    """A delta of static_delay_ms=0 sets the field to 0 and fires its event."""
+def test_explicit_zero_output_delay_in_delta_updates_field() -> None:
+    """A delta of output_delay_ms=0 sets the field to 0 and fires its event."""
     client = _make_client_stub()
     role = PlayerV1Role(client=client)
 
-    role.on_client_state(ClientStatePayload(player=PlayerStatePayload(static_delay_ms=400)))
-    assert role.static_delay_ms == 400
+    role.on_client_state(ClientStatePayload(player=PlayerStatePayload(output_delay_ms=400)))
+    assert role.output_delay_ms == 400
 
     client._signal_event.reset_mock()  # noqa: SLF001
 
-    role.on_client_state(ClientStatePayload(player=PlayerStatePayload(static_delay_ms=0)))
+    role.on_client_state(ClientStatePayload(player=PlayerStatePayload(output_delay_ms=0)))
 
-    assert role.static_delay_ms == 0
+    assert role.output_delay_ms == 0
     event = client._signal_event.call_args[0][0]  # noqa: SLF001
     assert isinstance(event, StaticDelayChangedEvent)
-    assert event.static_delay_ms == 0
+    assert event.output_delay_ms == 0
 
 
 def test_on_client_state_updates_supported_commands() -> None:
@@ -1107,24 +1107,24 @@ def test_on_client_state_updates_supported_commands() -> None:
     client = _make_client_stub()
     role = PlayerV1Role(client=client)
     payload = ClientStatePayload(
-        player=PlayerStatePayload(supported_commands=[PlayerCommand.SET_STATIC_DELAY])
+        player=PlayerStatePayload(supported_commands=[PlayerCommand.SET_OUTPUT_DELAY])
     )
     role.on_client_state(payload)
-    assert PlayerCommand.SET_STATIC_DELAY in role.state_supported_commands
+    assert PlayerCommand.SET_OUTPUT_DELAY in role.state_supported_commands
 
 
-def test_set_static_delay_sends_command() -> None:
-    """set_static_delay() sends command when client supports it."""
+def test_set_output_delay_sends_command() -> None:
+    """set_output_delay() sends command when client supports it."""
     client = _make_client_stub()
     role = PlayerV1Role(client=client)
-    role.state_supported_commands = [PlayerCommand.SET_STATIC_DELAY]
-    role.set_static_delay(500)
+    role.state_supported_commands = [PlayerCommand.SET_OUTPUT_DELAY]
+    role.set_output_delay(500)
     client.send_message.assert_called_once()
 
 
-def test_set_static_delay_noop_without_support() -> None:
-    """set_static_delay() is a no-op when client doesn't support it."""
+def test_set_output_delay_noop_without_support() -> None:
+    """set_output_delay() is a no-op when client doesn't support it."""
     client = _make_client_stub()
     role = PlayerV1Role(client=client)
-    role.set_static_delay(500)
+    role.set_output_delay(500)
     client.send_message.assert_not_called()

--- a/tests/server/roles/test_player_v1.py
+++ b/tests/server/roles/test_player_v1.py
@@ -29,8 +29,8 @@ from aiosendspin.server.roles.base import AudioChunk, AudioRequirements, StreamR
 from aiosendspin.server.roles.player.audio_transformers import FlacEncoder, PcmPassthrough
 from aiosendspin.server.roles.player.events import (
     MinBufferChangedEvent,
+    OutputDelayChangedEvent,
     RequiredLeadTimeChangedEvent,
-    StaticDelayChangedEvent,
     VolumeChangedEvent,
 )
 
@@ -1078,7 +1078,7 @@ def test_partial_client_state_does_not_reset_timing_fields() -> None:
         type(call.args[0])
         for call in client._signal_event.call_args_list  # noqa: SLF001
     ]
-    assert StaticDelayChangedEvent not in emitted_types
+    assert OutputDelayChangedEvent not in emitted_types
     assert RequiredLeadTimeChangedEvent not in emitted_types
     assert MinBufferChangedEvent not in emitted_types
     assert VolumeChangedEvent in emitted_types
@@ -1098,7 +1098,7 @@ def test_explicit_zero_output_delay_in_delta_updates_field() -> None:
 
     assert role.output_delay_ms == 0
     event = client._signal_event.call_args[0][0]  # noqa: SLF001
-    assert isinstance(event, StaticDelayChangedEvent)
+    assert isinstance(event, OutputDelayChangedEvent)
     assert event.output_delay_ms == 0
 
 
@@ -1128,3 +1128,52 @@ def test_set_output_delay_noop_without_support() -> None:
     role = PlayerV1Role(client=client)
     role.set_output_delay(500)
     client.send_message.assert_not_called()
+
+
+def test_set_output_delay_addresses_client_using_pre_rename_command() -> None:
+    """A client that only declared set_static_delay still gets a delay command it understands."""
+    client = _make_client_stub()
+    role = PlayerV1Role(client=client)
+    role.state_supported_commands = [PlayerCommand.SET_STATIC_DELAY]
+
+    role.set_output_delay(500)
+
+    client.send_message.assert_called_once()
+    sent = client.send_message.call_args.args[0]
+    assert sent.payload.player.command == PlayerCommand.SET_STATIC_DELAY
+    assert sent.payload.player.output_delay_ms == 500
+    assert sent.payload.player.to_dict() == {"command": "set_static_delay", "static_delay_ms": 500}
+
+
+def test_set_output_delay_prefers_current_command_when_both_declared() -> None:
+    """A client declaring both spellings is addressed with the current one."""
+    client = _make_client_stub()
+    role = PlayerV1Role(client=client)
+    role.state_supported_commands = [PlayerCommand.SET_STATIC_DELAY, PlayerCommand.SET_OUTPUT_DELAY]
+
+    role.set_output_delay(500)
+
+    sent = client.send_message.call_args.args[0]
+    assert sent.payload.player.command == PlayerCommand.SET_OUTPUT_DELAY
+
+
+def test_player_client_state_deviations_flags_pre_rename_delay_key() -> None:
+    """A client/state using static_delay_ms is a deviation."""
+    role = PlayerV1Role(client=_make_client_stub())
+    payload = ClientStatePayload(
+        available=True,
+        player=PlayerStatePayload.from_dict({"static_delay_ms": 250}),
+    )
+    reasons = role.client_state_deviations(payload)
+    assert any("static_delay_ms" in r for r in reasons)
+
+
+def test_player_client_state_deviations_flags_pre_rename_command_name() -> None:
+    """Declaring set_static_delay in supported_commands is a deviation."""
+    role = PlayerV1Role(client=_make_client_stub())
+    payload = ClientStatePayload(
+        available=True,
+        player=PlayerStatePayload(supported_commands=[PlayerCommand.SET_STATIC_DELAY]),
+    )
+    reasons = role.client_state_deviations(payload)
+    assert any("set_static_delay" in r for r in reasons)

--- a/tests/server/test_connection_writer.py
+++ b/tests/server/test_connection_writer.py
@@ -361,7 +361,7 @@ async def test_drop_pending_binary_unblocks_backpressured_role() -> None:
 
 
 def test_check_late_binary_uses_player_effective_timestamp() -> None:
-    """Static delay should make late-drop compare against effective play time."""
+    """Output delay should make late-drop compare against effective play time."""
     loop = asyncio.new_event_loop()
     try:
         clock = ManualClock(now_us_value=10_000_000)
@@ -372,7 +372,7 @@ def test_check_late_binary_uses_player_effective_timestamp() -> None:
         conn._transport = wsock  # noqa: SLF001
 
         role = PlayerV1Role(client=_make_player_client_stub())
-        role.static_delay_ms = 5_000
+        role.output_delay_ms = 5_000
         role._stream_start_time_us = 0  # noqa: SLF001
 
         handling = BinaryHandling(drop_late=True, grace_period_us=2_000_000)
@@ -711,7 +711,7 @@ def _make_connection_with_droppable_client(
     client = MagicMock()
     client.active_roles = []
     role = MagicMock()
-    role.get_static_delay_us.return_value = 0
+    role.get_output_delay_us.return_value = 0
     client.get_binary_handling_cached.return_value = (
         BinaryHandling(drop_late=drop_late, grace_period_us=2_000_000),
         role,
@@ -862,7 +862,7 @@ def test_late_binary_warning_is_throttled_across_a_burst(
 def test_late_binary_diagnostics_use_the_effective_play_time(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A static delay shifts the deadline, so enq_lead must agree with late_by_us."""
+    """A output delay shifts the deadline, so enq_lead must agree with late_by_us."""
     loop = asyncio.new_event_loop()
     try:
         clock = ManualClock(now_us_value=10_000_000)
@@ -874,7 +874,7 @@ def test_late_binary_diagnostics_use_the_effective_play_time(
 
         role = PlayerV1Role(client=_make_player_client_stub())
         role._stream_start_time_us = 0  # noqa: SLF001
-        role.static_delay_ms = 5_000
+        role.output_delay_ms = 5_000
 
         # Raw timestamp is 4s ahead, but the effective play time is 1s in the past.
         entry = _RoleQueueEntry(epoch=0, timestamp_us=14_000_000, enqueued_at_us=9_500_000)

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -128,13 +128,13 @@ class _DummyRole:
         self,
         requirements: AudioRequirements,
         *,
-        static_delay_us: int = 0,
+        output_delay_us: int = 0,
         replay_from_pcm_cache: bool = False,
         required_lead_time_us: int = DEFAULT_INITIAL_DELAY_US,
         min_buffer_us: int = 0,
     ) -> None:
         self._requirements = requirements
-        self._static_delay_us = static_delay_us
+        self._output_delay_us = output_delay_us
         self._replay_from_pcm_cache = replay_from_pcm_cache
         self._required_lead_time_us = required_lead_time_us
         self._min_buffer_us = min_buffer_us
@@ -147,8 +147,8 @@ class _DummyRole:
     def replay_from_pcm_cache(self) -> bool:
         return self._replay_from_pcm_cache
 
-    def get_static_delay_us(self) -> int:
-        return self._static_delay_us
+    def get_output_delay_us(self) -> int:
+        return self._output_delay_us
 
     def get_required_lead_time_us(self) -> int:
         return self._required_lead_time_us
@@ -264,7 +264,7 @@ def _make_connected_player(
 
 
 @pytest.mark.asyncio
-async def test_late_join_target_includes_player_static_delay() -> None:
+async def test_late_join_target_includes_player_output_delay() -> None:
     """Late-join target should use raw timestamps far enough ahead for delayed players."""
     loop = asyncio.get_running_loop()
     clock = ManualClock(now_us_value=1_000_000)
@@ -272,11 +272,11 @@ async def test_late_join_target_includes_player_static_delay() -> None:
     client, _ = _make_connected_player(loop, group, "p1", clock=clock)
     role = client.role("player@v1")
     assert role is not None
-    role.static_delay_ms = 5_000
+    role.output_delay_ms = 5_000
 
     stream = PushStream(loop=loop, clock=clock, group=group)
 
-    # now + max(min_buffer=1000ms, required_lead=250ms) + static_delay=5s
+    # now + max(min_buffer=1000ms, required_lead=250ms) + output_delay=5s
     assert stream.get_late_join_target_timestamp_us(role=role) == 7_000_000
 
 
@@ -289,7 +289,7 @@ async def test_live_send_ahead_uses_min_buffer_not_required_lead() -> None:
     client, _ = _make_connected_player(loop, group, "p1", clock=clock)
     role = client.role("player@v1")
     assert role is not None
-    role.static_delay_ms = 0
+    role.output_delay_ms = 0
     role.min_buffer_ms = 200
     role.required_lead_time_ms = 400  # must be ignored for live
 
@@ -308,13 +308,13 @@ async def test_late_join_target_uses_required_lead_time() -> None:
     client, _ = _make_connected_player(loop, group, "p1", clock=clock)
     role = client.role("player@v1")
     assert role is not None
-    role.static_delay_ms = 5_000
+    role.output_delay_ms = 5_000
     role.required_lead_time_ms = 400
     role.min_buffer_ms = 100  # below required_lead, so required_lead is the binding floor
 
     stream = PushStream(loop=loop, clock=clock, group=group)
 
-    # now + max(100ms min_buffer, 400ms required_lead) + 5s static_delay
+    # now + max(100ms min_buffer, 400ms required_lead) + 5s output_delay
     assert stream.get_late_join_target_timestamp_us(role=role) == 6_400_000
 
 
@@ -332,7 +332,7 @@ async def test_late_join_target_matches_fresh_start_floor() -> None:
     client, _ = _make_connected_player(loop, group, "p1", clock=clock)
     role = client.role("player@v1")
     assert role is not None
-    role.static_delay_ms = 0
+    role.output_delay_ms = 0
     role.required_lead_time_ms = 250
     role.min_buffer_ms = 1_000
 
@@ -343,15 +343,15 @@ async def test_late_join_target_matches_fresh_start_floor() -> None:
 
 
 @pytest.mark.asyncio
-async def test_non_main_join_rebase_includes_player_static_delay() -> None:
-    """Solo-channel rejoin should clamp raw timing high enough for static delay."""
+async def test_non_main_join_rebase_includes_player_output_delay() -> None:
+    """Solo-channel rejoin should clamp raw timing high enough for output delay."""
     loop = asyncio.get_running_loop()
     clock = ManualClock(now_us_value=1_000_000)
     group = _DummyGroup(clients=[])
     client, _ = _make_connected_player(loop, group, "p1", clock=clock)
     role = client.role("player@v1")
     assert role is not None
-    role.static_delay_ms = 5_000
+    role.output_delay_ms = 5_000
 
     channel_id = UUID("77777777-7777-7777-7777-777777777777")
     stream = PushStream(loop=loop, clock=clock, group=group)
@@ -3629,15 +3629,15 @@ def test_soxr_fallback_caches_failure_per_format(
 
 
 # ---------------------------------------------------------------------------
-# Static delay send-ahead budget tests
+# Output delay send-ahead budget tests
 # ---------------------------------------------------------------------------
 
-_STATIC_DELAY_US = 5_000_000  # 5 s
+_OUTPUT_DELAY_US = 5_000_000  # 5 s
 
 
 def _make_role(
     *,
-    static_delay_us: int = 0,
+    output_delay_us: int = 0,
     required_lead_time_us: int = DEFAULT_INITIAL_DELAY_US,
     min_buffer_us: int = 0,
     channel_id: UUID = MAIN_CHANNEL,
@@ -3651,19 +3651,19 @@ def _make_role(
             channel_id=channel_id,
             frame_duration_us=25_000,
         ),
-        static_delay_us=static_delay_us,
+        output_delay_us=output_delay_us,
         required_lead_time_us=required_lead_time_us,
         min_buffer_us=min_buffer_us,
     )
 
 
 @pytest.mark.asyncio
-async def test_commit_audio_bootstrap_includes_static_delay() -> None:
+async def test_commit_audio_bootstrap_includes_output_delay() -> None:
     """First commit with a large-delay player pushes timeline forward."""
     loop = asyncio.get_running_loop()
     clock = ManualClock(now_us_value=1_000_000)
     group = _DummyGroup(clients=[])
-    role = _make_role(static_delay_us=_STATIC_DELAY_US)
+    role = _make_role(output_delay_us=_OUTPUT_DELAY_US)
     group.clients.append(_DummyClient([role]))
 
     stream = PushStream(loop=loop, clock=clock, group=group)
@@ -3671,17 +3671,17 @@ async def test_commit_audio_bootstrap_includes_static_delay() -> None:
     stream.prepare_audio(bytes(4800), fmt)
     play_start = await stream.commit_audio()
 
-    assert play_start >= clock.now_us() + DEFAULT_INITIAL_DELAY_US + _STATIC_DELAY_US
+    assert play_start >= clock.now_us() + DEFAULT_INITIAL_DELAY_US + _OUTPUT_DELAY_US
 
 
 @pytest.mark.asyncio
-async def test_mixed_delay_timeline_uses_largest_static_delay() -> None:
+async def test_mixed_delay_timeline_uses_largest_output_delay() -> None:
     """With 0 ms and 5 s delay players, timeline anchored for the largest."""
     loop = asyncio.get_running_loop()
     clock = ManualClock(now_us_value=1_000_000)
     group = _DummyGroup(clients=[])
-    role_fast = _make_role(static_delay_us=0)
-    role_slow = _make_role(static_delay_us=_STATIC_DELAY_US)
+    role_fast = _make_role(output_delay_us=0)
+    role_slow = _make_role(output_delay_us=_OUTPUT_DELAY_US)
     group.clients.extend([_DummyClient([role_fast]), _DummyClient([role_slow])])
 
     stream = PushStream(loop=loop, clock=clock, group=group)
@@ -3689,7 +3689,7 @@ async def test_mixed_delay_timeline_uses_largest_static_delay() -> None:
     stream.prepare_audio(bytes(4800), fmt)
     play_start = await stream.commit_audio()
 
-    assert play_start >= clock.now_us() + DEFAULT_INITIAL_DELAY_US + _STATIC_DELAY_US
+    assert play_start >= clock.now_us() + DEFAULT_INITIAL_DELAY_US + _OUTPUT_DELAY_US
 
 
 @pytest.mark.asyncio
@@ -3698,7 +3698,7 @@ async def test_commit_audio_uses_reported_lead_time() -> None:
     loop = asyncio.get_running_loop()
     clock = ManualClock(now_us_value=1_000_000)
     group = _DummyGroup(clients=[])
-    role = _make_role(required_lead_time_us=50_000, min_buffer_us=0, static_delay_us=0)
+    role = _make_role(required_lead_time_us=50_000, min_buffer_us=0, output_delay_us=0)
     group.clients.append(_DummyClient([role]))
 
     stream = PushStream(loop=loop, clock=clock, group=group)
@@ -3715,7 +3715,7 @@ async def test_commit_audio_min_buffer_floors_send_ahead() -> None:
     loop = asyncio.get_running_loop()
     clock = ManualClock(now_us_value=1_000_000)
     group = _DummyGroup(clients=[])
-    role = _make_role(required_lead_time_us=50_000, min_buffer_us=2_000_000, static_delay_us=0)
+    role = _make_role(required_lead_time_us=50_000, min_buffer_us=2_000_000, output_delay_us=0)
     group.clients.append(_DummyClient([role]))
 
     stream = PushStream(loop=loop, clock=clock, group=group)
@@ -3733,7 +3733,7 @@ async def test_buffered_source_floors_at_min_buffer_at_startup() -> None:
     loop = asyncio.get_running_loop()
     clock = ManualClock(now_us_value=1_000_000)
     group = _DummyGroup(clients=[])
-    role = _make_role(required_lead_time_us=0, min_buffer_us=15_000_000, static_delay_us=0)
+    role = _make_role(required_lead_time_us=0, min_buffer_us=15_000_000, output_delay_us=0)
     group.clients.append(_DummyClient([role]))
 
     stream = PushStream(loop=loop, clock=clock, group=group)
@@ -3752,7 +3752,7 @@ async def test_explicit_play_start_us_overrides_stale_channel_timing() -> None:
     loop = asyncio.get_running_loop()
     clock = ManualClock(now_us_value=1_000_000)
     group = _DummyGroup(clients=[])
-    role = _make_role(required_lead_time_us=0, min_buffer_us=0, static_delay_us=0)
+    role = _make_role(required_lead_time_us=0, min_buffer_us=0, output_delay_us=0)
     group.clients.append(_DummyClient([role]))
 
     stream = PushStream(loop=loop, clock=clock, group=group)
@@ -3783,9 +3783,9 @@ async def test_send_ahead_uses_largest_member_budget() -> None:
     loop = asyncio.get_running_loop()
     clock = ManualClock(now_us_value=1_000_000)
     group = _DummyGroup(clients=[])
-    role_low = _make_role(required_lead_time_us=100_000, min_buffer_us=0, static_delay_us=0)
+    role_low = _make_role(required_lead_time_us=100_000, min_buffer_us=0, output_delay_us=0)
     role_high = _make_role(
-        required_lead_time_us=0, min_buffer_us=1_500_000, static_delay_us=200_000
+        required_lead_time_us=0, min_buffer_us=1_500_000, output_delay_us=200_000
     )
     group.clients.extend([_DummyClient([role_low]), _DummyClient([role_high])])
 
@@ -3800,18 +3800,18 @@ async def test_send_ahead_uses_largest_member_budget() -> None:
 
 
 @pytest.mark.asyncio
-async def test_sleep_to_limit_buffer_accounts_for_static_delay() -> None:
-    """Buffer throttle allows extra lead equal to the largest static delay."""
+async def test_sleep_to_limit_buffer_accounts_for_output_delay() -> None:
+    """Buffer throttle allows extra lead equal to the largest output delay."""
     loop = asyncio.get_running_loop()
     clock = ManualClock(now_us_value=1_000_000)
     group = _DummyGroup(clients=[])
-    role = _make_role(static_delay_us=_STATIC_DELAY_US)
+    role = _make_role(output_delay_us=_OUTPUT_DELAY_US)
     group.clients.append(_DummyClient([role]))
 
     stream = PushStream(loop=loop, clock=clock, group=group)
-    # Timeline 5.25 s ahead — exactly DEFAULT + static_delay
+    # Timeline 5.25 s ahead — exactly DEFAULT + output_delay
     stream._channel_timing[MAIN_CHANNEL] = (  # noqa: SLF001
-        clock.now_us() + DEFAULT_INITIAL_DELAY_US + _STATIC_DELAY_US
+        clock.now_us() + DEFAULT_INITIAL_DELAY_US + _OUTPUT_DELAY_US
     )
 
     # With a 500 ms base buffer, effective limit = 500 ms + 5 s = 5.5 s.
@@ -3821,13 +3821,13 @@ async def test_sleep_to_limit_buffer_accounts_for_static_delay() -> None:
 
 
 @pytest.mark.asyncio
-async def test_historical_stale_filter_includes_static_delay() -> None:
-    """Historical chunk between DEFAULT and DEFAULT+static_delay is filtered."""
+async def test_historical_stale_filter_includes_output_delay() -> None:
+    """Historical chunk between DEFAULT and DEFAULT+output_delay is filtered."""
     loop = asyncio.get_running_loop()
     clock = ManualClock(now_us_value=1_000_000)
     channel = UUID("cccccccc-cccc-cccc-cccc-cccccccccccc")
     group = _DummyGroup(clients=[])
-    role = _make_role(static_delay_us=_STATIC_DELAY_US, channel_id=channel)
+    role = _make_role(output_delay_us=_OUTPUT_DELAY_US, channel_id=channel)
     group.clients.append(_DummyClient([role]))
 
     stream = PushStream(loop=loop, clock=clock, group=group)
@@ -3850,7 +3850,7 @@ async def test_zero_delay_regression_commit_audio_unchanged() -> None:
     loop = asyncio.get_running_loop()
     clock = ManualClock(now_us_value=1_000_000)
     group = _DummyGroup(clients=[])
-    role = _make_role(static_delay_us=0)
+    role = _make_role(output_delay_us=0)
     group.clients.append(_DummyClient([role]))
 
     stream = PushStream(loop=loop, clock=clock, group=group)

--- a/tests/test_client_protocol_callbacks.py
+++ b/tests/test_client_protocol_callbacks.py
@@ -509,8 +509,8 @@ async def test_send_group_command_seek_forwards_position_ms() -> None:
     assert msg["payload"]["controller"]["position_ms"] == 12_000
 
 
-async def test_server_command_set_static_delay_applies_and_notifies() -> None:
-    """A server/command SET_STATIC_DELAY updates the offset and fires the callback."""
+async def test_server_command_set_output_delay_applies_and_notifies() -> None:
+    """A server/command SET_OUTPUT_DELAY updates the offset and fires the callback."""
     client = make_sdk_client(
         client_name="Test Client", roles=[Roles.PLAYER], player_support=_player_support()
     )
@@ -520,11 +520,11 @@ async def test_server_command_set_static_delay_applies_and_notifies() -> None:
     client.add_server_command_listener(received.append)
 
     payload = ServerCommandPayload(
-        player=PlayerCommandPayload(command=PlayerCommand.SET_STATIC_DELAY, static_delay_ms=250)
+        player=PlayerCommandPayload(command=PlayerCommand.SET_OUTPUT_DELAY, output_delay_ms=250)
     )
     connection._handle_server_command(payload)  # noqa: SLF001
 
-    assert connection.static_delay_ms == 250.0
+    assert connection.output_delay_ms == 250.0
     assert received == [payload]
 
 
@@ -541,5 +541,5 @@ async def test_server_command_without_player_only_notifies() -> None:
     payload = ServerCommandPayload()
     connection._handle_server_command(payload)  # noqa: SLF001
 
-    assert connection.static_delay_ms == 0.0
+    assert connection.output_delay_ms == 0.0
     assert received == [payload]

--- a/tests/test_client_protocol_callbacks.py
+++ b/tests/test_client_protocol_callbacks.py
@@ -528,6 +528,25 @@ async def test_server_command_set_output_delay_applies_and_notifies() -> None:
     assert received == [payload]
 
 
+async def test_server_command_pre_rename_delay_applies_and_notifies() -> None:
+    """A pre-rename server/command set_static_delay updates the offset and fires the callback."""
+    client = make_sdk_client(
+        client_name="Test Client", roles=[Roles.PLAYER], player_support=_player_support()
+    )
+    connection = SendspinConnection(client)
+
+    received: list[ServerCommandPayload] = []
+    client.add_server_command_listener(received.append)
+
+    payload = ServerCommandPayload.from_dict(
+        {"player": {"command": "set_static_delay", "static_delay_ms": 250}}
+    )
+    connection._handle_server_command(payload)  # noqa: SLF001
+
+    assert connection.output_delay_ms == 250.0
+    assert received == [payload]
+
+
 async def test_server_command_without_player_only_notifies() -> None:
     """A server/command with no player sub-command leaves the delay unchanged but still notifies."""
     client = make_sdk_client(


### PR DESCRIPTION
## Summary

Implements [spec PR #164](https://github.com/Sendspin/spec/pull/164) ("rename static_delay_ms to output_delay_ms"), which aiosendspin hadn't caught up to yet:

- `PlayerStatePayload.static_delay_ms` → `output_delay_ms`
- `PlayerCommandPayload.static_delay_ms` → `output_delay_ms`
- `PlayerCommand.SET_STATIC_DELAY` (`"set_static_delay"`) → `SET_OUTPUT_DELAY` (`"set_output_delay"`)
- `StaticDelayChangedEvent` → `OutputDelayChangedEvent` (a public event type this repo exposes, not wire-facing, but part of the same rename — missed in the first commit, fixed in the second)

Applied consistently across the server-side player role, client-side model usage, and docstrings.

**Backward compatibility** (mirroring [#343](https://github.com/Sendspin/aiosendspin/pull/343)'s "keep serving clients on the pre-rename artwork wire"): a client still using `static_delay_ms`/`set_static_delay` is tolerated, not disconnected.

- `PlayerCommand.SET_STATIC_DELAY` stays a valid enum value.
- `PlayerStatePayload.__pre_deserialize__` rewrites incoming `static_delay_ms` onto `output_delay_ms`, recording `legacy_delay_key` so `PlayerV1Role.client_state_deviations()` flags it — tolerated when the server allows noncompliant clients, rejected in strict mode via the existing `flag_noncompliance` machinery (no new enforcement path needed).
- `set_output_delay()` now addresses the client using whichever spelling it declared in `state_supported_commands` — a client that only ever declared `set_static_delay` wouldn't recognize a `set_output_delay` command in `server/command`.
- `PlayerCommandPayload.__post_serialize__` serializes `output_delay_ms` under the wire key matching `command`, so constructing the payload with `command=SET_STATIC_DELAY` produces the pre-rename wire shape from the same Python-side field.

## Why now

Same root cause as #343: [Sendspin/sendspin-jvm#33](https://github.com/Sendspin/sendspin-jvm/pull/33) adopted the new field names ahead of aiosendspin. Once #343 merged and got a sendspin-jvm client's `client/hello` past the artwork-parsing failure, `client/state` then failed for the same reason one layer deeper — a sendspin-jvm client sends `output_delay_ms` and declares `set_output_delay` in `supported_commands`, and aiosendspin rejected it: `"'set_output_delay' is not a valid PlayerCommand"`. See [Sendspin/conformance#107](https://github.com/Sendspin/conformance/pull/107) for where this surfaced (re-running the matrix after #343 merged).

## Test plan

- [x] Full test suite: `pytest -n0` (xdist disabled — its worker-spawn native `av`/PyAV extension loading is flaky in this sandbox, independent of this change) — 1606 passed, 8 skipped, 0 failed
- [x] `ruff check` and `ruff format --check` both clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
