### PR TITLE
SPEC 163 - client stream rename

### DIFF
--- a/aiosendspin/client/connection.py
+++ b/aiosendspin/client/connection.py
@@ -246,7 +246,7 @@ class SendspinConnection:
     _artwork_stream_active: bool = False
     """True if artwork stream is active."""
     _source_stream_active: bool = False
-    """True between client_stream/start and client_stream/end for the source role."""
+    """True between client-stream/start and client-stream/end for the source role."""
     _current_visualizer_config: StreamStartVisualizer | None = None
     """Current visualizer config from stream/start."""
 

--- a/aiosendspin/client/source.py
+++ b/aiosendspin/client/source.py
@@ -71,7 +71,7 @@ class SourceCapture:
         return self._codec
 
     async def start(self) -> None:
-        """Send ``client_stream/start`` to begin the capture stream."""
+        """Send ``client-stream/start`` to begin the capture stream."""
         if self._started:
             if self._connection.is_source_stream_active():
                 return

--- a/aiosendspin/models/source.py
+++ b/aiosendspin/models/source.py
@@ -64,10 +64,10 @@ class SourceCommandServerPayload(SendspinModel):
         omit_none = True
 
 
-# Client -> Server: client_stream/start source object
+# Client -> Server: client-stream/start source object
 @dataclass
 class ClientStreamStartSource(SendspinModel):
-    """Source object in client_stream/start message."""
+    """Source object in client-stream/start message."""
 
     codec: AudioCodec
     """Codec of the input stream."""
@@ -85,7 +85,7 @@ class ClientStreamStartSource(SendspinModel):
 
 @dataclass
 class ClientStreamStartPayload(SendspinModel):
-    """Payload for client_stream/start message."""
+    """Payload for client-stream/start message."""
 
     source: ClientStreamStartSource
 
@@ -100,12 +100,12 @@ class ClientStreamStartMessage(ClientMessage):
     """Message sent by a source client to announce the active input stream format."""
 
     payload: ClientStreamStartPayload
-    type: Literal["client_stream/start"] = "client_stream/start"
+    type: Literal["client-stream/start", "client_stream/start"] = "client-stream/start"
 
 
-# Client -> Server: client_stream/end
+# Client -> Server: client-stream/end
 @dataclass
 class ClientStreamEndMessage(ClientMessage):
     """Message sent by a source client to end the current input stream."""
 
-    type: Literal["client_stream/end"] = "client_stream/end"
+    type: Literal["client-stream/end", "client_stream/end"] = "client-stream/end"

--- a/aiosendspin/models/types.py
+++ b/aiosendspin/models/types.py
@@ -4,10 +4,38 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
+from typing import Final
 
 from mashumaro.types import Discriminator
 
 from .base import SendspinConfig, SendspinModel
+
+# Wire names the spec has replaced, kept readable so an existing client still parses.
+SUPERSEDED_CLIENT_MESSAGE_TYPES: Final[dict[str, str]] = {
+    "client-stream/start": "client_stream/start",
+    "client-stream/end": "client_stream/end",
+}
+
+
+_CURRENT_BY_SUPERSEDED: Final[dict[str, str]] = {
+    superseded: current for current, superseded in SUPERSEDED_CLIENT_MESSAGE_TYPES.items()
+}
+
+
+def current_message_type(message_type: str) -> str | None:
+    """Return the name that replaced ``message_type``, or None if it is already current."""
+    return _CURRENT_BY_SUPERSEDED.get(message_type)
+
+
+def _client_message_tags(variant: type) -> list[str]:
+    """Return every ``type`` value that names ``variant``, current spelling first."""
+    # Read off the class itself: a base or mixin without its own ``type`` names nothing,
+    # and raising here would take down parsing for every client message.
+    current = variant.__dict__.get("type")
+    if not isinstance(current, str):
+        return []
+    superseded = SUPERSEDED_CLIENT_MESSAGE_TYPES.get(current)
+    return [current] if superseded is None else [current, superseded]
 
 
 # Base message classes
@@ -18,7 +46,9 @@ class ClientMessage(SendspinModel):
     class Config(SendspinConfig):
         """Config for parsing json messages."""
 
-        discriminator = Discriminator(field="type", include_subtypes=True)
+        discriminator = Discriminator(
+            field="type", include_subtypes=True, variant_tagger_fn=_client_message_tags
+        )
 
 
 @dataclass

