### PR TITLE
psk category replaces trust level

### DIFF
--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -83,7 +83,6 @@ from aiosendspin.models.types import (
     Roles,
     ServerMessage,
     SignalState,
-    TrustLevel,
     UndefinedField,
     role_family,
 )
@@ -1011,7 +1010,6 @@ class SendspinConnection:
             artwork_support=self._client.artwork_support,
             visualizer_support=self._client.visualizer_support,
             source_support=self._client.source_support,
-            trust_level=self._compute_trust(),
             supported_pair_methods=[
                 await self._pair_method_descriptor(m) for m in await self._supported_pair_methods()
             ],
@@ -1032,12 +1030,6 @@ class SendspinConnection:
             formats=[f.value for f in await self._dynamic_pairing_formats()],
             out_channels=list(out_channels) if out_channels else None,
         )
-
-    def _compute_trust(self) -> TrustLevel:
-        """Trust extended to the reached server: ``user`` when paired, else ``none``."""
-        if self._noise_psk is not None and self._noise_psk.category is PskCategory.LONG_TERM:
-            return TrustLevel.USER
-        return TrustLevel.NONE
 
     async def _send_client_hello(self) -> None:
         assert self._ws is not None

--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -1365,7 +1365,7 @@ class SendspinConnection:
     async def _handle_unpair(self) -> None:
         """Handle server/unpair: drop the matched record (unless shared) and close."""
         if self._noise_psk is None or self._noise_psk.category is not PskCategory.LONG_TERM:
-            return  # trust_level 'none' (pairing / unpaired handshake): ignore and continue.
+            return  # Not a long-term session (pairing / unpaired): ignore and continue.
         await handle_unpair(self._client.pairing_store, matched_psk_id=self._noise_psk.psk_id)
         await self._goodbye_and_disconnect(GoodbyeReason.UNPAIRED)
 

--- a/aiosendspin/models/core.py
+++ b/aiosendspin/models/core.py
@@ -43,7 +43,6 @@ from .types import (
     PlaybackStateType,
     Roles,
     ServerMessage,
-    TrustLevel,
     UndefinedField,
     undefined_field,
 )
@@ -145,8 +144,6 @@ class ClientHelloPayload(SendspinModel):
     """Friendly name of the client."""
     supported_roles: list[str]
     """List of versioned role IDs the client supports (e.g., 'player@v1')."""
-    trust_level: TrustLevel = TrustLevel.NONE
-    """Trust the client extends to this server ('none' during pairing/unpaired playback)."""
     device_info: DeviceInfo | None = None
     """Optional information about the device."""
     client_id: str | None = None

--- a/aiosendspin/models/types.py
+++ b/aiosendspin/models/types.py
@@ -53,7 +53,7 @@ def undefined_field() -> UndefinedField:
 
 
 class TrustLevel(Enum):
-    """Trust a client extends to a server, governing allowed management operations."""
+    """Trust a connection carries, derived from the PSK category that admitted it."""
 
     NONE = "none"
     USER = "user"

--- a/aiosendspin/noise/driver.py
+++ b/aiosendspin/noise/driver.py
@@ -376,6 +376,9 @@ def _category_admits(declared: str | None, actual: PskCategory) -> bool:
     leniency is not reachable by an attacker: message 1's payload is encrypted under keys
     mixing the server's static key, and referencing a psk_id at all means holding the PSK
     it hashes from. A code naming no category we know matches nothing, as a miss.
