### PR TITLE
key supported_pair_methods by pairing method identifier

### DIFF
--- a/aiosendspin/client/__init__.py
+++ b/aiosendspin/client/__init__.py
@@ -1,5 +1,7 @@
 """Public interface for the Sendspin client package."""
 
+from aiosendspin.models.types import SECRET_LOCATIONS
+
 from .client import (
     AudioChunkCallback,
     DisconnectCallback,
@@ -12,7 +14,6 @@ from .client import (
 )
 from .listener import ClientListener
 from .models import (
-    SECRET_LOCATIONS,
     AudioFormat,
     PairingCodeDisplay,
     PairingCodeSpeaker,

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -32,6 +32,7 @@ from aiosendspin.models.core import (
     ClientStatePayload,
     ClientTimeMessage,
     ClientTimePayload,
+    DynamicPairMethodDescriptor,
     GroupUpdateServerMessage,
     GroupUpdateServerPayload,
     PairMethodDescriptor,
@@ -48,6 +49,7 @@ from aiosendspin.models.core import (
     StreamClearMessage,
     StreamEndMessage,
     StreamStartMessage,
+    SupportedPairMethods,
     UnpairedAccess,
 )
 from aiosendspin.models.management import (
@@ -267,6 +269,7 @@ class SendspinConnection:
         self._selected_pairing: ActivatePairing | None = None
         self._pairing_index = 0
         self._pairing_attempt_in_progress = False
+        self._logged_static_pairing_code_dropped = False
         self._exchange_in_progress = False
         self._send_lock = asyncio.Lock()
         self._time_filter = SendspinTimeFilter()
@@ -685,7 +688,20 @@ class SendspinConnection:
             methods.append(PairMethod.STATIC_PAIRING_CODE)
         if PairMethod.DYNAMIC_PAIRING_CODE in implemented and config.dynamic_pairing_code_enabled:
             methods.append(PairMethod.DYNAMIC_PAIRING_CODE)
+            methods = self._without_static_pairing_code(methods)
         return tuple(methods)
+
+    def _without_static_pairing_code(self, methods: list[PairMethod]) -> list[PairMethod]:
+        """Drop ``static_pairing_code``, which may not be offered alongside the dynamic one."""
+        if PairMethod.STATIC_PAIRING_CODE not in methods:
+            return methods
+        if not self._logged_static_pairing_code_dropped:
+            self._logged_static_pairing_code_dropped = True
+            logger.info(
+                "Offering dynamic_pairing_code only: a client may not offer both pairing-code "
+                "methods, so the configured static pairing code goes unused"
+            )
+        return [m for m in methods if m is not PairMethod.STATIC_PAIRING_CODE]
 
     async def _unpaired_access_enabled(self) -> bool:
         """Whether the client currently admits unpaired access (from pairing config)."""
@@ -1012,26 +1028,30 @@ class SendspinConnection:
             visualizer_support=self._client.visualizer_support,
             source_support=self._client.source_support,
             trust_level=self._compute_trust(),
-            supported_pair_methods=[
-                await self._pair_method_descriptor(m) for m in await self._supported_pair_methods()
-            ],
+            supported_pair_methods=await self._build_supported_pair_methods(),
             unpaired_access=UnpairedAccess(enabled=await self._unpaired_access_enabled()),
         )
         return ClientHelloMessage(payload=payload)
 
-    async def _pair_method_descriptor(self, method: PairMethod) -> PairMethodDescriptor:
-        """Build the ``client/hello`` descriptor for ``method``."""
-        if method is not PairMethod.DYNAMIC_PAIRING_CODE:
-            locations = self._client.secret_locations
-            return PairMethodDescriptor(
-                method=method, locations=list(locations) if locations else None
+    async def _build_supported_pair_methods(self) -> SupportedPairMethods:
+        """Build the ``client/hello`` advertisement of the methods this client offers."""
+        methods = await self._supported_pair_methods()
+        offered = SupportedPairMethods()
+        if PairMethod.PAIRING_PSK in methods:
+            offered.pairing_psk = self._secret_method_descriptor()
+        if PairMethod.STATIC_PAIRING_CODE in methods:
+            offered.static_pairing_code = self._secret_method_descriptor()
+        if PairMethod.DYNAMIC_PAIRING_CODE in methods:
+            offered.dynamic_pairing_code = DynamicPairMethodDescriptor(
+                out_channels=list(self._client.pairing_code_out_channels),
+                formats=[f.value for f in await self._dynamic_pairing_formats()],
             )
-        out_channels = self._client.pairing_code_out_channels
-        return PairMethodDescriptor(
-            method=method,
-            formats=[f.value for f in await self._dynamic_pairing_formats()],
-            out_channels=list(out_channels) if out_channels else None,
-        )
+        return offered
+
+    def _secret_method_descriptor(self) -> PairMethodDescriptor:
+        """Build the descriptor for a method whose secret the operator looks up."""
+        locations = self._client.secret_locations
+        return PairMethodDescriptor(locations=list(locations) if locations else None)
 
     def _compute_trust(self) -> TrustLevel:
         """Trust extended to the reached server: ``user`` when paired, else ``none``."""

--- a/aiosendspin/client/models.py
+++ b/aiosendspin/client/models.py
@@ -5,14 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol
 
-from aiosendspin.models.types import AudioCodec
+from aiosendspin.models.types import SECRET_LOCATIONS, AudioCodec
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
-
-# Places a static pairing secret may be found, per the spec's pair-method descriptor.
-SECRET_LOCATIONS: frozenset[str] = frozenset({"device", "leaflet", "operator"})
 
 # Visual out-channel for a derived dynamic pairing code, cleared by a ``None`` call.
 type PairingCodeDisplay = Callable[[str | None], Awaitable[None]]
@@ -39,8 +36,9 @@ class PairingSupport:
 
     The gesture itself is reported by calling ``SendspinClient.open_pairing_window``.
     Its presence enables offering ``static_pairing_code``, unless
-    ``offer_static_pairing_code`` declines it. Any pairing-code out-channel
-    additionally enables ``dynamic_pairing_code``.
+    ``offer_static_pairing_code`` declines it. Any pairing-code out-channel enables
+    ``dynamic_pairing_code``, which supersedes ``static_pairing_code``: a client may
+    offer only one pairing-code method.
     """
 
     gesture_prompt: Callable[[bool], Awaitable[None]] | None = None

--- a/aiosendspin/models/core.py
+++ b/aiosendspin/models/core.py
@@ -35,6 +35,9 @@ from .source import (
     SourceStatePayload,
 )
 from .types import (
+    PAIRING_CODE_FORMATS,
+    PAIRING_CODE_OUT_CHANNELS,
+    SECRET_LOCATIONS,
     Activity,
     ClientMessage,
     ConnectionReason,
@@ -110,23 +113,144 @@ class DeviceInfo(SendspinModel):
         omit_none = True
 
 
+# Descriptor fields whose values a peer filters down to the identifiers it knows, keyed by
+# the method that carries them. Doubles as the set of method identifiers we recognize.
+_PAIR_METHOD_VALUE_FILTERS: dict[str, dict[str, frozenset[str]]] = {
+    PairMethod.PAIRING_PSK.value: {"locations": SECRET_LOCATIONS},
+    PairMethod.STATIC_PAIRING_CODE.value: {"locations": SECRET_LOCATIONS},
+    PairMethod.DYNAMIC_PAIRING_CODE.value: {
+        "formats": PAIRING_CODE_FORMATS,
+        "out_channels": PAIRING_CODE_OUT_CHANNELS,
+    },
+}
+
+# Records the parser writes onto the container; never read from the wire.
+_PAIR_METHOD_SIDECARS: frozenset[str] = frozenset(
+    {"ignored_methods", "unusable_methods", "offered_both_pairing_code_methods"}
+)
+
+
+def _pair_methods_from_list(entries: Any) -> dict[str, Any]:
+    """Key a superseded list of self-describing descriptors by method identifier."""
+    return {
+        entry["method"]: {k: v for k, v in entry.items() if k != "method"}
+        for entry in entries
+        if isinstance(entry, dict) and isinstance(entry.get("method"), str)
+    }
+
+
+def _filter_descriptor_values(
+    descriptor: dict[str, Any], value_filters: dict[str, frozenset[str]]
+) -> dict[str, Any]:
+    """Drop descriptor values this implementation does not recognize."""
+    filtered = dict(descriptor)
+    for field_name, allowed in value_filters.items():
+        if field_name not in filtered:
+            continue
+        values = filtered[field_name]
+        # A field of the wrong type offers nothing usable, same as one filtered empty.
+        filtered[field_name] = (
+            [v for v in values if v in allowed] if isinstance(values, list) else []
+        )
+    return filtered
+
+
 @dataclass
 class PairMethodDescriptor(SendspinModel):
-    """A pairing method a client offers in client/hello."""
+    """A secret-based pairing method a client offers in client/hello."""
 
-    method: PairMethod
-    """The pairing method identifier."""
-    formats: list[str] | None = None
-    """For dynamic_pairing_code only: emission formats offered by the client."""
-    out_channels: list[str] | None = None
-    """For dynamic_pairing_code only: channels through which the code is conveyed."""
     locations: list[str] | None = None
-    """For static_pairing_code and pairing_psk only: where the operator finds the secret."""
+    """Where the operator finds the method's configured secret, from SECRET_LOCATIONS."""
 
     class Config(SendspinConfig):
-        """Omit method-specific fields where they do not apply."""
+        """Omit the hint where the client does not give one."""
 
         omit_none = True
+
+
+@dataclass
+class DynamicPairMethodDescriptor(SendspinModel):
+    """The dynamic pairing code method a client offers in client/hello."""
+
+    out_channels: list[str]
+    """Channels through which the code reaches the operator, from PAIRING_CODE_OUT_CHANNELS."""
+    formats: list[str]
+    """Emission formats the client offers, from PAIRING_CODE_FORMATS. Non-empty."""
+
+    def __post_init__(self) -> None:
+        """Validate field values."""
+        if not self.formats:
+            raise ValueError("formats must be non-empty")
+        if not self.out_channels:
+            raise ValueError("out_channels must be non-empty")
+
+
+@dataclass
+class SupportedPairMethods(SendspinModel):
+    """Pairing methods a client offers, keyed by method identifier.
+
+    Only recognized methods survive the parse: an identifier this implementation does not
+    know is dropped into ``ignored_methods`` rather than rejected, since it signals a client
+    speaking a newer revision of the spec. Tolerance covers identifiers and values, not
+    shape: a recognized method whose descriptor is not an object fails the parse.
+    """
+
+    pairing_psk: PairMethodDescriptor | None = None
+    """The pairing PSK method, offered by every conformant client."""
+    static_pairing_code: PairMethodDescriptor | None = None
+    """The static pairing code method."""
+    dynamic_pairing_code: DynamicPairMethodDescriptor | None = None
+    """The per-session dynamic pairing code method."""
+    ignored_methods: list[str] | None = None
+    """Method identifiers this implementation does not recognize, recorded for the server
+    to log. Not part of the wire schema (omitted when None)."""
+    unusable_methods: list[str] | None = None
+    """Recognized methods dropped for offering no value this implementation knows, recorded
+    for the server to log. Not part of the wire schema (omitted when None)."""
+    offered_both_pairing_code_methods: bool | None = None
+    """Whether the client offered both pairing-code methods, leaving neither the static one
+    nor an unusable dynamic one. Not part of the wire schema (omitted when None)."""
+
+    class Config(SendspinConfig):
+        """Omit methods the client does not offer."""
+
+        omit_none = True
+
+    @classmethod
+    def __pre_deserialize__(cls, d: dict[str, Any]) -> dict[str, Any]:
+        """Drop unrecognized methods and values, then degrade an over-broad advertisement."""
+        normalized = {k: v for k, v in d.items() if k in _PAIR_METHOD_VALUE_FILTERS}
+        ignored = sorted(set(d) - set(normalized) - _PAIR_METHOD_SIDECARS)
+        for key, value_filters in _PAIR_METHOD_VALUE_FILTERS.items():
+            descriptor = normalized.get(key)
+            if not isinstance(descriptor, dict):
+                continue
+            normalized[key] = _filter_descriptor_values(descriptor, value_filters)
+        # Offering both code methods is judged on the identifiers received, before any are
+        # dropped: the static descriptor is disregarded whether or not the dynamic one
+        # survives, so an over-broad advertisement degrades toward no code method at all.
+        both = (
+            PairMethod.STATIC_PAIRING_CODE.value in normalized
+            and PairMethod.DYNAMIC_PAIRING_CODE.value in normalized
+        )
+        if both:
+            del normalized[PairMethod.STATIC_PAIRING_CODE.value]
+        dynamic = normalized.get(PairMethod.DYNAMIC_PAIRING_CODE.value)
+        unusable = isinstance(dynamic, dict) and not (
+            dynamic.get("formats") and dynamic.get("out_channels")
+        )
+        if unusable:
+            del normalized[PairMethod.DYNAMIC_PAIRING_CODE.value]
+        # Always overwrite so a client cannot spoof the records via the wire.
+        normalized["ignored_methods"] = ignored or None
+        normalized["unusable_methods"] = (
+            [PairMethod.DYNAMIC_PAIRING_CODE.value] if unusable else None
+        )
+        normalized["offered_both_pairing_code_methods"] = both or None
+        return normalized
+
+
+assert set(_PAIR_METHOD_VALUE_FILTERS) <= {f.name for f in fields(SupportedPairMethods)}
 
 
 @dataclass
@@ -166,8 +290,11 @@ class ClientHelloPayload(SendspinModel):
         ClientHelloVisualizerSupportDraftR1 | None, Alias("visualizer@_draft_r1_support")
     ] = None
     """Visualizer support for clients on the legacy `visualizer@_draft_r1` wire."""
-    supported_pair_methods: list[PairMethodDescriptor] | None = None
+    supported_pair_methods: SupportedPairMethods | None = None
     """Pairing methods this client offers."""
+    legacy_pair_methods_list_used: bool | None = None
+    """Whether supported_pair_methods arrived as the superseded list, recorded for the
+    server to flag. Not part of the wire schema (omitted when None)."""
     unpaired_access: UnpairedAccess = field(default_factory=UnpairedAccess)
     """Whether this client currently admits unpaired access."""
     legacy_support_keys_used: list[str] | None = None
@@ -201,8 +328,15 @@ class ClientHelloPayload(SendspinModel):
             # Rewrite to the versioned alias only when the client didn't also send it.
             if versioned_key not in normalized:
                 normalized[versioned_key] = value
-        # Always overwrite so a client cannot spoof the record via the wire.
+        # Clients on the superseded wire send supported_pair_methods as a list whose
+        # entries each name their own method; rewrite it onto the keyed object.
+        pair_methods = normalized.get("supported_pair_methods")
+        legacy_pair_methods_list = isinstance(pair_methods, list)
+        if legacy_pair_methods_list:
+            normalized["supported_pair_methods"] = _pair_methods_from_list(pair_methods)
+        # Always overwrite so a client cannot spoof the records via the wire.
         normalized["legacy_support_keys_used"] = legacy_keys or None
+        normalized["legacy_pair_methods_list_used"] = legacy_pair_methods_list or None
         return normalized
 
     def __post_init__(self) -> None:

--- a/aiosendspin/models/types.py
+++ b/aiosendspin/models/types.py
@@ -264,6 +264,13 @@ class PairingCodeFormat(Enum):
     QR_CODE = "qr_code"
 
 
+# Values a pair-method descriptor may carry. A peer ignores any other value it finds there,
+# so these gate the parse as plain sets; an enum would reject the descriptor outright.
+PAIRING_CODE_FORMATS: frozenset[str] = frozenset(f.value for f in PairingCodeFormat)
+PAIRING_CODE_OUT_CHANNELS: frozenset[str] = frozenset({"display", "speaker"})
+SECRET_LOCATIONS: frozenset[str] = frozenset({"device", "leaflet", "operator"})
+
+
 class PairAbortReason(Enum):
     """Reason a pairing attempt was aborted."""
 

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -1086,18 +1086,7 @@ class SendspinConnection:
         )
         self._logger = logger.getChild(client_id)
         self._logger.debug("Received client/hello: %s", client_info)
-        if client_info.legacy_support_keys_used:
-            self._flag_noncompliance(
-                "client/hello used unversioned support keys: "
-                + ", ".join(client_info.legacy_support_keys_used)
-            )
-        if client_info.unlisted_support_roles:
-            self._flag_noncompliance(
-                "client/hello sent support objects for unlisted roles: "
-                + ", ".join(client_info.unlisted_support_roles)
-            )
-        if client_info.artwork_support is not None:
-            self._flag_legacy_artwork_wire(client_info.artwork_support)
+        self._note_client_hello_wire(client_info)
         if unimplemented := self._unimplemented_roles(client_info.supported_roles):
             self._logger.info(
                 "Client offered roles/versions this server does not implement: %s", unimplemented
@@ -1144,6 +1133,46 @@ class SendspinConnection:
             )
         if any(channel.format is PictureFormat.BMP for channel in support.channels):
             self._flag_noncompliance("client/hello artwork declared the removed 'bmp' format")
+
+    def _note_client_hello_wire(self, client_info: ClientHelloPayload) -> None:
+        """Record what the hello reveals about the wire revision the client speaks."""
+        if client_info.legacy_support_keys_used:
+            self._flag_noncompliance(
+                "client/hello used unversioned support keys: "
+                + ", ".join(client_info.legacy_support_keys_used)
+            )
+        if client_info.unlisted_support_roles:
+            self._flag_noncompliance(
+                "client/hello sent support objects for unlisted roles: "
+                + ", ".join(client_info.unlisted_support_roles)
+            )
+        if client_info.artwork_support is not None:
+            self._flag_legacy_artwork_wire(client_info.artwork_support)
+        self._note_pair_method_wire(client_info)
+
+    def _note_pair_method_wire(self, client_info: ClientHelloPayload) -> None:
+        """Flag pair-method deviations, and log identifiers this server does not know."""
+        if client_info.legacy_pair_methods_list_used:
+            self._flag_noncompliance("client/hello sent supported_pair_methods as a list")
+        methods = client_info.supported_pair_methods
+        if methods is None:
+            return
+        if methods.offered_both_pairing_code_methods:
+            self._flag_noncompliance(
+                "client/hello offered both pairing-code methods; disregarding static_pairing_code"
+            )
+        if methods.ignored_methods:
+            # Offering a method this server does not know is conformant: the client speaks a
+            # newer revision of the spec. Worth noticing, but not a compliance failure.
+            self._logger.info(
+                "client/hello offered unrecognized pairing methods: %s",
+                ", ".join(methods.ignored_methods),
+            )
+        if methods.unusable_methods:
+            self._logger.info(
+                "client/hello offered pairing methods with no usable values: %s",
+                ", ".join(methods.unusable_methods),
+            )
 
     async def _admit_legacy_client_id(self, client_id: str) -> bool:
         """Whether an unauthenticated (legacy) hello may claim ``client_id``."""
@@ -1467,19 +1496,11 @@ class SendspinConnection:
         assert self._pairing_attempt is not None
         requested = self._pairing_attempt.pairing_format
         assert requested is not None
-        descriptor = next(
-            (
-                d
-                for d in (self._client_info.supported_pair_methods or [])
-                if d.method is PairMethod.DYNAMIC_PAIRING_CODE
-            ),
-            None,
-        )
+        methods = self._client_info.supported_pair_methods
+        descriptor = methods.dynamic_pairing_code if methods is not None else None
         if descriptor is None:
             # The advertisement lags a management enable; the client arbitrates.
             return requested
-        if not descriptor.formats:
-            raise PairingError("client's dynamic_pairing_code descriptor is missing formats")
         if requested.value not in descriptor.formats:
             raise PairingError(f"client does not offer the {requested.value} emission format")
         return requested

--- a/tests/integration/test_management_flow.py
+++ b/tests/integration/test_management_flow.py
@@ -19,7 +19,6 @@ from aiosendspin.models.types import (
     AudioCodec,
     GoodbyeReason,
     ManagementResult,
-    PairMethod,
     PlayerCommand,
     Roles,
 )
@@ -404,8 +403,8 @@ async def test_set_pairing_config_disables_offered_method() -> None:
             first = await _await_connected_client(server, identity.peer_id)
             assert first.connection is not None
             info = first.connection._client_info  # noqa: SLF001
-            offered = {d.method for d in info.supported_pair_methods or []}
-            assert PairMethod.PAIRING_PSK in offered
+            assert info.supported_pair_methods is not None
+            assert info.supported_pair_methods.pairing_psk is not None
 
             conn = server.enable_management(identity.peer_id)
             await _await_activity(client, Activity.MANAGEMENT)
@@ -428,8 +427,8 @@ async def test_set_pairing_config_disables_offered_method() -> None:
             again = await _await_connected_client(server, identity.peer_id)
             assert again.connection is not None
             info = again.connection._client_info  # noqa: SLF001
-            offered = {d.method for d in info.supported_pair_methods or []}
-            assert PairMethod.PAIRING_PSK not in offered
+            assert info.supported_pair_methods is not None
+            assert info.supported_pair_methods.pairing_psk is None
         finally:
             await reconnect.disconnect()
 

--- a/tests/integration/test_noise_pairing_flow.py
+++ b/tests/integration/test_noise_pairing_flow.py
@@ -630,8 +630,8 @@ async def test_live_pairing_method_enabled_after_hello_still_pairs() -> None:
             conn = await _find_connection_by_client_id(server, client_identity.peer_id)
             assert conn._client_info is not None  # noqa: SLF001
             info = conn._client_info  # noqa: SLF001
-            offered = {d.method for d in (info.supported_pair_methods or [])}
-            assert PairMethod.DYNAMIC_PAIRING_CODE not in offered
+            assert info.supported_pair_methods is not None
+            assert info.supported_pair_methods.dynamic_pairing_code is None
 
             config = await client_store.get_pairing_config()
             await client_store.store_pairing_config(
@@ -689,11 +689,10 @@ async def test_live_pairing_qr_code() -> None:
             await client.connect(url)
             conn = await _find_connection_by_client_id(server, client_identity.peer_id)
             assert conn._client_info is not None  # noqa: SLF001
-            descriptor = next(
-                d
-                for d in (conn._client_info.supported_pair_methods or [])  # noqa: SLF001
-                if d.method is PairMethod.DYNAMIC_PAIRING_CODE
-            )
+            methods = conn._client_info.supported_pair_methods  # noqa: SLF001
+            assert methods is not None
+            descriptor = methods.dynamic_pairing_code
+            assert descriptor is not None
             assert descriptor.formats == ["digits", "qr_code"]
             await conn.initiate_pairing(
                 PairingAttempt(
@@ -711,7 +710,11 @@ async def test_live_pairing_qr_code() -> None:
 
 
 async def test_live_pairing_ignores_unrecognized_advertised_formats() -> None:
-    """A descriptor format from a newer spec revision is ignored; the known ones still pair."""
+    """A descriptor format from a newer spec revision is ignored; the known ones still pair.
+
+    The parse filters unknown formats out, so the descriptor is mutated afterwards to reach
+    the server's own selection check directly.
+    """
     server_store = InMemoryServerPairingStore()
     server = _make_server(server_store)
     client_identity = Identity.generate()
@@ -738,11 +741,10 @@ async def test_live_pairing_ignores_unrecognized_advertised_formats() -> None:
             await client.connect(url)
             conn = await _find_connection_by_client_id(server, client_identity.peer_id)
             assert conn._client_info is not None  # noqa: SLF001
-            descriptor = next(
-                d
-                for d in (conn._client_info.supported_pair_methods or [])  # noqa: SLF001
-                if d.method is PairMethod.DYNAMIC_PAIRING_CODE
-            )
+            methods = conn._client_info.supported_pair_methods  # noqa: SLF001
+            assert methods is not None
+            descriptor = methods.dynamic_pairing_code
+            assert descriptor is not None
             descriptor.formats = ["holographic", "digits"]
 
             await conn.initiate_pairing(
@@ -757,17 +759,11 @@ async def test_live_pairing_ignores_unrecognized_advertised_formats() -> None:
             await client.disconnect()
 
 
-@pytest.mark.parametrize(
-    ("formats", "match"),
-    [
-        (["holographic"], "does not offer the digits"),
-        (None, "missing formats"),
-    ],
-)
-async def test_live_pairing_unusable_advertised_formats(
-    formats: list[str] | None, match: str
-) -> None:
-    """Only unknown formats offer nothing to select; a missing field is nonconformant."""
+async def test_live_pairing_unusable_advertised_formats() -> None:
+    """A format the client does not offer is refused before the attempt starts.
+
+    As above, the descriptor is mutated past the parse to exercise the selection check itself.
+    """
     server_store = InMemoryServerPairingStore()
     server = _make_server(server_store)
     client_identity = Identity.generate()
@@ -785,14 +781,13 @@ async def test_live_pairing_unusable_advertised_formats(
             await client.connect(url)
             conn = await _find_connection_by_client_id(server, client_identity.peer_id)
             assert conn._client_info is not None  # noqa: SLF001
-            descriptor = next(
-                d
-                for d in (conn._client_info.supported_pair_methods or [])  # noqa: SLF001
-                if d.method is PairMethod.DYNAMIC_PAIRING_CODE
-            )
-            descriptor.formats = formats
+            methods = conn._client_info.supported_pair_methods  # noqa: SLF001
+            assert methods is not None
+            descriptor = methods.dynamic_pairing_code
+            assert descriptor is not None
+            descriptor.formats = ["holographic"]
 
-            with pytest.raises(PairingError, match=match):
+            with pytest.raises(PairingError, match="does not offer the digits"):
                 await conn.initiate_pairing(
                     PairingAttempt(
                         method=PairMethod.DYNAMIC_PAIRING_CODE,

--- a/tests/models/test_hello_pairing_fields.py
+++ b/tests/models/test_hello_pairing_fields.py
@@ -7,9 +7,11 @@ import orjson
 from aiosendspin.models.core import (
     ActivatePairing,
     ClientHelloPayload,
+    DynamicPairMethodDescriptor,
     PairMethodDescriptor,
     ServerActivatePayload,
     ServerHelloPayload,
+    SupportedPairMethods,
     UnpairedAccess,
 )
 from aiosendspin.models.types import Activity, PairMethod, TrustLevel
@@ -23,13 +25,15 @@ def test_client_hello_pairing_fields_round_trip() -> None:
         version=1,
         supported_roles=["controller@v1"],
         trust_level=TrustLevel.USER,
-        supported_pair_methods=[PairMethodDescriptor(method=PairMethod.PAIRING_PSK)],
+        supported_pair_methods=SupportedPairMethods(pairing_psk=PairMethodDescriptor()),
         unpaired_access=UnpairedAccess(enabled=True),
     )
     restored = ClientHelloPayload.from_json(payload.to_json())
     assert restored == payload
     assert restored.trust_level is TrustLevel.USER
-    assert restored.supported_pair_methods == [PairMethodDescriptor(method=PairMethod.PAIRING_PSK)]
+    assert restored.supported_pair_methods == SupportedPairMethods(
+        pairing_psk=PairMethodDescriptor()
+    )
     assert restored.unpaired_access.enabled is True
 
 
@@ -74,16 +78,18 @@ def test_activate_pairing_omits_format_for_non_dynamic_methods() -> None:
     assert raw["pairing"] == {"method": "static_pairing_code"}
 
 
-def test_unrecognized_descriptor_format_still_parses() -> None:
-    """A hello advertising a format from a newer spec revision parses; the reader ignores it."""
+def test_unrecognized_descriptor_format_is_dropped() -> None:
+    """A format from a newer spec revision is ignored rather than selected or rejected."""
     raw = (
         '{"client_id":"c1","name":"Client","version":1,"supported_roles":["controller@v1"],'
-        '"supported_pair_methods":[{"method":"dynamic_pairing_code",'
-        '"formats":["digits","holographic"]}]}'
+        '"supported_pair_methods":{"dynamic_pairing_code":'
+        '{"formats":["digits","holographic"],"out_channels":["display"]}}}'
     )
     payload = ClientHelloPayload.from_json(raw)
     assert payload.supported_pair_methods is not None
-    assert payload.supported_pair_methods[0].formats == ["digits", "holographic"]
+    dynamic = payload.supported_pair_methods.dynamic_pairing_code
+    assert dynamic is not None
+    assert dynamic.formats == ["digits"]
 
 
 def test_unrecognized_activate_format_still_parses() -> None:
@@ -113,11 +119,132 @@ def test_activate_pairing_languages_round_trip() -> None:
 
 
 def test_pair_method_descriptor_locations_round_trip() -> None:
-    """A static-secret descriptor carries the locations hint, others omit it."""
-    descriptor = PairMethodDescriptor(
-        method=PairMethod.STATIC_PAIRING_CODE, locations=["device", "leaflet"]
-    )
+    """A static-secret descriptor carries the locations hint, or omits it entirely."""
+    descriptor = PairMethodDescriptor(locations=["device", "leaflet"])
     restored = PairMethodDescriptor.from_json(descriptor.to_json())
     assert restored.locations == ["device", "leaflet"]
-    bare = PairMethodDescriptor(method=PairMethod.PAIRING_PSK)
-    assert orjson.loads(bare.to_json()) == {"method": "pairing_psk"}
+    assert orjson.loads(PairMethodDescriptor().to_json()) == {}
+
+
+def test_supported_pair_methods_serializes_keyed_by_method() -> None:
+    """The advertisement goes on the wire as an object keyed by method identifier."""
+    payload = ClientHelloPayload(
+        client_id="c1",
+        name="Client",
+        version=1,
+        supported_roles=["controller@v1"],
+        supported_pair_methods=SupportedPairMethods(
+            pairing_psk=PairMethodDescriptor(locations=["device"]),
+            dynamic_pairing_code=DynamicPairMethodDescriptor(
+                out_channels=["display"], formats=["digits"]
+            ),
+        ),
+    )
+    raw = orjson.loads(payload.to_json())
+    assert raw["supported_pair_methods"] == {
+        "pairing_psk": {"locations": ["device"]},
+        "dynamic_pairing_code": {"out_channels": ["display"], "formats": ["digits"]},
+    }
+
+
+def test_superseded_pair_methods_list_is_accepted() -> None:
+    """A client advertising the superseded list is understood, and the shape recorded."""
+    raw = (
+        '{"client_id":"c1","name":"Client","version":1,"supported_roles":["controller@v1"],'
+        '"supported_pair_methods":[{"method":"pairing_psk","locations":["device"]},'
+        '{"method":"dynamic_pairing_code","formats":["digits"],"out_channels":["speaker"]}]}'
+    )
+    payload = ClientHelloPayload.from_json(raw)
+    assert payload.legacy_pair_methods_list_used is True
+    methods = payload.supported_pair_methods
+    assert methods is not None
+    assert methods.pairing_psk == PairMethodDescriptor(locations=["device"])
+    assert methods.dynamic_pairing_code == DynamicPairMethodDescriptor(
+        out_channels=["speaker"], formats=["digits"]
+    )
+
+
+def test_current_pair_methods_object_is_not_flagged_as_legacy() -> None:
+    """The keyed object is the current wire, so it sets no legacy record."""
+    raw = (
+        '{"client_id":"c1","name":"Client","version":1,"supported_roles":["controller@v1"],'
+        '"supported_pair_methods":{"pairing_psk":{}}}'
+    )
+    payload = ClientHelloPayload.from_json(raw)
+    assert payload.legacy_pair_methods_list_used is None
+    assert payload.supported_pair_methods == SupportedPairMethods(
+        pairing_psk=PairMethodDescriptor()
+    )
+
+
+def test_unrecognized_pair_method_is_ignored_not_rejected() -> None:
+    """An identifier from a newer revision is dropped, its value never validated."""
+    raw = (
+        '{"client_id":"c1","name":"Client","version":1,"supported_roles":["controller@v1"],'
+        '"supported_pair_methods":{"pairing_psk":{},"telepathy":{"anything":[1,2]}}}'
+    )
+    methods = ClientHelloPayload.from_json(raw).supported_pair_methods
+    assert methods is not None
+    assert methods.pairing_psk == PairMethodDescriptor()
+    assert methods.ignored_methods == ["telepathy"]
+
+
+def test_both_pairing_code_methods_degrade_to_dynamic() -> None:
+    """Offering both code methods is a spec violation; the static one is disregarded."""
+    raw = (
+        '{"client_id":"c1","name":"Client","version":1,"supported_roles":["controller@v1"],'
+        '"supported_pair_methods":{"static_pairing_code":{},'
+        '"dynamic_pairing_code":{"formats":["digits"],"out_channels":["display"]}}}'
+    )
+    methods = ClientHelloPayload.from_json(raw).supported_pair_methods
+    assert methods is not None
+    assert methods.static_pairing_code is None
+    assert methods.dynamic_pairing_code is not None
+    assert methods.offered_both_pairing_code_methods is True
+
+
+def test_dynamic_without_recognized_values_is_dropped() -> None:
+    """A dynamic descriptor left with nothing usable is dropped, and recorded on its own.
+
+    It is not an identifier the reader failed to recognize, so it is kept apart from those.
+    """
+    raw = (
+        '{"client_id":"c1","name":"Client","version":1,"supported_roles":["controller@v1"],'
+        '"supported_pair_methods":{"pairing_psk":{},'
+        '"dynamic_pairing_code":{"formats":["holographic"],"out_channels":["display"]}}}'
+    )
+    methods = ClientHelloPayload.from_json(raw).supported_pair_methods
+    assert methods is not None
+    assert methods.dynamic_pairing_code is None
+    assert methods.unusable_methods == ["dynamic_pairing_code"]
+    assert methods.ignored_methods is None
+
+
+def test_both_offered_disregards_static_even_when_dynamic_is_unusable() -> None:
+    """Receiving both identifiers disregards the static descriptor, whatever the dynamic holds."""
+    raw = (
+        '{"client_id":"c1","name":"Client","version":1,"supported_roles":["controller@v1"],'
+        '"supported_pair_methods":{"pairing_psk":{},"static_pairing_code":{},'
+        '"dynamic_pairing_code":{"formats":["holographic"],"out_channels":["display"]}}}'
+    )
+    methods = ClientHelloPayload.from_json(raw).supported_pair_methods
+    assert methods is not None
+    assert methods.offered_both_pairing_code_methods is True
+    assert methods.static_pairing_code is None
+    assert methods.dynamic_pairing_code is None
+    assert methods.unusable_methods == ["dynamic_pairing_code"]
+    assert methods.pairing_psk is not None
+
+
+def test_pair_method_records_cannot_be_spoofed_over_the_wire() -> None:
+    """The parser overwrites its own records, so a client cannot plant them."""
+    raw = (
+        '{"client_id":"c1","name":"Client","version":1,"supported_roles":["controller@v1"],'
+        '"supported_pair_methods":{"pairing_psk":{},"ignored_methods":["invented"],'
+        '"unusable_methods":["invented"],"offered_both_pairing_code_methods":true}}'
+    )
+    methods = ClientHelloPayload.from_json(raw).supported_pair_methods
+    assert methods is not None
+    assert methods.ignored_methods is None
+    assert methods.unusable_methods is None
+    assert methods.offered_both_pairing_code_methods is None

--- a/tests/models/test_source.py
+++ b/tests/models/test_source.py
@@ -9,6 +9,7 @@ from aiosendspin.models.core import (
     ClientStatePayload,
     PairMethodDescriptor,
     ServerCommandPayload,
+    SupportedPairMethods,
 )
 from aiosendspin.models.source import (
     ClientStreamEndMessage,
@@ -18,7 +19,6 @@ from aiosendspin.models.source import (
 from aiosendspin.models.types import (
     AudioCodec,
     ClientMessage,
-    PairMethod,
     SignalState,
     TrustLevel,
 )
@@ -62,7 +62,7 @@ def test_hello_drops_source_support_without_role() -> None:
 
 def test_hello_preserves_supported_pair_methods_positional_argument() -> None:
     """Source support does not displace existing client/hello positional arguments."""
-    pair_methods = [PairMethodDescriptor(method=PairMethod.PAIRING_PSK)]
+    pair_methods = SupportedPairMethods(pairing_psk=PairMethodDescriptor())
     payload = ClientHelloPayload(
         "Client",
         [],

--- a/tests/server/test_hello_pair_method_wire.py
+++ b/tests/server/test_hello_pair_method_wire.py
@@ -1,0 +1,155 @@
+"""How the server records what a client/hello reveals about its pair-method wire."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aiosendspin.models.core import ClientHelloPayload
+from aiosendspin.noise.keys import Identity
+from aiosendspin.noise.trust_store import InMemoryServerPairingStore
+from aiosendspin.server import SendspinServer
+from aiosendspin.server.clock import LoopClock
+from aiosendspin.server.compliance import ClientComplianceError
+from aiosendspin.server.connection import SendspinConnection
+
+
+@dataclass(slots=True)
+class _DummyServer:
+    loop: asyncio.AbstractEventLoop
+    clock: Any
+    id: str = "srv"
+    name: str = "server"
+
+
+def _conn_with_client() -> tuple[SendspinConnection, MagicMock]:
+    loop = asyncio.get_running_loop()
+    conn = SendspinConnection(
+        _DummyServer(loop=loop, clock=LoopClock(loop)), wsock_client=MagicMock()
+    )
+    client = MagicMock()
+    conn._client = client  # noqa: SLF001
+    return conn, client
+
+
+def _hello(pair_methods: Any) -> ClientHelloPayload:
+    return ClientHelloPayload.from_dict(
+        {
+            "client_id": "c1",
+            "name": "Client",
+            "version": 1,
+            "supported_roles": ["controller@v1"],
+            "supported_pair_methods": pair_methods,
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_current_wire_is_not_flagged() -> None:
+    """A conformant advertisement raises nothing with the server."""
+    conn, client = _conn_with_client()
+    conn._note_client_hello_wire(_hello({"pairing_psk": {}}))  # noqa: SLF001
+    client.flag_noncompliance.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_superseded_list_shape_is_flagged() -> None:
+    """The superseded list shape is a tolerated deviation, so the server records it."""
+    conn, client = _conn_with_client()
+    conn._note_client_hello_wire(_hello([{"method": "pairing_psk"}]))  # noqa: SLF001
+    client.flag_noncompliance.assert_called_once()
+    assert "supported_pair_methods as a list" in client.flag_noncompliance.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_offering_both_pairing_code_methods_is_flagged() -> None:
+    """Offering both code methods breaks a MUST NOT, so it is a compliance failure."""
+    conn, client = _conn_with_client()
+    hello = _hello(
+        {
+            "static_pairing_code": {},
+            "dynamic_pairing_code": {"formats": ["digits"], "out_channels": ["display"]},
+        }
+    )
+    conn._note_client_hello_wire(hello)  # noqa: SLF001
+    client.flag_noncompliance.assert_called_once()
+    assert "both pairing-code methods" in client.flag_noncompliance.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_unrecognized_method_is_logged_but_not_flagged(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A method from a newer revision is conformant: a strict server must still admit it."""
+    conn, client = _conn_with_client()
+    hello = _hello({"pairing_psk": {}, "telepathy": {"anything": [1, 2]}})
+    with caplog.at_level(logging.INFO):
+        conn._note_client_hello_wire(hello)  # noqa: SLF001
+    client.flag_noncompliance.assert_not_called()
+    assert any("telepathy" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_unusable_method_is_reported_apart_from_an_unknown_one(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A method dropped for unusable values must not read as a newer-revision identifier."""
+    conn, client = _conn_with_client()
+    hello = _hello(
+        {
+            "pairing_psk": {},
+            "dynamic_pairing_code": {"formats": ["holographic"], "out_channels": ["display"]},
+        }
+    )
+    with caplog.at_level(logging.INFO):
+        conn._note_client_hello_wire(hello)  # noqa: SLF001
+    client.flag_noncompliance.assert_not_called()
+    assert any("no usable values" in record.message for record in caplog.records)
+    assert not any("unrecognized pairing methods" in record.message for record in caplog.records)
+
+
+def _strict_server() -> SendspinServer:
+    loop = asyncio.get_running_loop()
+    client_session = MagicMock()
+    client_session.closed = True
+    client_session.close = AsyncMock()
+    return SendspinServer(
+        loop=loop,
+        identity=Identity.generate(),
+        server_name="server",
+        client_session=client_session,
+        pairing_store=InMemoryServerPairingStore(),
+        allow_noncompliant_clients=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_strict_server_rejects_a_client_offering_both_code_methods() -> None:
+    """The flag is not cosmetic: a strict server turns the MUST NOT breach into a rejection."""
+    server = _strict_server()
+    conn = SendspinConnection(server, wsock_client=MagicMock())
+    conn._client = server.get_or_create_client("dev")  # noqa: SLF001
+    hello = _hello(
+        {
+            "static_pairing_code": {},
+            "dynamic_pairing_code": {"formats": ["digits"], "out_channels": ["display"]},
+        }
+    )
+
+    with pytest.raises(ClientComplianceError, match="both pairing-code methods"):
+        conn._note_client_hello_wire(hello)  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_strict_server_admits_a_client_offering_an_unknown_method() -> None:
+    """A client speaking a newer revision stays admissible even under strict compliance."""
+    server = _strict_server()
+    conn = SendspinConnection(server, wsock_client=MagicMock())
+    conn._client = server.get_or_create_client("dev")  # noqa: SLF001
+
+    conn._note_client_hello_wire(_hello({"pairing_psk": {}, "telepathy": {}}))  # noqa: SLF001

--- a/tests/test_client_pairing.py
+++ b/tests/test_client_pairing.py
@@ -29,7 +29,7 @@ from aiosendspin.noise.models import (
     ServerPairAuthMessage,
     ServerPairAuthPayload,
 )
-from aiosendspin.noise.pairing import PairingError
+from aiosendspin.noise.pairing import LocalPairingAbortError, PairingError
 from aiosendspin.noise.trust_store import (
     PAIRING_CODE_ESCALATION_THRESHOLD,
     PskCategory,
@@ -177,16 +177,12 @@ async def test_pairing_window_tolerates_bare_leave_activate() -> None:
     assert ClientPairPendingMessage.from_json(ws.sent[0]).payload.pairing_index == 1
 
 
-def _dynamic_pairing_code_connection() -> tuple[SendspinConnection, _FakeWS]:
-    """Build a Sentinel-keyed connection whose client offers dynamic pairing code."""
-
-    async def display(pairing_code: str | None) -> None:
-        pass
-
+def _pairing_connection(pairing_support: PairingSupport) -> tuple[SendspinConnection, _FakeWS]:
+    """Build a Sentinel-keyed connection whose client offers ``pairing_support``."""
     client = make_sdk_client(
         client_name="C",
         roles=[Roles.CONTROLLER],
-        pairing_support=PairingSupport(pairing_code_display=display),
+        pairing_support=pairing_support,
     )
     connection = SendspinConnection(client)
     ws = _FakeWS()
@@ -197,6 +193,20 @@ def _dynamic_pairing_code_connection() -> tuple[SendspinConnection, _FakeWS]:
         "psk-id", b"\x00" * 32, PskCategory.SENTINEL
     )
     return connection, ws
+
+
+def _dynamic_pairing_code_connection() -> tuple[SendspinConnection, _FakeWS]:
+    """Build a connection whose client offers the dynamic pairing code."""
+
+    async def display(pairing_code: str | None) -> None:
+        pass
+
+    return _pairing_connection(PairingSupport(pairing_code_display=display))
+
+
+def _static_pairing_code_connection() -> tuple[SendspinConnection, _FakeWS]:
+    """Build a connection whose client offers the static pairing code and no dynamic one."""
+    return _pairing_connection(PairingSupport())
 
 
 async def test_escalated_dynamic_attempt_is_gesture_gated() -> None:
@@ -283,7 +293,7 @@ async def test_static_pairing_code_attempt_consumes_a_pre_open_window(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A static-pairing-code attempt spends a window that is already open."""
-    connection, ws = _dynamic_pairing_code_connection()
+    connection, ws = _static_pairing_code_connection()
     client = connection._client  # noqa: SLF001
     await client.pairing_store.set_static_pairing_code("12345678")
     config = await client.pairing_store.get_pairing_config()
@@ -421,11 +431,12 @@ async def test_hello_descriptors_carry_the_wired_channels_and_locations() -> Non
         "psk-id", b"\x00" * 32, PskCategory.SENTINEL
     )
     hello = await connection._build_client_hello()  # noqa: SLF001
-    descriptors = {d.method: d for d in hello.payload.supported_pair_methods or []}
-    assert descriptors[PairMethod.DYNAMIC_PAIRING_CODE].out_channels == ["display", "speaker"]
-    assert descriptors[PairMethod.DYNAMIC_PAIRING_CODE].locations is None
-    assert descriptors[PairMethod.PAIRING_PSK].locations == ["device", "leaflet"]
-    assert descriptors[PairMethod.PAIRING_PSK].out_channels is None
+    methods = hello.payload.supported_pair_methods
+    assert methods is not None
+    assert methods.dynamic_pairing_code is not None
+    assert methods.dynamic_pairing_code.out_channels == ["display", "speaker"]
+    assert methods.pairing_psk is not None
+    assert methods.pairing_psk.locations == ["device", "leaflet"]
 
 
 async def test_pairing_code_speaker_receives_the_activation_languages() -> None:
@@ -576,3 +587,50 @@ async def test_leave_activate_resumes_time_sync() -> None:
         assert not connection._time_task.done()  # noqa: SLF001
     finally:
         await _cancel_time_task(connection)
+
+
+async def _connection_offering_both_code_methods() -> SendspinConnection:
+    """Build a connection whose config enables both pairing-code methods."""
+
+    async def display(pairing_code: str | None) -> None:
+        pass
+
+    client = make_sdk_client(
+        client_name="C",
+        roles=[Roles.CONTROLLER],
+        pairing_support=PairingSupport(pairing_code_display=display),
+    )
+    await client.pairing_store.set_static_pairing_code("12345678")
+    config = await client.pairing_store.get_pairing_config()
+    await client.pairing_store.store_pairing_config(
+        replace(config, static_pairing_code_enabled=True, dynamic_pairing_code_enabled=True)
+    )
+    connection = SendspinConnection(client)
+    connection._noise_psk = ResolvedPsk(  # noqa: SLF001
+        "psk-id", b"\x00" * 32, PskCategory.SENTINEL
+    )
+    return connection
+
+
+async def test_both_code_methods_wired_advertises_dynamic_only() -> None:
+    """A client may offer only one pairing-code method, and the per-session one wins."""
+    connection = await _connection_offering_both_code_methods()
+
+    hello = await connection._build_client_hello()  # noqa: SLF001
+
+    methods = hello.payload.supported_pair_methods
+    assert methods is not None
+    assert methods.dynamic_pairing_code is not None
+    assert methods.static_pairing_code is None
+    assert methods.pairing_psk is not None
+
+
+async def test_static_pairing_is_refused_once_it_is_no_longer_offered() -> None:
+    """Dropping static from the advertisement also refuses a server that selects it."""
+    connection = await _connection_offering_both_code_methods()
+    connection._ws = _FakeWS()  # type: ignore[assignment]  # noqa: SLF001
+
+    with pytest.raises(LocalPairingAbortError, match="method_not_supported"):
+        await connection._validate_pairing(  # noqa: SLF001
+            ActivatePairing(method=PairMethod.STATIC_PAIRING_CODE)
+        )


### PR DESCRIPTION
# What does this implement/fix?

Implements spec [#179](https://github.com/Sendspin/spec/pull/179) and [#189](https://github.com/Sendspin/spec/pull/189), plus the ignore-unrecognized-identifiers rule from [#178](https://github.com/Sendspin/spec/pull/178) that shares the same parse path.

`supported_pair_methods` in `client/hello` becomes an object keyed by pairing method identifier rather than a list of self-describing descriptors, the reader ignores identifiers and values it does not recognize, and a client may no longer offer both pairing-code methods.

Clients on the superseded list wire keep working: the server rewrites the shape and flags it, as it already does for unversioned support keys and pre-rename artwork dimensions. Their tests are kept as legacy-wire acceptance tests.

One judgement call worth a look. An unrecognized method identifier is logged, not sent through `_flag_noncompliance`: such a client is conformant per `pairing.md:318`, so flagging it would make a server running `allow_noncompliant_clients=False` reject spec-compliant clients. Offering both code methods is an explicit MUST NOT, so that one is flagged.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.