--- a/aiosendspin/models/types.py
+++ b/aiosendspin/models/types.py
@@ -11,19 +11,19 @@ from mashumaro.types import Discriminator
 from .base import SendspinConfig, SendspinModel
 
 # Wire names the spec has replaced, kept readable so an existing client still parses.
-SUPERSEDED_CLIENT_MESSAGE_TYPES: Final[dict[str, str]] = {
+SUPERSEDED_NAME_BY_CURRENT: Final[dict[str, str]] = {
     "client-stream/start": "client_stream/start",
     "client-stream/end": "client_stream/end",
 }
 
 
 _CURRENT_BY_SUPERSEDED: Final[dict[str, str]] = {
-    superseded: current for current, superseded in SUPERSEDED_CLIENT_MESSAGE_TYPES.items()
+    superseded: current for current, superseded in SUPERSEDED_NAME_BY_CURRENT.items()
 }
 
 
-def current_message_type(message_type: str) -> str | None:
-    """Return the name that replaced ``message_type``, or None if it is already current."""
+def replacement_for(message_type: str) -> str | None:
+    """Return the name that replaced ``message_type``, or None if nothing did."""
     return _CURRENT_BY_SUPERSEDED.get(message_type)
 
 
@@ -34,7 +34,7 @@ def _client_message_tags(variant: type) -> list[str]:
     current = variant.__dict__.get("type")
     if not isinstance(current, str):
         return []
-    superseded = SUPERSEDED_CLIENT_MESSAGE_TYPES.get(current)
+    superseded = SUPERSEDED_NAME_BY_CURRENT.get(current)
     return [current] if superseded is None else [current, superseded]
 
 

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -102,7 +102,7 @@ from aiosendspin.models.types import (
     PlaybackStateType,
     Roles,
     ServerMessage,
-    current_message_type,
+    replacement_for,
     role_family,
 )
 from aiosendspin.noise.constants import SENTINEL_PSK
@@ -1136,7 +1136,7 @@ class SendspinConnection:
 
     def _flag_superseded_message_type(self, message_type: str) -> None:
         """Flag a message that arrived under the name the spec replaced."""
-        current = current_message_type(message_type)
+        current = replacement_for(message_type)
         if current is not None:
             self._flag_noncompliance(f"client sent {message_type}, superseded by {current}")
 

--- a/aiosendspin/server/connection.py
+++ b/aiosendspin/server/connection.py
@@ -102,6 +102,7 @@ from aiosendspin.models.types import (
     PlaybackStateType,
     Roles,
     ServerMessage,
+    current_message_type,
     role_family,
 )
 from aiosendspin.noise.constants import SENTINEL_PSK
@@ -1133,6 +1134,12 @@ class SendspinConnection:
             )
         return True
 