+
+    The spec lists the field as required, so this tolerance is transitional: drop it once
+    no supported server predates the field.
     """
     return declared is None or PskCategory.from_code(declared) is actual
 

--- a/aiosendspin/noise/driver.py
+++ b/aiosendspin/noise/driver.py
@@ -33,7 +33,7 @@ from .models import (
     ServerInitPayload,
 )
 from .session import NoiseCipherSuite, NoiseSession
-from .trust_store import ResolvedPsk
+from .trust_store import PskCategory, ResolvedPsk
 from .wire import EncryptedWebSocket, RawWebSocket
 
 # Per-message timeout during cleartext init and Noise handshake.
@@ -122,7 +122,7 @@ async def run_handshake_server(
     # server/init immediately followed by Noise message 1 (spec: no client
     # message is awaited in between).
     await ws.send_str(server_init_text)
-    await _exchange_as_initiator(ws, session=session, psk_id=resolved.psk_id, timeout_s=timeout_s)
+    await _exchange_as_initiator(ws, session=session, psk=resolved, timeout_s=timeout_s)
 
     return HandshakeResult(
         encrypted_ws=EncryptedWebSocket(ws, session),
@@ -205,7 +205,7 @@ async def run_rehandshake_server(
         prologue=prologue,
         psk=psk.psk,
     )
-    await _exchange_as_initiator(enc_ws, session=session, psk_id=psk.psk_id, timeout_s=timeout_s)
+    await _exchange_as_initiator(enc_ws, session=session, psk=psk, timeout_s=timeout_s)
     enc_ws.swap_session(session)
     return HandshakeResult(
         encrypted_ws=enc_ws,
@@ -277,11 +277,12 @@ async def _exchange_as_initiator(
     transport: HandshakeWebSocket,
     *,
     session: NoiseSession,
-    psk_id: str,
+    psk: ResolvedPsk,
     timeout_s: float,
 ) -> None:
     """Exchange the two ``noise/handshake`` messages as the initiator (server)."""
-    msg1_pt = NoiseMsg1Payload(psk_id=psk_id).to_json().encode("utf-8")
+    msg1 = NoiseMsg1Payload(psk_id=psk.psk_id, psk_category=psk.category.code)
+    msg1_pt = msg1.to_json().encode("utf-8")
     msg1_ct = session.write_message(msg1_pt)
     await transport.send_str(_pack_handshake(msg1_ct))
     hs2_text = await receive_text_frame(transport, what="Noise message 2", timeout_s=timeout_s)
@@ -308,6 +309,9 @@ async def _exchange_as_responder(
     msg1_obj = _parse_msg1_payload(msg1_pt)
 
     resolved = await psk_resolver(msg1_obj.psk_id)
+    if resolved is not None and not _category_admits(msg1_obj.psk_category, resolved.category):
+        # Holding the referenced PSK under another category is a lookup miss, not a match.
+        resolved = None
     if resolved is None:
         raise HandshakeAbortedError(f"no PSK matches psk_id={msg1_obj.psk_id!r}")
     # Stored-pubkey post-match check: the record's bound server_id must be the
@@ -363,6 +367,17 @@ def _read_handshake_message(session: NoiseSession, text: str, what: str) -> byte
         return session.read_message(ciphertext)
     except (NoiseInvalidMessage, NoiseHandshakeError, NoiseValueError) as exc:
         raise HandshakeAbortedError(f"{what} failed Noise authentication") from exc
+
+
+def _category_admits(declared: str | None, actual: PskCategory) -> bool:
+    """Whether a PSK of ``actual`` category answers a message 1 declaring ``declared``.
+
+    A server predating the field declares nothing, and every category answers it. That
+    leniency is not reachable by an attacker: message 1's payload is encrypted under keys
+    mixing the server's static key, and referencing a psk_id at all means holding the PSK
+    it hashes from. A code naming no category we know matches nothing, as a miss.
+    """
+    return declared is None or PskCategory.from_code(declared) is actual
 
 
 def _parse_msg1_payload(plaintext: bytes) -> NoiseMsg1Payload:

--- a/aiosendspin/noise/models.py
+++ b/aiosendspin/noise/models.py
@@ -71,6 +71,16 @@ class NoiseMsg1Payload(SendspinModel):
 
     psk_id: str
     """43-char base64url SHA-256 of the PSK (see ``psk_id_for``)."""
+    psk_category: str | None = None
+    """Category the server is using the referenced PSK as, as a ``PskCategory`` code.
+
+    Absent from servers predating the field, which the client reads as any category.
+    """
+
+    class Config(SendspinConfig):
+        """Omit the category rather than sending it as null."""
+
+        omit_none = True
 
 
 @dataclass

--- a/aiosendspin/noise/trust_store.py
+++ b/aiosendspin/noise/trust_store.py
@@ -60,6 +60,26 @@ class PskCategory(StrEnum):
     SENTINEL = "sentinel"
     """The published Sentinel PSK — used for pairing-code pairing and unpaired playback."""
 
+    @property
+    def code(self) -> str:
+        """The two-letter identifier this category travels under in Noise message 1."""
+        return _PSK_CATEGORY_CODES[self]
+
+    @classmethod
+    def from_code(cls, code: str) -> PskCategory | None:
+        """Return the category a Noise message 1 code names, or None if it names none."""
+        return _PSK_CATEGORIES_BY_CODE.get(code)
+
+
+# The wire codes are deliberately equal-length, so the encrypted payload's length does not
+# reveal which category the server referenced.
+_PSK_CATEGORY_CODES: dict[PskCategory, str] = {
+    PskCategory.LONG_TERM: "lt",
+    PskCategory.PAIRING: "pr",
+    PskCategory.SENTINEL: "sn",
+}
+_PSK_CATEGORIES_BY_CODE: dict[str, PskCategory] = {c: k for k, c in _PSK_CATEGORY_CODES.items()}
+
 
 class StorageExhaustedError(Exception):
     """A pairing cannot persist its record and has no shared-PSK fallback."""

--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -79,6 +79,13 @@ class DisconnectBehaviour(Enum):
     """
 
 
