### PR TITLE
group name on group update

### DIFF
--- a/aiosendspin/server/client.py
+++ b/aiosendspin/server/client.py
@@ -743,7 +743,13 @@ class SendspinClient:
     ) -> None:
         """Store hello identity/capabilities with optional explicit negotiated roles."""
         self._info = client_info
+        # A group with no name of its own reports its founding member's, so this device
+        # learning its own name can change what its whole group is called.
+        group = self._group
+        previous_group_name = group.group_name if group is not None else None
         self._name = client_info.name
+        if group is not None and previous_group_name is not None:
+            group._publish_if_name_changed(previous_group_name)  # noqa: SLF001
         if negotiated_roles is None:
             self._negotiated_role_ids = negotiate_roles(
                 client_info.supported_roles, strict=not self._server.allow_noncompliant_clients

--- a/aiosendspin/server/group.py
+++ b/aiosendspin/server/group.py
@@ -198,14 +198,25 @@ class SendspinGroup:
             )
         )
 
+    def _send_group_update(self, client: SendspinClient, message: GroupUpdateServerMessage) -> None:
+        """Send one group/update to a client that has finished coming up.
+
+        A client still mid-bring-up is told the group's state by ``on_client_connected``
+        once its first client/state lands, so anything sent before then is superseded.
+        """
+        if client.is_connected:
+            client.send_message(message)
+
     def _send_group_update_to_clients(self) -> None:
-        """Send group/update to every member already past its first server/activate."""
+        """Send group/update to every member that has finished coming up."""
         group_message = self._group_update_message()
         for client in self._clients:
-            # A client mid-handshake is sent its own update once activated, and must not
-            # receive one before the server/activate that opens the connection.
-            if client.is_connected:
-                client.send_message(group_message)
+            self._send_group_update(client, group_message)
+
+    def _publish_if_name_changed(self, previous: str) -> None:
+        """Publish group/update when the name the group reports is no longer ``previous``."""
+        if self.group_name != previous:
+            self._send_group_update_to_clients()
 
     def on_client_connected(self, client: SendspinClient) -> None:
         """Send current group state to a client that just finished handshaking."""
@@ -342,18 +353,16 @@ class SendspinGroup:
 
     @property
     def group_name(self) -> str:
-        """Friendly name for this group, its first member's device name by default."""
+        """Friendly name for this group, its founding member's device name by default."""
         if self._group_name is not None:
             return self._group_name
         return self._clients[0].name if self._clients else ""
 
     def set_group_name(self, name: str | None) -> None:
         """Name this group, publishing the change; ``None`` restores the default."""
-        if name == self._group_name:
-            return
-
+        previous = self.group_name
         self._group_name = name
-        self._send_group_update_to_clients()
+        self._publish_if_name_changed(previous)
 
     @property
     def state(self) -> PlaybackStateType:
@@ -377,6 +386,7 @@ class SendspinGroup:
 
         # Cancel any pending delayed join for this client
         logger.debug("removing %s from group with members: %s", client.client_id, self._clients)
+        previous_name = self.group_name
         if len(self._clients) == 1:
             # Delete this group if that was the last client
             await self._stop_and_invalidate_stale_binary([client])
@@ -396,6 +406,8 @@ class SendspinGroup:
                 await self._stop_and_invalidate_stale_binary(self._clients)
             # Emit event for client removal
             self._signal_event(GroupMemberRemovedEvent(client.client_id))
+            # Losing the founding member changes the name the survivors report.
+            self._publish_if_name_changed(previous_name)
         # Each client needs to be in a group, add it to a new one
         new_group = SendspinGroup(self._server, client)
         # Send group update to notify client of their new solo group
@@ -486,4 +498,4 @@ class SendspinGroup:
 
         # Send current state to the new client
         logger.debug("Sending group update to new client %s", client.client_id)
-        client.send_message(self._group_update_message())
+        self._send_group_update(client, self._group_update_message())

--- a/aiosendspin/server/group.py
+++ b/aiosendspin/server/group.py
@@ -188,31 +188,31 @@ class SendspinGroup:
         if self._push_stream is not None and not self._push_stream.is_stopped:
             self._push_stream.on_role_leave(role)
 
