### PR TITLE
Keep the server running when mDNS advertising fails

### DIFF
--- a/aiosendspin/server/server.py
+++ b/aiosendspin/server/server.py
@@ -972,8 +972,10 @@ class SendspinServer:
             logger.error("Failed to start server on %s:%d: %s", host, port, e)
             await self._stop_mdns()
             if self._app_runner:
+                # cleanup() already stops/unregisters any site added to this runner.
                 await self._app_runner.cleanup()
                 self._app_runner = None
+            self._tcp_site = None
             if self._app:
                 await self._app.shutdown()
                 self._app = None
@@ -1041,20 +1043,28 @@ class SendspinServer:
             properties["name"] = self._name
         properties["path"] = path
 
-        info = AsyncServiceInfo(
-            type_=service_type,
-            name=f"{self._id}.{service_type}",
-            server=f"{self._id}.local.",
-            parsed_addresses=addresses,
-            port=port,
-            properties=properties,
-        )
         try:
+            info = AsyncServiceInfo(
+                type_=service_type,
+                name=f"{self._id}.{service_type}",
+                server=f"{self._id}.local.",
+                parsed_addresses=addresses,
+                port=port,
+                properties=properties,
+            )
             await self._zc.async_register_service(info)
             self._mdns_service = info
             logger.debug("mDNS advertising server on port %d with path %s", port, path)
         except NonUniqueNameException:
             logger.error("Sendspin server with identical name present in the local network!")
+        except OSError as e:
+            # e.g. an advertise address that is not an IP literal; the HTTP listener
+            # and client discovery are unaffected, the server just isn't announced
+            logger.error(
+                "Server is running but not advertised over mDNS (addresses %s): %s",
+                addresses,
+                e,
+            )
 
     async def _start_mdns_discovery(self) -> None:
         assert self._zc is not None

--- a/tests/server/test_server_start_robustness.py
+++ b/tests/server/test_server_start_robustness.py
@@ -1,0 +1,109 @@
+"""Tests for SendspinServer.start_server failure-path robustness."""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from aiosendspin.noise.keys import Identity
+from aiosendspin.noise.trust_store import InMemoryServerPairingStore
+from aiosendspin.server.server import SendspinServer
+
+
+def _make_server() -> SendspinServer:
+    loop = asyncio.get_running_loop()
+    client_session = MagicMock()
+    client_session.closed = True
+    client_session.close = AsyncMock()
+    return SendspinServer(
+        loop=loop,
+        identity=Identity.generate(),
+        server_name="server",
+        client_session=client_session,
+        pairing_store=InMemoryServerPairingStore(),
+    )
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+class _FakeAsyncZeroconf:
+    """Zeroconf test double avoiding real multicast sockets in tests."""
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        self.zeroconf = MagicMock()
+        self.async_register_service = AsyncMock()
+        self.async_unregister_service = AsyncMock()
+        self.async_close = AsyncMock()
+
+
+class _FakeAsyncServiceBrowser:
+    """Service browser test double that skips real mDNS discovery."""
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        self.async_cancel = AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_start_server_survives_invalid_advertise_address(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An unparsable advertise address must not tear down the HTTP listener or discovery."""
+    monkeypatch.setattr("aiosendspin.server.server.AsyncZeroconf", _FakeAsyncZeroconf)
+    monkeypatch.setattr("aiosendspin.server.server.AsyncServiceBrowser", _FakeAsyncServiceBrowser)
+
+    server = _make_server()
+    port = _free_port()
+
+    with caplog.at_level("ERROR"):
+        await server.start_server(
+            port=port,
+            host="127.0.0.1",
+            advertise_addresses=["homeassistant.local"],
+        )
+
+    try:
+        assert server._tcp_site is not None  # noqa: SLF001
+        assert server._mdns_service is None  # noqa: SLF001
+        assert server._mdns_browser is not None  # noqa: SLF001
+
+        assert any("not advertised over mDNS" in record.getMessage() for record in caplog.records)
+
+        # The port must still accept connections; the HTTP listener is unaffected.
+        _reader, writer = await asyncio.wait_for(
+            asyncio.open_connection("127.0.0.1", port), timeout=2.0
+        )
+        writer.close()
+        await writer.wait_closed()
+    finally:
+        await server.close()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_start_server_port_in_use_raises_and_close_is_safe() -> None:
+    """A failed start_server (port already bound) must not corrupt teardown state."""
+    server = _make_server()
+    port = _free_port()
+
+    blocker = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    blocker.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    blocker.bind(("127.0.0.1", port))
+    blocker.listen(1)
+    try:
+        with pytest.raises(OSError, match="address already in use"):
+            await server.start_server(port=port, host="127.0.0.1")
+    finally:
+        blocker.close()
+
+    assert server._tcp_site is None  # noqa: SLF001
+    assert server._app_runner is None  # noqa: SLF001
+    assert server._app is None  # noqa: SLF001
+
+    await server.close()  # must not raise


### PR DESCRIPTION
Music Assistant passed a hostname as the mDNS advertise address (music-assistant/support#6413). zeroconf can't encode that, and the `OSError` it raised tore down the HTTP listener that had already started. The server stopped running entirely because it couldn't announce itself. Music Assistant stops passing hostnames in music-assistant/server#6305, and this makes the library robust against it.

- A failed mDNS advertisement is logged as an error, and the listener and client discovery keep running
- A failed `start_server()`, for example on a port that's already in use, no longer leaves a stale site behind, so a following `close()` doesn't raise