+def _trust_for(category: PskCategory) -> TrustLevel:
+    """Return the trust a connection admitted under ``category`` carries."""
+    if category is PskCategory.LONG_TERM:
+        return TrustLevel.USER
+    return TrustLevel.NONE
+
+
 @dataclass(frozen=True, slots=True)
 class ConnectionSecurity:
     """Read-only view of a live connection's security state."""
@@ -86,7 +93,7 @@ class ConnectionSecurity:
     psk_category: PskCategory
     """Category of the PSK that admitted the connection; a server-verified fact."""
     trust_level: TrustLevel
-    """Trust the client declared toward this server; a client-asserted claim."""
+    """Trust this connection carries, derived from the PSK category that admitted it."""
 
 
 class SendspinClient:
@@ -250,10 +257,9 @@ class SendspinClient:
         conn = self._connection
         if conn is None or conn.psk_category is None:
             return None
-        trust_level = self._info.trust_level if self._info is not None else TrustLevel.NONE
         return ConnectionSecurity(
             psk_category=conn.psk_category,
-            trust_level=trust_level,
+            trust_level=_trust_for(conn.psk_category),
         )
 
     @property

--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -79,21 +79,19 @@ class DisconnectBehaviour(Enum):
     """
 
 
-def _trust_for(category: PskCategory) -> TrustLevel:
-    """Return the trust a connection admitted under ``category`` carries."""
-    if category is PskCategory.LONG_TERM:
-        return TrustLevel.USER
-    return TrustLevel.NONE
-
-
 @dataclass(frozen=True, slots=True)
 class ConnectionSecurity:
     """Read-only view of a live connection's security state."""
 
     psk_category: PskCategory
     """Category of the PSK that admitted the connection; a server-verified fact."""
-    trust_level: TrustLevel
-    """Trust this connection carries, derived from the PSK category that admitted it."""
+
+    @property
+    def trust_level(self) -> TrustLevel:
+        """Trust this connection carries, derived from the PSK category that admitted it."""
+        if self.psk_category is PskCategory.LONG_TERM:
+            return TrustLevel.USER
+        return TrustLevel.NONE
 
 
 class SendspinClient:
@@ -257,10 +255,7 @@ class SendspinClient:
         conn = self._connection
         if conn is None or conn.psk_category is None:
             return None
-        return ConnectionSecurity(
-            psk_category=conn.psk_category,
-            trust_level=_trust_for(conn.psk_category),
-        )
+        return ConnectionSecurity(psk_category=conn.psk_category)
 
     @property
     def is_paired(self) -> bool:

--- a/tests/integration/test_noise_pairing_flow.py
+++ b/tests/integration/test_noise_pairing_flow.py
@@ -556,7 +556,7 @@ async def test_live_pairing_dynamic_pairing_code_language_hint(
 
 
 async def test_live_pairing_updates_connection_security_trust() -> None:
-    """The post-pairing re-hello propagates the client's re-asserted trust_level."""
+    """Pairing promotes the connection to the long-term PSK, and trust follows the category."""
     server_store = InMemoryServerPairingStore()
     server = _make_server(server_store)
     client_identity = Identity.generate()

--- a/tests/models/test_hello_pairing_fields.py
+++ b/tests/models/test_hello_pairing_fields.py
@@ -12,32 +12,40 @@ from aiosendspin.models.core import (
     ServerHelloPayload,
     UnpairedAccess,
 )
-from aiosendspin.models.types import Activity, PairMethod, TrustLevel
+from aiosendspin.models.types import Activity, PairMethod
 
 
 def test_client_hello_pairing_fields_round_trip() -> None:
-    """client/hello carries trust, pairing methods, and unpaired-access flag."""
+    """client/hello carries pairing methods and the unpaired-access flag."""
     payload = ClientHelloPayload(
         client_id="c1",
         name="Client",
         version=1,
         supported_roles=["controller@v1"],
-        trust_level=TrustLevel.USER,
         supported_pair_methods=[PairMethodDescriptor(method=PairMethod.PAIRING_PSK)],
         unpaired_access=UnpairedAccess(enabled=True),
     )
     restored = ClientHelloPayload.from_json(payload.to_json())
     assert restored == payload
-    assert restored.trust_level is TrustLevel.USER
     assert restored.supported_pair_methods == [PairMethodDescriptor(method=PairMethod.PAIRING_PSK)]
     assert restored.unpaired_access.enabled is True
+
+
+def test_client_hello_ignores_a_legacy_trust_level() -> None:
+    """A client still declaring its own trust is understood; the field carries no meaning."""
+    legacy = (
+        '{"client_id":"c1","name":"Client","version":1,'
+        '"supported_roles":["controller@v1"],"trust_level":"user"}'
+    )
+    payload = ClientHelloPayload.from_json(legacy)
+    assert payload.supported_roles == ["controller@v1"]
+    assert not hasattr(payload, "trust_level")
 
 
 def test_client_hello_defaults_when_pairing_fields_absent() -> None:
     """A hello without the new fields deserializes to spec-safe defaults (legacy clients)."""
     legacy = '{"client_id":"c1","name":"Client","version":1,"supported_roles":["controller@v1"]}'
     payload = ClientHelloPayload.from_json(legacy)
-    assert payload.trust_level is TrustLevel.NONE
     assert payload.supported_pair_methods is None
     assert payload.unpaired_access == UnpairedAccess(enabled=False)
 

--- a/tests/models/test_source.py
+++ b/tests/models/test_source.py
@@ -60,7 +60,7 @@ def test_hello_drops_source_support_without_role() -> None:
 
 
 def test_hello_preserves_supported_pair_methods_positional_argument() -> None:
-    """Source support does not displace existing client/hello positional arguments."""
+    """Source support is appended, so it does not displace supported_pair_methods."""
     pair_methods = [PairMethodDescriptor(method=PairMethod.PAIRING_PSK)]
     payload = ClientHelloPayload(
         "Client",

--- a/tests/models/test_source.py
+++ b/tests/models/test_source.py
@@ -20,7 +20,6 @@ from aiosendspin.models.types import (
     ClientMessage,
     PairMethod,
     SignalState,
-    TrustLevel,
 )
 
 
@@ -66,7 +65,6 @@ def test_hello_preserves_supported_pair_methods_positional_argument() -> None:
     payload = ClientHelloPayload(
         "Client",
         [],
-        TrustLevel.NONE,
         None,
         None,
         None,

--- a/tests/noise/test_driver.py
+++ b/tests/noise/test_driver.py
@@ -735,3 +735,134 @@ async def test_server_rejects_msg2_with_malformed_payload() -> None:
             timeout_s=1.0,
         )
     await client_task
+
+
+async def test_psk_held_under_another_category_is_a_lookup_miss() -> None:
+    """The declared category binds: the same psk_id under another category does not match."""
+    server_id = Identity.generate()
+    client_id = Identity.generate()
+    psk = generate_psk()
+    # The server references the PSK as long-term; the client holds it as a pairing PSK.
+    server_resolved = ResolvedPsk(psk_id=psk_id_for(psk), psk=psk, category=PskCategory.LONG_TERM)
+    client_resolved = ResolvedPsk(psk_id=psk_id_for(psk), psk=psk, category=PskCategory.PAIRING)
+
+    server_ws, client_ws = make_ws_pair()
+    server_task = asyncio.create_task(
+        run_handshake_server(
+            server_ws,
+            local_identity=server_id,
+            psk_provider=_provider(server_resolved),
+            timeout_s=1.0,
+        )
+    )
+    with pytest.raises(HandshakeAbortedError, match="no PSK matches psk_id"):
+        await run_handshake_client(
+            client_ws,
+            local_identity=client_id,
+            suite=NoiseCipherSuite.CHACHAPOLY,
+            psk_resolver=_resolver({client_resolved.psk_id: client_resolved}),
+        )
+    await asyncio.gather(server_task, return_exceptions=True)
+
+
+async def test_message_1_without_a_category_admits_any_category() -> None:
+    """A server predating the field declares no category, and the client still matches."""
+    server_id = Identity.generate()
+    client_id = Identity.generate()
+    psk = generate_psk()
+    resolved = ResolvedPsk(
+        psk_id=psk_id_for(psk),
+        psk=psk,
+        category=PskCategory.LONG_TERM,
+        counterparty_id=server_id.peer_id,
+    )
+    server_ws, client_ws = make_ws_pair()
+
+    async def legacy_server() -> None:
+        """Drive the server side, writing the pre-spec message 1 payload verbatim."""
+        client_init = (await server_ws.receive()).data
+        server_init = ServerInitMessage(
+            payload=ServerInitPayload(server_id=server_id.peer_id, version=PROTOCOL_VERSION),
+        ).to_json()
+        prologue = client_init.encode("utf-8") + server_init.encode("utf-8")
+        session = NoiseSession.as_initiator(
+            suite=NoiseCipherSuite.CHACHAPOLY,
+            local_static_priv=server_id.private_bytes,
+            remote_static_pub=client_id.public_bytes,
+            prologue=prologue,
+            psk=psk,
+        )
+        await server_ws.send_str(server_init)
+        msg1 = session.write_message(f'{{"psk_id":"{resolved.psk_id}"}}'.encode())
+        await server_ws.send_str(
+            NoiseHandshakeMessage(payload=NoiseHandshakePayload(data=b64url_encode(msg1))).to_json()
+        )
+        hs2 = NoiseHandshakeMessage.from_json((await server_ws.receive()).data)
+        session.read_message(b64url_decode(hs2.payload.data))
+
+    server_task = asyncio.create_task(legacy_server())
+    client_result = await run_handshake_client(
+        client_ws,
+        local_identity=client_id,
+        suite=NoiseCipherSuite.CHACHAPOLY,
+        psk_resolver=_resolver({resolved.psk_id: resolved}),
+    )
+    await server_task
+
+    assert client_result.psk.category is PskCategory.LONG_TERM
+
+
+async def test_rehandshake_category_mismatch_aborts() -> None:
+    """A category mismatch during a re-handshake is a miss, and a miss there aborts."""
+    server_id = Identity.generate()
+    client_id = Identity.generate()
+
+    psk1 = generate_psk()
+    psk1_resolved = ResolvedPsk(psk_id=psk_id_for(psk1), psk=psk1, category=PskCategory.SENTINEL)
+
+    server_ws, client_ws = make_ws_pair()
+    server_init, client_init = await asyncio.gather(
+        run_handshake_server(
+            server_ws,
+            local_identity=server_id,
+            psk_provider=_provider(psk1_resolved),
+        ),
+        run_handshake_client(
+            client_ws,
+            local_identity=client_id,
+            suite=NoiseCipherSuite.CHACHAPOLY,
+            psk_resolver=_resolver({psk1_resolved.psk_id: psk1_resolved}),
+        ),
+    )
+
+    # The server re-handshakes referencing psk2 as long-term; the client holds it as pairing.
+    psk2 = generate_psk()
+    server_psk2 = ResolvedPsk(
+        psk_id=psk_id_for(psk2),
+        psk=psk2,
+        category=PskCategory.LONG_TERM,
+        counterparty_id=client_id.peer_id,
+    )
+    client_psk2 = ResolvedPsk(psk_id=psk_id_for(psk2), psk=psk2, category=PskCategory.PAIRING)
+
+    server_task = asyncio.create_task(
+        run_rehandshake_server(
+            server_init.encrypted_ws,
+            local_identity=server_id,
+            client_id=client_id.peer_id,
+            suite=server_init.suite,
+            prologue=server_init.handshake_hash,
+            psk=server_psk2,
+            timeout_s=1.0,
+        )
+    )
+    with pytest.raises(HandshakeAbortedError, match="no PSK matches psk_id"):
+        await run_rehandshake_client(
+            client_init.encrypted_ws,
+            local_identity=client_id,
+            server_id=server_id.peer_id,
+            suite=client_init.suite,
+            prologue=client_init.handshake_hash,
+            psk_resolver=_resolver({client_psk2.psk_id: client_psk2}),
+        )
+    await asyncio.gather(server_task, return_exceptions=True)

--- a/tests/noise/test_models.py
+++ b/tests/noise/test_models.py
@@ -14,6 +14,7 @@ from aiosendspin.noise.models import (
     ServerInitMessage,
     ServerInitPayload,
 )
+from aiosendspin.noise.trust_store import PskCategory
 
 
 def test_client_init_message_round_trip() -> None:
@@ -67,11 +68,25 @@ def test_noise_handshake_message_round_trip() -> None:
     assert parsed.type == "noise/handshake"
 
 
-def test_noise_msg1_payload_carries_psk_id() -> None:
-    """The encrypted msg-1 inner payload exposes ``psk_id`` exactly."""
-    payload = NoiseMsg1Payload(psk_id="GFsV9tLaSQm9HcFWpKsgYQOr7wFTvNUtkmFwuVz3zoo")
+def test_noise_msg1_payload_carries_psk_id_and_category() -> None:
+    """The encrypted msg-1 inner payload exposes ``psk_id`` and the PSK's category code."""
+    payload = NoiseMsg1Payload(
+        psk_id="GFsV9tLaSQm9HcFWpKsgYQOr7wFTvNUtkmFwuVz3zoo",
+        psk_category=PskCategory.SENTINEL.code,
+    )
     raw = payload.to_json()
-    assert raw == '{"psk_id":"GFsV9tLaSQm9HcFWpKsgYQOr7wFTvNUtkmFwuVz3zoo"}'
+    assert raw == ('{"psk_id":"GFsV9tLaSQm9HcFWpKsgYQOr7wFTvNUtkmFwuVz3zoo","psk_category":"sn"}')
+
+
+def test_noise_msg1_payload_omits_an_absent_category() -> None:
+    """A payload without the category omits the key rather than sending null."""
+    payload = NoiseMsg1Payload(psk_id="GFsV9tLaSQm9HcFWpKsgYQOr7wFTvNUtkmFwuVz3zoo")
+    assert payload.to_json() == '{"psk_id":"GFsV9tLaSQm9HcFWpKsgYQOr7wFTvNUtkmFwuVz3zoo"}'
+
+
+def test_noise_msg1_category_codes_share_one_length() -> None:
+    """Equal-length codes keep the encrypted payload's length independent of the category."""
+    assert len({len(category.code) for category in PskCategory}) == 1
 
 
 def test_noise_msg2_payload_serializes_to_empty_object() -> None:


### PR DESCRIPTION
# What does this implement/fix?

Implements spec [#158](https://github.com/Sendspin/spec/pull/158).

Noise message 1 now carries `psk_category` alongside `psk_id`, naming which category the server is using the referenced PSK as. The client matches the `psk_id` only against candidates of that category, so a PSK it holds under a different one is a lookup miss. In exchange, `trust_level` leaves `client/hello`: the server reads trust off the PSK category it matched rather than being told by the client.


NOTE:

- **`ConnectionSecurity.trust_level` changes provenance.** It is now a property derived from `psk_category` rather than a value the client asserted. Consumers see the same attribute, but a client claiming `user` over a Sentinel connection reported `USER` and now reports `NONE`. No authorization gate moves — none of them read the field; they already read the PSK category. This is an API-honesty fix, not a hardening.

- **`ClientHelloPayload`'s positional signature shifts**, since a field was removed.  Keyword construction is unaffected.

Backwards compatible in both directions: a hello still carrying `trust_level` parses and the value is ignored, and a server predating `psk_category` declares none, which the client reads as admitting any category. That leniency is not attacker-reachable — message 1's payload is encrypted under keys mixing the server's static key, and referencing a
`psk_id` at all means holding the PSK it hashes from. It is transitional, and marked as such in `_category_admits`: the spec lists the field as required, so it should be dropped once no supported server predates it.

One implementation note for anyone reading against the spec: `connection.md:119` describes a category-scoped lookup, while this resolves by `psk_id` and filters by category afterwards. The outcome differs only if one `psk_id` were held under two categories at once, which would require two byte-identical PSKs.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Enhancement to an existing feature — `enhancement`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.