+    def _flag_superseded_message_type(self, message_type: str) -> None:
+        """Flag a message that arrived under the name the spec replaced."""
+        current = current_message_type(message_type)
+        if current is not None:
+            self._flag_noncompliance(f"client sent {message_type}, superseded by {current}")
+
     def _flag_legacy_artwork_wire(self, support: ClientHelloArtworkSupport) -> None:
         """Flag artwork channels declared on the wire the spec superseded."""
         legacy_keys = sorted(
@@ -1842,6 +1849,7 @@ class SendspinConnection:
         if isinstance(message, ClientStreamStartMessage):
             if self._client is None:
                 return
+            self._flag_superseded_message_type(message.type)
             for role in self._client.active_roles:
                 role.on_client_stream_start(message.payload)
             return
@@ -1849,6 +1857,7 @@ class SendspinConnection:
         if isinstance(message, ClientStreamEndMessage):
             if self._client is None:
                 return
+            self._flag_superseded_message_type(message.type)
             for role in self._client.active_roles:
                 role.on_client_stream_end()
             return

--- a/aiosendspin/server/roles/base.py
+++ b/aiosendspin/server/roles/base.py
@@ -468,7 +468,7 @@ class Role(ABC):
         """
 
     def on_client_stream_start(self, payload: ClientStreamStartPayload) -> None:  # noqa: B027
-        """Handle client_stream/start."""
+        """Handle client-stream/start."""
 
     def on_client_stream_end(self) -> None:  # noqa: B027
-        """Handle client_stream/end."""
+        """Handle client-stream/end."""

--- a/aiosendspin/server/roles/source/v1.py
+++ b/aiosendspin/server/roles/source/v1.py
@@ -113,7 +113,7 @@ class SourceV1Role(Role):
         if not self._start_requested:
             # Let server compliance policy decide whether to disconnect.
             self._client.flag_noncompliance(
-                "client_stream/start sent without a preceding source start command"
+                "client-stream/start sent without a preceding source start command"
             )
             return
         source = payload.source
@@ -133,7 +133,7 @@ class SourceV1Role(Role):
                 header = base64.b64decode(source.codec_header, validate=True)
             except (binascii.Error, ValueError):
                 self._client.flag_noncompliance(
-                    "client_stream/start codec_header is not valid Base64"
+                    "client-stream/start codec_header is not valid Base64"
                 )
                 return
         if source.codec is AudioCodec.FLAC and (
@@ -144,7 +144,7 @@ class SourceV1Role(Role):
             or int.from_bytes(header[5:8], "big") != 34
         ):
             self._client.flag_noncompliance(
-                "client_stream/start FLAC codec_header must contain STREAMINFO"
+                "client-stream/start FLAC codec_header must contain STREAMINFO"
             )
             return
         try:

--- a/tests/client/test_source_capture.py
+++ b/tests/client/test_source_capture.py
@@ -72,7 +72,7 @@ async def test_opus_timestamps_lead_capture_by_the_encoder_pre_skip() -> None:
 
 
 async def test_start_announces_client_stream_only() -> None:
-    """start() sends client_stream/start and nothing else (framing is the lifecycle)."""
+    """start() sends client-stream/start and nothing else (framing is the lifecycle)."""
     conn = _FakeConnection()
     capture = SourceCapture(_FakeClient(), conn, _pcm_format())  # type: ignore[arg-type]
     await capture.start()

--- a/tests/client/test_source_deactivation.py
+++ b/tests/client/test_source_deactivation.py
@@ -78,13 +78,13 @@ def _connection(
 
 
 async def test_source_dropped_from_active_roles_ends_client_stream() -> None:
-    """Removing source@v1 from active_roles auto-sends client_stream/end."""
+    """Removing source@v1 from active_roles auto-sends client-stream/end."""
     ws = _FakeWs()
     conn = _connection(ws, active_roles=[Roles.SOURCE.value], stream_active=True)
     await conn._apply_activation(  # noqa: SLF001
         ServerActivatePayload(activities=[Activity.PLAYBACK], active_roles=[])
     )
-    assert any("client_stream/end" in m for m in ws.sent)
+    assert any("client-stream/end" in m for m in ws.sent)
     assert conn._source_stream_active is False  # noqa: SLF001
 
 
@@ -95,7 +95,7 @@ async def test_no_client_stream_end_when_source_retained() -> None:
     await conn._apply_activation(  # noqa: SLF001
         ServerActivatePayload(activities=[Activity.PLAYBACK], active_roles=[Roles.SOURCE.value])
     )
-    assert not any("client_stream/end" in m for m in ws.sent)
+    assert not any("client-stream/end" in m for m in ws.sent)
     assert conn._source_stream_active is True  # noqa: SLF001
 
 
@@ -192,7 +192,7 @@ async def test_source_unavailable_ends_stream_before_state() -> None:
 
     messages = [orjson.loads(message) for message in ws.sent]
     assert [message["type"] for message in messages] == [
-        "client_stream/end",
+        "client-stream/end",
         "client/state",
     ]
     assert messages[-1]["payload"] == {"available": False, "source": {}}

--- a/tests/models/test_source.py
+++ b/tests/models/test_source.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+import orjson
 import pytest
 
 from aiosendspin.models.core import (
@@ -13,6 +16,7 @@ from aiosendspin.models.core import (
 from aiosendspin.models.source import (
     ClientStreamEndMessage,
     ClientStreamStartMessage,
+    ClientStreamStartPayload,
     ClientStreamStartSource,
 )
 from aiosendspin.models.types import (
@@ -115,13 +119,13 @@ def test_server_command_source_requires_command() -> None:
 def test_client_stream_messages_dispatch_by_discriminator() -> None:
     """client_stream messages resolve to their concrete classes via the type field."""
     start = ClientMessage.from_json(
-        '{"type":"client_stream/start","payload":{"source":'
+        '{"type":"client-stream/start","payload":{"source":'
         '{"codec":"flac","channels":2,"sample_rate":48000,"bit_depth":16,"codec_header":"AAA="}}}'
     )
     assert isinstance(start, ClientStreamStartMessage)
     assert start.payload.source.codec is AudioCodec.FLAC
 
-    end = ClientMessage.from_json('{"type":"client_stream/end"}')
+    end = ClientMessage.from_json('{"type":"client-stream/end"}')
     assert isinstance(end, ClientStreamEndMessage)
 
 
@@ -130,3 +134,43 @@ def test_client_stream_start_header_optional_for_all_codecs() -> None:
     for codec in (AudioCodec.OPUS, AudioCodec.FLAC, AudioCodec.PCM):
         src = ClientStreamStartSource(codec=codec, channels=2, sample_rate=48000, bit_depth=16)
         assert src.codec_header is None
+
+
+def test_superseded_stream_message_names_still_parse() -> None:
+    """A source on the pre-rename wire is understood, and says which name it used."""
+    start = ClientMessage.from_json(
+        '{"type":"client_stream/start","payload":{"source":'
+        '{"codec":"pcm","sample_rate":48000,"bit_depth":16,"channels":2}}}'
+    )
+    end = ClientMessage.from_json('{"type":"client_stream/end"}')
+
+    assert isinstance(start, ClientStreamStartMessage)
+    assert isinstance(end, ClientStreamEndMessage)
+    assert start.type == "client_stream/start"
+    assert end.type == "client_stream/end"
+
+
+def test_stream_messages_are_emitted_under_the_current_names() -> None:
+    """What this client sends is the spelling the spec now uses."""
+    assert orjson.loads(ClientStreamEndMessage().to_json())["type"] == "client-stream/end"
+    payload = ClientStreamStartPayload(
+        source=ClientStreamStartSource(
+            codec=AudioCodec.PCM, sample_rate=48000, bit_depth=16, channels=2
+        )
+    )
+    raw = orjson.loads(ClientStreamStartMessage(payload=payload).to_json())
+    assert raw["type"] == "client-stream/start"
+
+
+def test_a_client_message_without_a_type_does_not_break_dispatch() -> None:
+    """The tagger must tolerate a variant carrying no ``type`` of its own.
+
+    Raising there would take down parsing for every client message, not just source ones.
+    """
+
+    @dataclass
+    class _UntaggedClientMessage(ClientMessage):
+        """A subclass that declares no wire name, as a mixin or base might."""
+
+    parsed = ClientMessage.from_json('{"type":"client-stream/end"}')
+    assert isinstance(parsed, ClientStreamEndMessage)

--- a/tests/models/test_source.py
+++ b/tests/models/test_source.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 import orjson
 import pytest
+from mashumaro.exceptions import SuitableVariantNotFoundError
 
 from aiosendspin.models.core import (
     ClientHelloPayload,
@@ -25,6 +26,7 @@ from aiosendspin.models.types import (
     PairMethod,
     SignalState,
     TrustLevel,
+    _client_message_tags,
 )
 
 
@@ -172,5 +174,11 @@ def test_a_client_message_without_a_type_does_not_break_dispatch() -> None:
     class _UntaggedClientMessage(ClientMessage):
         """A subclass that declares no wire name, as a mixin or base might."""
 
+    assert _client_message_tags(_UntaggedClientMessage) == []
+
+    # Force the variant map to be rebuilt, so every subclass is put to the tagger rather
+    # than answered from what an earlier parse cached.
+    with pytest.raises(SuitableVariantNotFoundError):
+        ClientMessage.from_json('{"type":"nope/not-a-message"}')
     parsed = ClientMessage.from_json('{"type":"client-stream/end"}')
     assert isinstance(parsed, ClientStreamEndMessage)

--- a/tests/server/roles/source/test_v1.py
+++ b/tests/server/roles/source/test_v1.py
@@ -75,7 +75,7 @@ def _make_role() -> tuple[SourceV1Role, _FakeClient]:
 
 
 def test_client_stream_start_emits_event_with_native_format() -> None:
-    """on_client_stream/start announces the decoded handle and its PCM format."""
+    """on_client-stream/start announces the decoded handle and its PCM format."""
     role, client = _make_role()
     role.on_client_stream_start(_pcm_start_payload())
     started = [e for e in client.events if isinstance(e, SourceStreamStartedEvent)]
@@ -194,7 +194,7 @@ def test_flac_start_requires_streaminfo_header() -> None:
     )
 
     assert not role.stream_active
-    assert client.noncompliance == ["client_stream/start FLAC codec_header must contain STREAMINFO"]
+    assert client.noncompliance == ["client-stream/start FLAC codec_header must contain STREAMINFO"]
 
 
 async def test_stream_replacement_announces_the_end_of_the_old_handle() -> None:
@@ -276,12 +276,12 @@ def test_becoming_unavailable_implicitly_stops_stream() -> None:
     assert not role.stream_active
     assert len([e for e in client.events if isinstance(e, SourceStreamEndedEvent)]) == 1
     assert client.noncompliance == [
-        "client_stream/start sent without a preceding source start command"
+        "client-stream/start sent without a preceding source start command"
     ]
 
 
 async def test_second_start_restarts_stream() -> None:
-    """A second client_stream/start ends the prior handle and announces a new one."""
+    """A second client-stream/start ends the prior handle and announces a new one."""
     role, client = _make_role()
     role.on_client_stream_start(_pcm_start_payload())
     first = next(e for e in client.events if isinstance(e, SourceStreamStartedEvent)).handle
@@ -295,7 +295,7 @@ async def test_second_start_restarts_stream() -> None:
 
 
 async def test_client_stream_end_emits_event_and_closes_handle() -> None:
-    """client_stream/end surfaces SourceStreamEndedEvent AND terminates the handle."""
+    """client-stream/end surfaces SourceStreamEndedEvent AND terminates the handle."""
     role, client = _make_role()
     role.on_client_stream_start(_pcm_start_payload())
     handle = next(e for e in client.events if isinstance(e, SourceStreamStartedEvent)).handle

--- a/tests/server/roles/source/test_v1.py
+++ b/tests/server/roles/source/test_v1.py
@@ -75,7 +75,7 @@ def _make_role() -> tuple[SourceV1Role, _FakeClient]:
 
 
 def test_client_stream_start_emits_event_with_native_format() -> None:
-    """on_client-stream/start announces the decoded handle and its PCM format."""
+    """on_client_stream_start announces the decoded handle and its PCM format."""
     role, client = _make_role()
     role.on_client_stream_start(_pcm_start_payload())
     started = [e for e in client.events if isinstance(e, SourceStreamStartedEvent)]

--- a/tests/server/test_source_connection_dispatch.py
+++ b/tests/server/test_source_connection_dispatch.py
@@ -12,7 +12,7 @@ from aiosendspin.models.source import (
     ClientStreamStartPayload,
     ClientStreamStartSource,
 )
-from aiosendspin.models.types import AudioCodec, BinaryMessageType
+from aiosendspin.models.types import AudioCodec, BinaryMessageType, ClientMessage
 from aiosendspin.server.connection import SendspinConnection
 
 
@@ -41,6 +41,10 @@ class _RecordingRole:
 class _FakeClient:
     def __init__(self, roles: list[Any]) -> None:
         self._roles = roles
+        self.noncompliance: list[str] = []
+
+    def flag_noncompliance(self, reason: str) -> None:
+        self.noncompliance.append(reason)
 
     @property
     def active_roles(self) -> list[Any]:
@@ -95,7 +99,7 @@ def test_short_binary_payload_is_dropped_safely(caplog: Any) -> None:
 
 
 async def test_client_stream_start_and_end_dispatched_to_roles() -> None:
-    """client_stream/start and client_stream/end reach role hooks via _handle_message."""
+    """client-stream/start and client-stream/end reach role hooks via _handle_message."""
     role = _RecordingRole()
     conn = _bare_connection([role])
     start = ClientStreamStartMessage(
@@ -109,3 +113,35 @@ async def test_client_stream_start_and_end_dispatched_to_roles() -> None:
     await conn._handle_message(ClientStreamEndMessage(), timestamp_us=0)  # noqa: SLF001
     assert len(role.starts) == 1
     assert role.ends == 1
+
+
+async def test_superseded_stream_message_names_are_dispatched_and_flagged() -> None:
+    """A source on the pre-rename wire is still served, and the deviation recorded."""
+    role = _RecordingRole()
+    conn = _bare_connection([role])
+    start = ClientMessage.from_json(
+        '{"type":"client_stream/start","payload":{"source":'
+        '{"codec":"pcm","sample_rate":48000,"bit_depth":16,"channels":2}}}'
+    )
+    end = ClientMessage.from_json('{"type":"client_stream/end"}')
+
+    await conn._handle_message(start, timestamp_us=0)  # noqa: SLF001
+    await conn._handle_message(end, timestamp_us=0)  # noqa: SLF001
+
+    assert len(role.starts) == 1
+    assert role.ends == 1
+    assert conn._client.noncompliance == [  # noqa: SLF001
+        "client sent client_stream/start, superseded by client-stream/start",
+        "client sent client_stream/end, superseded by client-stream/end",
+    ]
+
+
+async def test_current_stream_message_names_are_not_flagged() -> None:
+    """The current spelling raises nothing with the server."""
+    role = _RecordingRole()
+    conn = _bare_connection([role])
+
+    await conn._handle_message(ClientStreamEndMessage(), timestamp_us=0)  # noqa: SLF001
+
+    assert role.ends == 1
+    assert conn._client.noncompliance == []  # noqa: SLF001

--- a/tests/server/test_source_connection_dispatch.py
+++ b/tests/server/test_source_connection_dispatch.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import pytest
+
 from aiosendspin.models import pack_binary_header_raw
 from aiosendspin.models.source import (
     ClientStreamEndMessage,
@@ -13,6 +15,7 @@ from aiosendspin.models.source import (
     ClientStreamStartSource,
 )
 from aiosendspin.models.types import AudioCodec, BinaryMessageType, ClientMessage
+from aiosendspin.server.compliance import ClientComplianceError
 from aiosendspin.server.connection import SendspinConnection
 
 
@@ -39,21 +42,24 @@ class _RecordingRole:
 
 
 class _FakeClient:
-    def __init__(self, roles: list[Any]) -> None:
+    def __init__(self, roles: list[Any], *, strict: bool = False) -> None:
         self._roles = roles
+        self._strict = strict
         self.noncompliance: list[str] = []
 
     def flag_noncompliance(self, reason: str) -> None:
         self.noncompliance.append(reason)
+        if self._strict:
+            raise ClientComplianceError(reason)
 
     @property
     def active_roles(self) -> list[Any]:
         return self._roles
 
 
-def _bare_connection(roles: list[Any]) -> SendspinConnection:
+def _bare_connection(roles: list[Any], *, strict: bool = False) -> SendspinConnection:
     conn = SendspinConnection.__new__(SendspinConnection)
-    conn._client = _FakeClient(roles)  # noqa: SLF001
+    conn._client = _FakeClient(roles, strict=strict)  # noqa: SLF001
     conn._logger = logging.getLogger("test.source.dispatch")  # noqa: SLF001
     return conn
 
@@ -145,3 +151,13 @@ async def test_current_stream_message_names_are_not_flagged() -> None:
 
     assert role.ends == 1
     assert conn._client.noncompliance == []  # noqa: SLF001
+
+
+async def test_superseded_stream_message_name_is_rejected_by_a_strict_server() -> None:
+    """The flag is not cosmetic: a strict server drops a source on the old spelling."""
+    conn = _bare_connection([_RecordingRole()], strict=True)
+
+    with pytest.raises(ClientComplianceError):
+        await conn._handle_message(  # noqa: SLF001
+            ClientMessage.from_json('{"type":"client_stream/end"}'), timestamp_us=0
+        )


### PR DESCRIPTION
# What does this implement/fix?

Implements spec [#163](https://github.com/Sendspin/spec/pull/163). `client_stream/start` and`client_stream/end` become `client-stream/start` and `client-stream/end` on the wire.

The discriminator accepts both spellings for the same message, driven by one map of superseded names in `models/types.py`, so a later rename joins it rather than growing a second mechanism. A source still on the old spelling is served and flagged, exactly as the legacy `client/state` field and the pre-rename artwork dimension keys already are — which means a server running `allow_noncompliant_clients=False` will drop it, that being what opting into strict mode has always meant. The name a message arrived under survives on the parsed message, so nothing has to be recorded alongside it.

NOTE:

- **The Python identifiers are deliberately unchanged**, unlike the sibling rename in #351.   There, a word changed (`static` → `output`). Here only the separator moved, and a hyphen  is not a Python identifier character — `on_client_stream_start` already spells  `client-stream/start` as closely as a method name can. `Role.on_client_stream_start` is an  ABC hook with a no-op default, so renaming it would silently stop delivering the callback  to any embedder who did not follow, and buy nothing.

- The client emits the new spelling, so it requires a server that understands it. That is the same trade as the other renames in this series.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Refactor (no behaviour change) — `refactor`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.