-    def _send_group_update_to_clients(self) -> None:
-        """Send group/update messages to all clients."""
-        group_message = GroupUpdateServerMessage(
+    def _group_update_message(self) -> GroupUpdateServerMessage:
+        """Build a group/update carrying this group's current state."""
+        return GroupUpdateServerMessage(
             GroupUpdateServerPayload(
                 playback_state=self._current_state,
                 group_id=self.group_id,
                 group_name=self.group_name,
             )
         )
+
+    def _send_group_update_to_clients(self) -> None:
+        """Send group/update to every member already past its first server/activate."""
+        group_message = self._group_update_message()
         for client in self._clients:
-            client.send_message(group_message)
+            # A client mid-handshake is sent its own update once activated, and must not
+            # receive one before the server/activate that opens the connection.
+            if client.is_connected:
+                client.send_message(group_message)
 
     def on_client_connected(self, client: SendspinClient) -> None:
         """Send current group state to a client that just finished handshaking."""
         if client not in self._clients:
             return
 
-        group_message = GroupUpdateServerMessage(
-            GroupUpdateServerPayload(
-                playback_state=self._current_state,
-                group_id=self.group_id,
-                group_name=self.group_name,
-            )
-        )
-        client.send_message(group_message)
+        client.send_message(self._group_update_message())
 
         if self._push_stream is not None and not self._push_stream.is_stopped:
             for role in client.active_roles:
@@ -341,9 +341,19 @@ class SendspinGroup:
         return self._group_id
 
     @property
-    def group_name(self) -> str | None:
-        """Friendly name for this group."""
-        return self._group_name
+    def group_name(self) -> str:
+        """Friendly name for this group, its first member's device name by default."""
+        if self._group_name is not None:
+            return self._group_name
+        return self._clients[0].name if self._clients else ""
+
+    def set_group_name(self, name: str | None) -> None:
+        """Name this group, publishing the change; ``None`` restores the default."""
+        if name == self._group_name:
+            return
+
+        self._group_name = name
+        self._send_group_update_to_clients()
 
     @property
     def state(self) -> PlaybackStateType:
@@ -475,12 +485,5 @@ class SendspinGroup:
                         self._push_stream.on_role_join(role)
 
         # Send current state to the new client
-        group_message = GroupUpdateServerMessage(
-            GroupUpdateServerPayload(
-                playback_state=self._current_state,
-                group_id=self.group_id,
-                group_name=self.group_name,
-            )
-        )
         logger.debug("Sending group update to new client %s", client.client_id)
-        client.send_message(group_message)
+        client.send_message(self._group_update_message())

--- a/tests/integration/test_historical_audio.py
+++ b/tests/integration/test_historical_audio.py
@@ -41,6 +41,11 @@ class _DummyGroup:
         self.clients = clients
         self.transformer_pool = TransformerPool()
 
+    group_name = "dummy group"
+
+    def _publish_if_name_changed(self, previous: str) -> None:  # noqa: ARG002
+        return
+
     def on_client_connected(self, client: SendspinClient) -> None:  # noqa: ARG002
         return
 

--- a/tests/integration/test_late_joiner_codec.py
+++ b/tests/integration/test_late_joiner_codec.py
@@ -40,6 +40,11 @@ class _DummyGroup:
         self.clients = clients
         self.transformer_pool = TransformerPool()
 
+    group_name = "dummy group"
+
+    def _publish_if_name_changed(self, previous: str) -> None:  # noqa: ARG002
+        return
+
     def on_client_connected(self, client: SendspinClient) -> None:  # noqa: ARG002
         return
 

--- a/tests/server/test_buffer_registration_timing.py
+++ b/tests/server/test_buffer_registration_timing.py
@@ -46,6 +46,11 @@ class _DummyGroup:
         self.group_id = group_id
         self.transformer_pool = TransformerPool()
 
+    group_name = "dummy group"
+
+    def _publish_if_name_changed(self, previous: str) -> None:  # noqa: ARG002
+        return
+
     def on_client_connected(self, client: Any) -> None:  # noqa: ARG002
         return
 

--- a/tests/server/test_client_multi_role.py
+++ b/tests/server/test_client_multi_role.py
@@ -38,6 +38,11 @@ class _DummyGroup:
         self.clients = clients
         self.transformer_pool = TransformerPool()
 
+    group_name = "dummy group"
+
+    def _publish_if_name_changed(self, previous: str) -> None:  # noqa: ARG002
+        return
+
     def on_client_connected(self, client: SendspinClient) -> None:  # noqa: ARG002
         return
 

--- a/tests/server/test_group_name.py
+++ b/tests/server/test_group_name.py
@@ -12,6 +12,7 @@ from aiosendspin.models.core import (
     ClientHelloPayload,
     GroupUpdateServerMessage,
 )
+from aiosendspin.models.types import PlaybackStateType
 from aiosendspin.server.client import SendspinClient
 from aiosendspin.server.clock import LoopClock
 from aiosendspin.server.group import SendspinGroup
@@ -112,8 +113,8 @@ async def test_the_first_update_carries_the_name() -> None:
 
 
 @pytest.mark.asyncio
-async def test_group_name_reaches_the_wire() -> None:
-    """The field is carried, rather than omitted as an absent optional."""
+async def test_an_overridden_name_reaches_the_wire() -> None:
+    """A name the embedder chose is what members are told, not the derived one."""
     loop = asyncio.get_running_loop()
     server = _DummyServer(loop=loop, clock=LoopClock(loop))
     client = _connected_member(server, "c1", "Kitchen Speaker")
@@ -152,3 +153,52 @@ async def test_clearing_the_name_restores_the_derived_default() -> None:
 
     assert client.group.group_name == "Kitchen Speaker"
     assert _group_updates(client)[-1].payload.group_name == "Kitchen Speaker"
+
+
+@pytest.mark.asyncio
+async def test_no_update_reaches_a_client_still_coming_up() -> None:
+    """A member mid-bring-up is not told anything before its own connect update.
+
+    It is attached to its group during the hello exchange, so a group change in that
+    window would otherwise reach it ahead of the state it is brought up with.
+    """
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+    client = SendspinClient(server, client_id="c1")
+    server.register(client)
+    SendspinGroup(server, client)
+    client.attach_connection(
+        _RecordingConnection(),
+        client_info=ClientHelloPayload(client_id="c1", name="Kitchen Speaker", supported_roles=[]),
+        negotiated_roles=[],
+        active_roles=[],
+    )
+
+    client.group._set_playback_state(PlaybackStateType.PLAYING)  # noqa: SLF001
+    assert _group_updates(client) == []
+
+    client.mark_connected()
+
+    updates = _group_updates(client)
+    assert len(updates) == 1
+    assert updates[0].payload.playback_state is PlaybackStateType.PLAYING
+
+
+@pytest.mark.asyncio
+async def test_losing_the_founder_republishes_the_derived_name() -> None:
+    """The survivors were reporting the departed device's name, so they must be told."""
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+    founder = _connected_member(server, "c1", "Kitchen Speaker")
+    joiner = _connected_member(server, "c2", "Living Room")
+    group = founder.group
+    await group.add_client(joiner)
+    assert group.group_name == "Kitchen Speaker"
+    before = len(_group_updates(joiner))
+
+    await group.remove_client(founder)
+
+    assert group.group_name == "Living Room"
+    updates = _group_updates(joiner)
+    assert len(updates) > before
+    assert updates[-1].payload.group_name == "Living Room"

--- a/tests/server/test_group_name.py
+++ b/tests/server/test_group_name.py
@@ -202,3 +202,34 @@ async def test_losing_the_founder_republishes_the_derived_name() -> None:
     updates = _group_updates(joiner)
     assert len(updates) > before
     assert updates[-1].payload.group_name == "Living Room"
+
+
+@pytest.mark.asyncio
+async def test_a_member_learning_its_own_name_tells_the_group() -> None:
+    """A device is known by its client_id until its hello lands, and the group with it.
+
+    A group founded before that hello reports the id, so the members it has gained since
+    have to be told when the real name arrives.
+    """
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+    founder = SendspinClient(server, client_id="c1")
+    server.register(founder)
+    SendspinGroup(server, founder)
+    joiner = _connected_member(server, "c2", "Living Room")
+    group = founder.group
+    await group.add_client(joiner)
+    assert group.group_name == "c1"
+    before = len(_group_updates(joiner))
+
+    founder.attach_connection(
+        _RecordingConnection(),
+        client_info=ClientHelloPayload(client_id="c1", name="Kitchen Speaker", supported_roles=[]),
+        negotiated_roles=[],
+        active_roles=[],
+    )
+
+    assert group.group_name == "Kitchen Speaker"
+    updates = _group_updates(joiner)
+    assert len(updates) > before
+    assert updates[-1].payload.group_name == "Kitchen Speaker"

--- a/tests/server/test_group_name.py
+++ b/tests/server/test_group_name.py
@@ -1,0 +1,154 @@
+"""The name a group reports in group/update, and when it publishes a change."""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+from dataclasses import dataclass
+
+import pytest
+
+from aiosendspin.models.core import (
+    ClientHelloPayload,
+    GroupUpdateServerMessage,
+)
+from aiosendspin.server.client import SendspinClient
+from aiosendspin.server.clock import LoopClock
+from aiosendspin.server.group import SendspinGroup
+
+
+@dataclass(slots=True)
+class _DummyServer:
+    loop: asyncio.AbstractEventLoop
+    clock: LoopClock
+    id: str = "srv"
+    name: str = "server"
+    _clients: dict[str, SendspinClient] = dataclasses.field(default_factory=dict)
+
+    def is_external_player(self, client_id: str) -> bool:  # noqa: ARG002
+        return False
+
+    def _signal_client_updated(self, client_id: str) -> None:
+        pass
+
+    def _signal_client_connected(self, client_id: str) -> None:
+        pass
+
+    def _signal_client_disconnected(self, client_id: str, goodbye_reason: object) -> None:
+        pass
+
+    def register(self, client: SendspinClient) -> None:
+        self._clients[client.client_id] = client
+
+    @property
+    def connected_clients(self) -> list[SendspinClient]:
+        return [c for c in self._clients.values() if c.is_connected]
+
+    def request_client_playback_connection(self, client_id: str) -> bool:  # noqa: ARG002
+        return False
+
+
+class _RecordingConnection:
+    def __init__(self) -> None:
+        self.messages: list[object] = []
+
+    async def disconnect(self, *, retry_connection: bool = True) -> None:  # noqa: ARG002
+        return
+
+    def send_message(self, message: object) -> None:
+        self.messages.append(message)
+
+    def send_role_message(self, role: str, message: object) -> None:
+        pass
+
+    def send_binary(self, data: bytes, **kwargs: object) -> bool:  # noqa: ARG002
+        return True
+
+
+def _connected_member(server: _DummyServer, client_id: str, name: str) -> SendspinClient:
+    """Register a client under ``name``, group it, and bring it fully up."""
+    client = SendspinClient(server, client_id=client_id)
+    server.register(client)
+    SendspinGroup(server, client)
+    client.attach_connection(
+        _RecordingConnection(),
+        client_info=ClientHelloPayload(client_id=client_id, name=name, supported_roles=[]),
+        negotiated_roles=[],
+        active_roles=[],
+    )
+    client.mark_connected()
+    return client
+
+
+def _group_updates(client: SendspinClient) -> list[GroupUpdateServerMessage]:
+    connection = client.connection
+    assert isinstance(connection, _RecordingConnection)
+    return [m for m in connection.messages if isinstance(m, GroupUpdateServerMessage)]
+
+
+@pytest.mark.asyncio
+async def test_group_reports_its_member_name_by_default() -> None:
+    """An unnamed group is the device it contains, so it reports that device's name."""
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+    client = _connected_member(server, "c1", "Kitchen Speaker")
+
+    assert client.group.group_name == "Kitchen Speaker"
+
+
+@pytest.mark.asyncio
+async def test_the_first_update_carries_the_name() -> None:
+    """The field must be present, not omitted as an absent optional.
+
+    ``group/update`` omits None-valued fields, so a group with no name at all left the
+    key off the wire entirely, against the spec's requirement to carry every field.
+    """
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+    client = _connected_member(server, "c1", "Kitchen Speaker")
+
+    first = _group_updates(client)[0]
+    assert '"group_name":"Kitchen Speaker"' in first.to_json()
+
+
+@pytest.mark.asyncio
+async def test_group_name_reaches_the_wire() -> None:
+    """The field is carried, rather than omitted as an absent optional."""
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+    client = _connected_member(server, "c1", "Kitchen Speaker")
+
+    client.group.set_group_name("Downstairs")
+
+    updates = _group_updates(client)
+    assert updates
+    assert updates[-1].payload.group_name == "Downstairs"
+    assert '"group_name":"Downstairs"' in updates[-1].to_json()
+
+
+@pytest.mark.asyncio
+async def test_setting_the_name_publishes_once_per_change() -> None:
+    """Naming a group tells its members; naming it the same again tells no one."""
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+    client = _connected_member(server, "c1", "Kitchen Speaker")
+    before = len(_group_updates(client))
+
+    client.group.set_group_name("Downstairs")
+    client.group.set_group_name("Downstairs")
+
+    assert len(_group_updates(client)) == before + 1
+
+
+@pytest.mark.asyncio
+async def test_clearing_the_name_restores_the_derived_default() -> None:
+    """None is not a name of its own; it hands the group back to its member."""
+    loop = asyncio.get_running_loop()
+    server = _DummyServer(loop=loop, clock=LoopClock(loop))
+    client = _connected_member(server, "c1", "Kitchen Speaker")
+    client.group.set_group_name("Downstairs")
+
+    client.group.set_group_name(None)
+
+    assert client.group.group_name == "Kitchen Speaker"
+    assert _group_updates(client)[-1].payload.group_name == "Kitchen Speaker"

--- a/tests/server/test_push_stream_behavior.py
+++ b/tests/server/test_push_stream_behavior.py
@@ -66,6 +66,11 @@ class _DummyGroup:
         self._push_stream: PushStream | None = None
         self.has_active_stream = False
 
+    group_name = "dummy group"
+
+    def _publish_if_name_changed(self, previous: str) -> None:  # noqa: ARG002
+        return
+
     def on_client_connected(self, client: SendspinClient) -> None:  # noqa: ARG002
         return
 


### PR DESCRIPTION
# What does this implement/fix?

A group with no name of its own now reports the name of the device it holds. For a
single-member group that is the only name there is, rather than a rule invented for the
occasion. `set_group_name()` lets an embedder with its own notion of a group name supply
one and publishes the change; passing `None` hands the group back to its member's name.

NOTE:

- **`SendspinGroup.group_name` narrows from `str | None` to `str`.** That is the type
  `messaging.md:401` gives the field. The wire model is deliberately unchanged —
  `GroupUpdateServerPayload` keeps all three fields optional, because the client SDK parses
  incoming messages into it and `merge()` coalesces queued updates through them.

- **The name is derived when read, not stored at construction.** A group is created before
  its client's `client/hello` arrives, so a copy taken then would capture the `client_id`
  that the real name later replaces.

- **Deriving it makes a previously unreachable MUST reachable.** While the name was a
  constant `None` it could never change, so `messaging.md:395` ("MUST promptly send ...
  whenever any field changes") had nothing to bite on. It does now, and all three paths
  that change what a group reports publish it: an embedder naming it, losing the member it
  derives from, and that member learning its own name when its `client/hello` lands.

- **Group updates now go only to members that have finished coming up.** A client is
  attached to its group during the hello exchange, before it has delivered its first
  `client/state`, and a change published in that window would reach it ahead of the state
  it is brought up with. `send_message` was already a no-op for a fully disconnected client,
  so nothing previously delivered is lost — and `on_client_connected` sends current state at
  exactly the point the flag flips.

- **Five test doubles gain two members each.** `_DummyGroup` exists in five copies that
  diverge by design, so they are extended in place rather than collapsed into a shared
  fixture — that is its own change, and most of this diff's line count.

**Related issue (if applicable):**

- n/a

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue) — `bugfix`

## Checklist

- [x] The code change is tested and works locally.
- [x] `pre-commit run --all-files` passes.
- [x] `pytest` passes, and tests have been added/updated under `tests/` where applicable.
